### PR TITLE
docs: add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,66 @@
+# Code of Conduct
+
+## Our Pledge
+
+We are committed to making Clinical Insight Engine a welcoming, respectful, and harassment-free project for everyone, regardless of background, identity, experience level, or role in the community.
+
+This project discusses healthcare and machine learning concepts, so contributors are expected to communicate with extra care, accuracy, and respect.
+
+## Expected Behavior
+
+Examples of behavior that helps the community include:
+
+- Using welcoming and inclusive language.
+- Respecting different viewpoints and experiences.
+- Giving constructive technical feedback.
+- Keeping discussions focused on the issue, pull request, or project goal.
+- Being patient with new contributors.
+- Acknowledging mistakes and correcting them when needed.
+- Avoiding the sharing of private, sensitive, or health-related personal data.
+
+## Unacceptable Behavior
+
+Examples of unacceptable behavior include:
+
+- Harassment, insults, threats, or personal attacks.
+- Discriminatory language or behavior.
+- Public or private sharing of another person's private information without permission.
+- Deliberately derailing technical discussions.
+- Spam, trolling, or repeated low-effort comments.
+- Publishing secrets, credentials, real patient data, or other sensitive information.
+- Any conduct that would reasonably be considered inappropriate in a professional open-source community.
+
+## Project Scope and Medical Disclaimer
+
+Clinical Insight Engine is intended for educational and research use only. Community discussions should not present the project as a source of medical diagnosis, treatment decisions, or professional medical advice.
+
+When discussing risk predictions, model behavior, datasets, or clinical workflows, contributors should be careful to preserve the project's disclaimer and avoid claims that overstate the system's medical reliability.
+
+## Reporting
+
+If you experience or witness behavior that violates this Code of Conduct, please report it to the project maintainers.
+
+When reporting, include:
+
+- A description of what happened.
+- Links to the issue, pull request, discussion, or comment if available.
+- Screenshots or logs when helpful.
+- Any context that can help maintainers respond fairly.
+
+Maintainers will review reports as promptly and privately as possible.
+
+## Enforcement
+
+Maintainers may take appropriate action in response to Code of Conduct violations, including:
+
+- Clarifying expectations with the contributor.
+- Editing or removing inappropriate comments.
+- Closing or locking discussions.
+- Rejecting or closing pull requests.
+- Temporarily or permanently limiting participation in the project.
+
+Enforcement decisions should be fair, consistent, and focused on protecting the health of the community.
+
+## Attribution
+
+This Code of Conduct is adapted from common open-source community guidelines and tailored for the Clinical Insight Engine project.


### PR DESCRIPTION
## Summary
- add CODE_OF_CONDUCT.md for community expectations
- include reporting and enforcement guidance for maintainers
- preserve project-specific caution around medical claims and sensitive health data

## Validation
- checked CODE_OF_CONDUCT.md includes reporting, enforcement, and project-specific disclaimer sections
- git diff --check

Fixes #18