### PR TITLE
chore: add standard GitHub Pull Request Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+## Description
+
+<!-- Provide a clear and concise description of the changes in this PR -->
+
+## Related Issue
+
+Closes #<!-- Issue number -->
+
+## Type of Change
+
+- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
+- [ ] ✨ New feature (non-breaking change that adds functionality)
+- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] 📝 Documentation update
+- [ ] 🎨 Style / UI improvement
+- [ ] ♻️ Refactor (no functional changes)
+- [ ] ⚡ Performance improvement
+- [ ] 🧪 Test addition or update
+- [ ] 🔧 Chore / Tooling / Config
+
+## Changes Made
+
+<!-- List the key changes made in this PR -->
+
+- 
+- 
+- 
+
+## Screenshots (if applicable)
+
+<!-- Add before/after screenshots for UI changes -->
+
+## Testing
+
+- [ ] I have tested these changes locally
+- [ ] I have added/updated tests where applicable
+- [ ] All existing tests pass
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code where necessary
+- [ ] I have updated the documentation if needed
+- [ ] My changes generate no new warnings or errors


### PR DESCRIPTION
## Description

Adds a structured GitHub Pull Request Template under `.github/pull_request_template.md` to guide contributors through providing clear descriptions, linking issues, and completing a review checklist.

## Related Issue

Closes #110

## Type of Change

- [x] 📝 Documentation update
- [x] 🔧 Chore / Tooling / Config

## Changes Made

- Added `.github/pull_request_template.md` with:
  - Description and related issue sections
  - Type of change checklist (bug fix, feature, docs, etc.)
  - Changes made section
  - Screenshots placeholder for UI changes
  - Testing and general contribution checklists

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
