### PR TITLE
fix: guard patient history date cell against unparseable timestamps

### DIFF
--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -1,6 +1,6 @@
 import { AppLayout } from "@/components/layout/AppLayout";
 import { useAssessments } from "@/hooks/use-assessments";
-import { format } from "date-fns";
+import { format, isValid } from "date-fns";
 import { Loader2, Search, Calendar, User, Activity } from "lucide-react";
 import { useState } from "react";
 
@@ -21,6 +21,12 @@ export default function History() {
     a.gender.toLowerCase().includes(searchTerm.toLowerCase()) || 
     a.riskCategory.toLowerCase().includes(searchTerm.toLowerCase())
   ) || [];
+
+  const formatAssessmentDate = (dateVal: any) => {
+    if (!dateVal) return "Unknown";
+    const dateObj = new Date(dateVal);
+    return isValid(dateObj) ? format(dateObj, 'MMM d, yyyy') : "Unknown";
+  };
 
   return (
     <AppLayout>
@@ -88,7 +94,7 @@ export default function History() {
                   {filteredAssessments.map((assessment) => (
                     <tr key={assessment.id} className="hover:bg-muted/30 transition-colors text-sm">
                       <td className="p-4 whitespace-nowrap">
-                        {assessment.createdAt ? format(new Date(assessment.createdAt), 'MMM d, yyyy') : 'Unknown'}
+                        {formatAssessmentDate(assessment.createdAt)}
                       </td>
                       <td className="p-4">{assessment.age}</td>
                       <td className="p-4 font-medium">{assessment.bmi}</td>


### PR DESCRIPTION
Fixes #52

Integrates date-fns isValid checks prior to string formatting in Date cells to prevent component render RangeError crashes.

Requesting review and assignment labels! ✨