### PR TITLE
chore: add SECURITY.md for responsible vulnerability disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+We take the security of **Clinical-Insight-Engine** seriously. If you discover a security vulnerability, please help us responsibly disclose it.
+
+**Please do NOT open a public GitHub issue for security vulnerabilities.**
+
+Instead, please report them via one of the following methods:
+
+1. **GitHub Private Vulnerability Reporting** (preferred): Use the [Security Advisories](../../security/advisories/new) feature on this repository.
+2. **Email**: Contact the maintainer directly via their GitHub profile contact.
+
+### What to Include
+
+When reporting a vulnerability, please include:
+
+- A clear description of the vulnerability and its potential impact
+- Steps to reproduce the issue
+- Affected versions or components
+- Any suggested mitigation or fix (optional)
+
+### Response Timeline
+
+- **Acknowledgement**: Within 48 hours of your report
+- **Status Update**: Within 7 days
+- **Fix / Patch**: We aim to address critical vulnerabilities within 30 days
+
+We appreciate your efforts to keep this project and its users safe. Thank you for practicing responsible disclosure! 🙏


### PR DESCRIPTION
## Description

Adds a `SECURITY.md` file to the repository root with a structured security vulnerability disclosure policy for responsible reporting.

## Related Issue

Closes #111

## Type of Change

- [x] 📝 Documentation update
- [x] 🔧 Chore / Tooling / Config

## Changes Made

- Added `SECURITY.md` with:
  - Supported versions table
  - Preferred reporting methods (GitHub Security Advisories, email)
  - Guidelines on what to include in vulnerability reports
  - Response timeline expectations (48h ack, 7d update, 30d patch)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
