### PR TITLE
fix: update client to import shared schema instead of duplicating

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -7,17 +7,18 @@ import { AssessmentResult } from "@/components/AssessmentResult";
 import { useCreateAssessment } from "@/hooks/use-assessments";
 import { Activity, AlertCircle, Clock3, Loader2, ShieldCheck, TrendingUp, UserCircle } from "lucide-react";
 import { type AssessmentResponse } from "@shared/routes";
+import { insertAssessmentSchema } from "@shared/schema";
 
-// Form schema aligned with the backend insert schema
-const formSchema = z.object({
-  gender: z.enum(["Male", "Female", "Other"], { required_error: "Please select a gender" }),
-  age: z.coerce.number().min(1, "Age must be greater than 0").max(120, "Age is too high"),
-  hypertension: z.boolean().default(false),
-  heartDisease: z.boolean().default(false),
-  smokingHistory: z.enum(["never", "No Info", "current", "former", "ever", "not current"], { required_error: "Please select smoking history" }),
-  bmi: z.coerce.number().min(10, "BMI must be between 10 and 60").max(60, "BMI must be between 10 and 60"),
-  hba1cLevel: z.coerce.number().min(3, "HbA1c must be between 3 and 15").max(15, "HbA1c must be between 3 and 15"),
-  bloodGlucoseLevel: z.coerce.number().min(50, "Blood glucose must be between 50 and 400").max(400, "Blood glucose must be between 50 and 400"),
+// Form schema using shared schema as single source of truth
+const formSchema = insertAssessmentSchema.pick({
+  gender: true,
+  age: true,
+  hypertension: true,
+  heartDisease: true,
+  smokingHistory: true,
+  bmi: true,
+  hba1cLevel: true,
+  bloodGlucoseLevel: true,
 });
 
 type FormData = z.infer<typeof formSchema>;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -7,19 +7,22 @@ export interface IStorage {
   createAssessment(assessment: any): Promise<Assessment>; 
 }
 
+// Type for creating assessments with pre-computed model outputs (used in seeding)
+export type AssessmentCreateInput = InsertAssessment & { 
+  riskScore: string, 
+  riskCategory: string, 
+  factors: any,
+  confidenceInterval?: string,
+  modelConfidence?: string 
+};
+
 export class DatabaseStorage implements IStorage {
   async getAssessments(): Promise<Assessment[]> {
     const db = getDb(); // 2. This works great now!
     return await db.select().from(assessments);
   }
 
-  async createAssessment(assessment: InsertAssessment & { 
-    riskScore: string, 
-    riskCategory: string, 
-    factors: any,
-    confidenceInterval?: string,
-    modelConfidence?: string 
-  }): Promise<Assessment> {
+  async createAssessment(assessment: AssessmentCreateInput): Promise<Assessment> {
     const db = getDb(); 
 // Cast the values to 'any' to satisfy Drizzle's strict type checker
 const [created] = await db.insert(assessments).values(assessment as any).returning();    return created;


### PR DESCRIPTION
## Summary

This PR completes the fix for issue #44: Form validation bounds differ between client (Dashboard.tsx) and server (schema.ts) + age min(0) is clinically invalid.

### Background

The validation bounds mismatch was already fixed in a previous commit (0080823) which aligned the server schema with the client bounds. However, the root cause of the issue was not addressed:

The Dashboard.tsx has a DUPLICATE Zod schema instead of importing from @shared/schema

This PR fixes the root cause by updating the client to import from the shared schema, ensuring single source of truth for validation.

### Changes Made

1. Updated client/src/pages/Dashboard.tsx:
   - Added import: import { insertAssessmentSchema } from "@shared/schema";
   - Changed from duplicating the schema to using shared schema with pick()

2. Fixed pre-existing type export issue in server/storage.ts:
   - Added missing AssessmentCreateInput type export
   - This type was being imported by server/routes.ts but not exported from storage.ts
   - Cleaned up the code by using the named type instead of inline type

### Why This Matters

- Single Source of Truth: Validation logic is now defined once in shared/schema.ts
- Prevents Drift: Client and server can never have mismatched validation bounds again
- Maintainability: Future changes to validation only need to be made in one place
- Consistency: Both client and server use the exact same validation rules

### Validation

npm run check

- TypeScript compilation passes with no errors
- Single commit on top of latest main
- Both files (Dashboard.tsx and storage.ts) are updated
- No breaking changes - form functionality remains the same

### Issue #44 Complete Status

| Issue | Status |
|-------|--------|
| Age min(0) clinically invalid | Fixed in main (min 1) |
| BMI bounds mismatch | Fixed in main (max 60) |
| HbA1c bounds mismatch | Fixed in main (max 15) |
| Blood Glucose bounds mismatch | Fixed in main (max 400) |
| Root Cause: Duplicate schema | Fixed in this PR |

Closes #44