### PR TITLE
fix: standardize server host binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ py -c "from analyze import create_synthetic_data; create_synthetic_data()"
 ```bash
 npm run dev
 ```
-Frontend runs at: `http://localhost:5173`
+The Express/Vite server listens on `PORT` or `5000` by default and binds to `0.0.0.0` so the app is reachable in local containers and hosted environments. Use `HOST=127.0.0.1 npm run dev` if you want a local-only listener.
 
 #### ML Pipeline (Training)
 ```bash

--- a/server/index.ts
+++ b/server/index.ts
@@ -85,19 +85,18 @@ app.use((req, res, next) => {
     await setupVite(httpServer, app);
   }
 
-  // ALWAYS serve the app on the port specified in the environment variable PORT
-  // Other ports are firewalled. Default to 5000 if not specified.
-  // this serves both the API and the client.
-  // It is the only port that is not firewalled.
- const port = parseInt(process.env.PORT || "5000", 10);
+  // Bind to 0.0.0.0 by default so local containers, Replit, and deployed
+  // environments expose the same listener. Set HOST=127.0.0.1 for local-only use.
+  const port = parseInt(process.env.PORT || "5000", 10);
+  const host = process.env.HOST || "0.0.0.0";
 
-httpServer.listen(
-  {
-    port,
-    host: "localhost",
-  },
-  () => {
-    log(`serving on port ${port}`);
-  },
-);
+  httpServer.listen(
+    {
+      port,
+      host,
+    },
+    () => {
+      log(`serving on ${host}:${port}`);
+    },
+  );
 })();


### PR DESCRIPTION
## Summary
- standardize Express server binding on `0.0.0.0` by default for containers and hosted environments
- keep `HOST` as an explicit override for local-only binding
- update README startup notes so the host strategy is documented

Closes #29

## Validation
- `git diff --check`

Note: TypeScript check could not be run in this local checkout because project `node_modules` are not installed here (`./node_modules/.bin/tsc` is missing).