### PR TITLE
fix: add database startup preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ npm run migrate
 npm run db:migrate
 ```
 
+The server runs a PostgreSQL preflight check before mounting routes. If startup
+prints `Database startup check failed`, confirm that PostgreSQL is running,
+`DATABASE_URL` points to the same database, and the migration command above has
+created the required tables.
+
 ### 6️⃣ Python Environment Setup
 
 #### Linux/macOS

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,14 +1,60 @@
-import { drizzle } from "drizzle-orm/node-postgres";
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import pg from "pg";
 import * as schema from "@shared/schema";
 
 const { Pool } = pg;
 
-if (!process.env.DATABASE_URL) {
-  throw new Error(
-    "DATABASE_URL must be set. Did you forget to provision a database?",
-  );
+let poolInstance: pg.Pool | undefined;
+let dbInstance: NodePgDatabase<typeof schema> | undefined;
+
+export class DatabaseStartupError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DatabaseStartupError";
+  }
 }
 
-export const pool = new Pool({ connectionString: process.env.DATABASE_URL });
-export const db = drizzle(pool, { schema });
+function formatDatabaseStartupMessage(detail: string) {
+  return [
+    `Database startup check failed: ${detail}`,
+    "Set DATABASE_URL to a reachable PostgreSQL database, then run npm run db:push before starting the server.",
+    "Example: DATABASE_URL=postgresql://postgres:postgres@localhost:5432/clinical_insight_engine",
+  ].join("\n");
+}
+
+function getDatabaseUrl() {
+  if (!process.env.DATABASE_URL) {
+    throw new DatabaseStartupError(
+      formatDatabaseStartupMessage("DATABASE_URL is not set."),
+    );
+  }
+
+  return process.env.DATABASE_URL;
+}
+
+export function getPool() {
+  if (!poolInstance) {
+    poolInstance = new Pool({ connectionString: getDatabaseUrl() });
+  }
+
+  return poolInstance;
+}
+
+export function getDb() {
+  if (!dbInstance) {
+    dbInstance = drizzle(getPool(), { schema });
+  }
+
+  return dbInstance;
+}
+
+export async function verifyDatabaseConnection() {
+  try {
+    await getPool().query("select 1");
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new DatabaseStartupError(
+      formatDatabaseStartupMessage(`PostgreSQL is unreachable. ${detail}`),
+    );
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,5 @@
 import express, { type Request, Response, NextFunction } from "express";
+import { DatabaseStartupError, verifyDatabaseConnection } from "./db";
 import { registerRoutes } from "./routes";
 import { serveStatic } from "./static";
 import { createServer } from "http";
@@ -60,6 +61,19 @@ app.use((req, res, next) => {
 });
 
 (async () => {
+  try {
+    await verifyDatabaseConnection();
+  } catch (error) {
+    if (error instanceof DatabaseStartupError) {
+      console.error(error.message);
+    } else {
+      console.error("Unexpected database startup error:", error);
+    }
+
+    process.exitCode = 1;
+    return;
+  }
+
   await registerRoutes(httpServer, app);
 
   app.use((err: any, _req: Request, res: Response, next: NextFunction) => {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,4 +1,4 @@
-import { db } from "./db";
+import { getDb } from "./db";
 import { assessments, type Assessment, type InsertAssessment } from "@shared/schema";
 
 export interface IStorage {
@@ -14,6 +14,7 @@ export interface IStorage {
 
 export class DatabaseStorage implements IStorage {
   async getAssessments(): Promise<Assessment[]> {
+    const db = getDb();
     return await db.select().from(assessments);
   }
 
@@ -24,6 +25,7 @@ export class DatabaseStorage implements IStorage {
     confidenceInterval?: string,
     modelConfidence?: string 
   }): Promise<Assessment> {
+    const db = getDb();
     const [created] = await db.insert(assessments).values(assessment).returning();
     return created;
   }


### PR DESCRIPTION
## Summary
- add a PostgreSQL startup preflight before registering routes
- lazy-initialize the database client so startup errors can be reported cleanly
- document the DATABASE_URL and migration checks for local setup

## Validation
- git diff --check

Note: TypeScript compilation could not be run locally because this checkout does not have node_modules installed and npm is unavailable in the current environment.

Closes #28