### PR TITLE
docs: added cmd alternative for window setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ cp .env.example .env
 
 # Windows (PowerShell)
 Copy-Item .env.example .env
+
+# Windows (Command Prompt - cmd)
+copy .env.example .env
 ```
 
 If `.env.example` doesn't exist, create `.env` manually:


### PR DESCRIPTION
## Description
Updated the README to include a Command Prompt (`cmd`) alternative for Windows users when creating the `.env` file.

## Changes Made
- Added CMD-compatible command:
  ```cmd
  copy .env.example .env
  ```
- Improved Windows setup clarity for contributors

## Related Issue
Closes #40