### PR TITLE
fix: set explicit connection timeout on pg pool to prevent hanging

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -34,7 +34,7 @@ function getDatabaseUrl() {
 
 export function getPool() {
   if (!poolInstance) {
-    poolInstance = new Pool({ connectionString: getDatabaseUrl() });
+    poolInstance = new Pool({ connectionString: getDatabaseUrl(), connectionTimeoutMillis: 5000, idleTimeoutMillis: 10000 });
   }
 
   return poolInstance;


### PR DESCRIPTION
Fixes #75

Configures connectionTimeoutMillis and idleTimeoutMillis on the PostgreSQL Pool instance to ensure deterministic behavior on startup DB connectivity failures and faster error propagation.

Requesting review and assignment labels! ✨