### PR TITLE
fix: update backend API startup command in README #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,12 +205,7 @@ Create the required tables:
 npm run db:push
 ```
 
-If the above doesn't work, try:
-```bash
-npm run migrate
-# or
-npm run db:migrate
-```
+
 
 The server runs a PostgreSQL preflight check before mounting routes. If startup
 prints `Database startup check failed`, confirm that PostgreSQL is running,

--- a/README.md
+++ b/README.md
@@ -289,10 +289,10 @@ py analyze.py
 #### Backend API (if separate)
 ```bash
 # Linux/macOS
-python3 main.py
+npm run dev
 
 # Windows
-py main.py
+npm run dev
 ```
 
 ---


### PR DESCRIPTION
## Problem
README.md incorrectly instructed users to start the backend using:
- python3 main.py (Linux/macOS)
- py main.py (Windows)

These commands only run a placeholder script, not the actual server.

## Fix
Updated the Backend API section to use the correct command:
- npm run dev (Linux/macOS)
- npm run dev (Windows)

## Issue
Fixes #15 

## Type
Documentation fix

---
## Fix 2 - Issue #16
Removed non-existent commands from README:
- npm run migrate (did not exist)
- npm run db:migrate (did not exist)
- Removed duplicate section
- Only correct command npm run db:push is kept

Fixes #16