### PR TITLE
ux: extend patient history search to age, vitals, and smoking status

### DIFF
--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -26,6 +26,11 @@ export default function History() {
       String(a.age).includes(term) ||
       String(a.bmi).includes(term) ||
       String(a.hba1cLevel).includes(term) ||
+      String(a.bloodGlucoseLevel).includes(term) ||
+      a.smokingHistory.toLowerCase().includes(term) ||
+      String(a.age).includes(term) ||
+      String(a.bmi).includes(term) ||
+      String(a.hba1cLevel).includes(term) ||
       String(a.bloodGlucoseLevel).includes(term)
     );
   }) || [];


### PR DESCRIPTION
Fixes #77

Expands the history list search filter to match records against age, BMI, HbA1c level, blood glucose level, and smoking history in addition to gender and risk category.

Requesting review and assignment labels! ✨