### PR TITLE
fix: resolve __dirname and analyze.py path for ESM production builds

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -9,8 +9,15 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import os from "os";
 import path from "path";
+import { fileURLToPath } from "url";
 
 const execFileAsync = promisify(execFile);
+
+// ESM-compatible path resolution for analyze.py
+// Resolve relative to this source file, not process.cwd()
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const analyzePyPath = path.resolve(__dirname, "..", "analyze.py");
 
 function getPythonExecutable() {
   const candidates = process.platform === "win32"
@@ -99,10 +106,10 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
       writeFileSync(tempFile, JSON.stringify(input));
       
       try {
-       // Call Python script to perform the logistic regression analysis
-        const { stdout, stderr } = await execFileAsync(
-          getPythonExecutable(),
-          ["analyze.py", "predict_file", tempFile],
+        // Call Python script to perform the logistic regression analysis
+         const { stdout, stderr } = await execFileAsync(
+           getPythonExecutable(),
+           [analyzePyPath, "predict_file", tempFile],
           {
             timeout: 30000
           }

--- a/server/static.ts
+++ b/server/static.ts
@@ -1,6 +1,11 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
+
+// ESM-compatible __dirname (CommonJS globals not available in ESM)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 export function serveStatic(app: Express) {
   const distPath = path.resolve(__dirname, "public");

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,6 +1,15 @@
 // server/storage.ts
 import { getDb } from "./db"; // 1. Changed to import getDb instead of db
-import { assessments, type Assessment, type InsertAssessment } from "@shared/schema";
+import { assessments, type Assessment, type InsertAssessment, type AssessmentFactor } from "@shared/schema";
+
+// Type for creating assessments with pre-computed model outputs (used in seeding)
+export type AssessmentCreateInput = InsertAssessment & {
+  riskScore: string;
+  riskCategory: string;
+  factors: AssessmentFactor[];
+  confidenceInterval?: string;
+  modelConfidence?: string;
+};
 
 export interface IStorage {
   getAssessments(): Promise<Assessment[]>;


### PR DESCRIPTION
## Summary

Fixes two related path resolution issues that affect production deployments.

**Bug 1 - Critical Production Crash (server/static.ts):**
- `__dirname` is a CommonJS global, NOT available in ES Modules
- Project uses `"type": "module"` in package.json (ESM)
- Development worked because `server/vite.ts` is used (which correctly uses ESM patterns)
- Production would crash with: `ReferenceError: __dirname is not defined in ES module scope`

**Bug 2 - Python Path Resolution (server/routes.ts):**
- `"analyze.py"` string resolved from `process.cwd()`
- Would fail if server started from different directory (Docker, systemd, `cd scripts && node ...`)
- Now resolves relative to source file using ESM-compatible `__dirname`

**Bonus Fix - Pre-existing TypeScript Error (server/storage.ts):**
- Added missing `AssessmentCreateInput` type export
- Fixes: `Module './storage' has no exported member 'AssessmentCreateInput'`

## Changes

| File | Change |
|------|--------|
| `server/static.ts` | Added ESM-compatible `__dirname` using `fileURLToPath(import.meta.url)` |
| `server/routes.ts` | Changed `"analyze.py"` to resolved `analyzePyPath` relative to source file |
| `server/storage.ts` | Added missing `AssessmentCreateInput` type export |

## Validation

```bash
npm run check
```

- [x] TypeScript: ✅ No errors
- [x] ESM `fileURLToPath` import: ✅ Tested and working
- [x] Path resolution: ✅ Verified correct path construction

Fixes #43