### PR TITLE
fix: cleanly terminate server process on startup database connection failure

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -70,8 +70,7 @@ app.use((req, res, next) => {
       console.error("Unexpected database startup error:", error);
     }
 
-    process.exitCode = 1;
-    return;
+    process.exit(1);
   }
 
   await registerRoutes(httpServer, app);


### PR DESCRIPTION
Fixes #50

Ensures process.exit(1) is called on database connectivity check errors to avoid process hangs caused by unclosed pg pool event loop handles.

Requesting review and assignment labels! ✨