### PR TITLE
fix: correct express wildcard routing path syntax to support SPA refresh

### DIFF
--- a/server/static.ts
+++ b/server/static.ts
@@ -13,7 +13,7 @@ export function serveStatic(app: Express) {
   app.use(express.static(distPath));
 
   // fall through to index.html if the file doesn't exist
-  app.use("/{*path}", (_req, res) => {
+  app.get("*", (_req, res) => {
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
Fixes #73

Fixes Express wildcard routing fallback syntax to get('*') instead of Honolike use('/{*path}'), resolving 404 client router fallback errors on page refresh.

Requesting review and assignment labels! ✨