### PR TITLE
feat: add rate limiting to POST /api/assessments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",
         "express": "^5.0.1",
+        "express-rate-limit": "^8.5.2",
         "express-session": "^1.18.1",
         "framer-motion": "^11.13.1",
         "input-otp": "^1.4.2",
@@ -4890,6 +4891,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express-session": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
@@ -5350,6 +5369,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",
     "express": "^5.0.1",
+    "express-rate-limit": "^8.5.2",
     "express-session": "^1.18.1",
     "framer-motion": "^11.13.1",
     "input-otp": "^1.4.2",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -9,8 +9,25 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import os from "os";
 import path from "path";
+import { rateLimit } from "express-rate-limit";
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * Rate limiter for the ML assessment endpoint.
+ * This endpoint spawns a Python subprocess for each request, which is resource-intensive.
+ * Limits to 5 requests per minute per IP to prevent DoS attacks.
+ */
+const assessmentLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  limit: 5, // 5 requests per IP per window
+  standardHeaders: "draft-8",
+  legacyHeaders: false,
+  message: {
+    error: "Too many assessment requests. Please try again later.",
+    retryAfter: 60, // seconds
+  },
+});
 
 function getPythonExecutable() {
   const candidates = process.platform === "win32"
@@ -90,7 +107,7 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
   // Seed database on startup
   seedDatabase().catch(console.error);
   
-  app.post(api.assessments.create.path, async (req, res) => {
+  app.post(api.assessments.create.path, assessmentLimiter, async (req, res) => {
     try {
       const input = api.assessments.create.input.parse(req.body);
       


### PR DESCRIPTION
## Summary

Adds express-rate-limit middleware to the `POST /api/assessments` endpoint. This endpoint spawns a Python subprocess for each ML inference request, which is resource-intensive. Without rate limiting, the application is vulnerable to Denial of Service (DoS) attacks.

## What Changed

- Installed `express-rate-limit` dependency
- Added rate limiter configuration in `server/routes.ts`:
  - `windowMs: 60000` (1 minute window)
  - `limit: 5` (5 requests per IP)
  - `standardHeaders: "draft-8"` (RateLimit standard headers)
  - `legacyHeaders: false`
  - JSON error response with `retryAfter: 60`
- Applied only to `POST /api/assessments` endpoint

## Why It Matters

In a clinical decision support system handling patient data, availability is critical. An attacker could exhaust server resources by sending many concurrent requests to the ML inference endpoint.

## Validation Commands Run

```bash
npm run check
```

- TypeScript compilation: ✅ Passed (no errors)
- Integration tested: rate limiter imports and configures correctly as Express middleware

Fixes #42