### PR TITLE
fix: resolve __dirname ReferenceError by defining it for Node ESM

### DIFF
--- a/server/static.ts
+++ b/server/static.ts
@@ -1,6 +1,10 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 export function serveStatic(app: Express) {
   const distPath = path.resolve(__dirname, "public");


### PR DESCRIPTION
Fixes #72

Resolves production build crashes caused by referencing undefined CommonJS __dirname in an ESM module context. Implements fileURLToPath dynamically.

Requesting review and assignment labels! ✨