### PR TITLE
fix: implement server-side authentication for API routes

### DIFF
--- a/client/src/components/AuthFlowModal.tsx
+++ b/client/src/components/AuthFlowModal.tsx
@@ -20,9 +20,6 @@ import {
 
 export type AuthMode = "login" | "register";
 
-declare const __DEV_CLINICIAN_EMAIL__: string;
-declare const __DEV_CLINICIAN_PASSWORD__: string;
-
 interface AuthFlowModalProps {
   initialMode: AuthMode;
   isOpen: boolean;
@@ -111,7 +108,7 @@ function SecurityNotice() {
           </div>
         </div>
       </div>
-    </form>
+    </div>
   );
 }
 
@@ -126,7 +123,7 @@ function DevelopmentNotice() {
           Development Environment: Use local .env.local seeded clinician credentials to bypass or test dashboard integrations.
         </p>
       </div>
-    </form>
+    </div>
   );
 }
 
@@ -221,6 +218,8 @@ function LoginForm({
   onPasswordChange,
   onSubmit,
   onSwitch,
+  isLoading,
+  error,
 }: {
   email: string;
   password: string;
@@ -228,10 +227,18 @@ function LoginForm({
   onPasswordChange: (value: string) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   onSwitch: () => void;
+  isLoading?: boolean;
+  error?: string | null;
 }) {
   return (
     <form onSubmit={onSubmit} className="space-y-5">
       <DevelopmentNotice />
+
+      {error && (
+        <div className="rounded-xl border border-red-200 bg-red-50 p-3 text-sm font-semibold text-red-700">
+          {error}
+        </div>
+      )}
 
       <TextInput
         icon={Mail}
@@ -263,10 +270,23 @@ function LoginForm({
 
       <button
         type="submit"
-        className="flex w-full items-center justify-center gap-2 rounded-2xl bg-[#2563EB] px-5 py-4 text-base font-black text-white shadow-lg shadow-blue-600/20 transition-all duration-200 hover:-translate-y-0.5 hover:scale-[1.01] hover:bg-blue-700 hover:shadow-xl hover:shadow-blue-600/25 focus:outline-none focus:ring-4 focus:ring-blue-200"
+        disabled={isLoading}
+        className="flex w-full items-center justify-center gap-2 rounded-2xl bg-[#2563EB] px-5 py-4 text-base font-black text-white shadow-lg shadow-blue-600/20 transition-all duration-200 hover:-translate-y-0.5 hover:scale-[1.01] hover:bg-blue-700 hover:shadow-xl hover:shadow-blue-600/25 focus:outline-none focus:ring-4 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0 disabled:hover:scale-100"
       >
-        Sign In
-        <ShieldCheck className="h-5 w-5" aria-hidden="true" />
+        {isLoading ? (
+          <>
+            <svg className="h-5 w-5 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            Signing In...
+          </>
+        ) : (
+          <>
+            Sign In
+            <ShieldCheck className="h-5 w-5" aria-hidden="true" />
+          </>
+        )}
       </button>
 
       <p className="text-center text-sm font-semibold text-slate-500">
@@ -314,13 +334,6 @@ function OtpForm({ onVerify }: { onVerify: () => void }) {
   const [otp, setOtp] = useState(["", "", "", "", "", ""]);
   const inputRefs = useRef<Array<HTMLInputElement | null>>([]);
   const isComplete = otp.every(Boolean);
-
-  const handleFormSubmit = (event: FormEvent) => {
-    event.preventDefault();
-    if (isComplete) {
-      onVerify();
-    }
-  };
 
   const updateDigit = (index: number, value: string) => {
     const digit = value.replace(/\D/g, "").slice(-1);
@@ -409,7 +422,8 @@ export function AuthFlowModal({ initialMode, isOpen, onClose }: AuthFlowModalPro
   const [loginEmail, setLoginEmail] = useState("");
   const [loginPassword, setLoginPassword] = useState("");
   const [pendingEmail, setPendingEmail] = useState("");
-  const [isLocalDevSession, setIsLocalDevSession] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -417,7 +431,8 @@ export function AuthFlowModal({ initialMode, isOpen, onClose }: AuthFlowModalPro
     setMode(initialMode);
     setStep("form");
     setPendingEmail("");
-    setIsLocalDevSession(false);
+    setError(null);
+    setIsLoading(false);
 
     const originalOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
@@ -429,34 +444,39 @@ export function AuthFlowModal({ initialMode, isOpen, onClose }: AuthFlowModalPro
 
   if (!isOpen) return null;
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    setError(null);
+
     const formData = new FormData(event.currentTarget);
     const email = String(formData.get("email") ?? "");
     const password = String(formData.get("password") ?? "");
-    const matchesLocalDevCredentials =
-      import.meta.env.DEV &&
-      Boolean(__DEV_CLINICIAN_EMAIL__) &&
-      Boolean(__DEV_CLINICIAN_PASSWORD__) &&
-      email === __DEV_CLINICIAN_EMAIL__ &&
-      password === __DEV_CLINICIAN_PASSWORD__;
 
-    setPendingEmail(email);
-    setIsLocalDevSession(matchesLocalDevCredentials);
-    setStep("otp");
+    setIsLoading(true);
+
+    try {
+      const response = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+        credentials: "include",
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.message || "Invalid email or password.");
+      }
+
+      setPendingEmail(email);
+      setStep("otp");
+    } catch (err: any) {
+      setError(err.message || "Login failed. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleVerify = () => {
-    localStorage.setItem(
-      "cardioguard-auth-session",
-      JSON.stringify({
-        authenticated: true,
-        email: pendingEmail || loginEmail,
-        authSource: isLocalDevSession ? "local-development" : "simulated",
-        isLocalDevelopment: isLocalDevSession,
-        verifiedAt: new Date().toISOString(),
-      }),
-    );
     onClose();
     setLocation("/dashboard");
   };
@@ -506,6 +526,8 @@ export function AuthFlowModal({ initialMode, isOpen, onClose }: AuthFlowModalPro
                     onPasswordChange={setLoginPassword}
                     onSubmit={handleSubmit}
                     onSwitch={() => setMode("register")}
+                    isLoading={isLoading}
+                    error={error}
                   />
                 ) : (
                   <RegisterForm onSubmit={handleSubmit} onSwitch={() => setMode("login")} />
@@ -529,6 +551,6 @@ export function AuthFlowModal({ initialMode, isOpen, onClose }: AuthFlowModalPro
           </div>
         </section>
       </motion.div>
-    </form>
+    </div>
   );
 }

--- a/client/src/components/layout/AppLayout.tsx
+++ b/client/src/components/layout/AppLayout.tsx
@@ -1,6 +1,6 @@
-import { ReactNode, useEffect } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { Link, useLocation } from "wouter";
-import { Activity, ClipboardList, HeartPulse, LogOut } from "lucide-react";
+import { Activity, ClipboardList, HeartPulse, LogOut, Loader2 } from "lucide-react";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
@@ -14,38 +14,29 @@ interface AppLayoutProps {
 
 export function AppLayout({ children }: AppLayoutProps) {
   const [location, setLocation] = useLocation();
+  const [user, setUser] = useState<{ email: string; name?: string } | null>(null);
+  const [checking, setChecking] = useState(true);
 
   useEffect(() => {
-    const sessionStr = localStorage.getItem("cardioguard-auth-session");
-    if (!sessionStr) {
-      setLocation("/");
-    } else {
-      try {
-        const session = JSON.parse(sessionStr);
-        if (!session.authenticated) {
-          setLocation("/");
-        }
-      } catch (e) {
-        setLocation("/");
-      }
-    }
+    fetch("/api/auth/me", { credentials: "include" })
+      .then((res) => {
+        if (!res.ok) throw new Error("Not authenticated");
+        return res.json();
+      })
+      .then((data) => setUser(data.user))
+      .catch(() => setLocation("/"))
+      .finally(() => setChecking(false));
   }, [setLocation]);
 
-  useEffect(() => {
-    const sessionStr = localStorage.getItem("cardioguard-auth-session");
-    if (!sessionStr) {
-      setLocation("/");
-    } else {
-      try {
-        const session = JSON.parse(sessionStr);
-        if (!session.authenticated) {
-          setLocation("/");
-        }
-      } catch (e) {
-        setLocation("/");
-      }
-    }
-  }, [setLocation]);
+  if (checking) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[#F8FAFC]">
+        <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
+      </div>
+    );
+  }
+
+  if (!user) return null;
 
   const navItems = [
     { href: "/dashboard", label: "New Assessment", icon: Activity },
@@ -95,16 +86,16 @@ export function AppLayout({ children }: AppLayoutProps) {
           <div className="m-4 border-t border-slate-100 pt-4">
             <div className="flex items-center gap-3 rounded-2xl bg-slate-50 p-3">
               <div className="w-10 h-10 rounded-2xl bg-white flex items-center justify-center text-blue-700 font-black text-sm border border-slate-100 shadow-sm">
-                Dr
+                {user.name?.charAt(0) || "Dr"}
               </div>
               <div className="flex min-w-0 flex-col">
-                <span className="text-sm font-black text-[#1E293B] leading-tight">Dr. Smith</span>
+                <span className="text-sm font-black text-[#1E293B] leading-tight">{user.name || user.email}</span>
                 <span className="text-xs text-slate-500 font-semibold">Cardiology</span>
               </div>
             </div>
             <button
-              onClick={() => {
-                localStorage.removeItem("cardioguard-auth-session");
+              onClick={async () => {
+                await fetch("/api/auth/logout", { method: "POST", credentials: "include" });
                 setLocation("/");
               }}
               className="mt-3 w-full flex items-center justify-center gap-2 px-4 py-2 text-xs font-bold text-red-600 hover:text-red-700 bg-red-50 hover:bg-red-100 rounded-xl transition-all duration-200 border border-red-100"

--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -41,12 +41,6 @@ export default function History() {
     return isValid(dateObj) ? format(dateObj, 'MMM d, yyyy') : "Unknown";
   };
 
-  const formatAssessmentDate = (dateVal: any) => {
-    if (!dateVal) return "Unknown";
-    const dateObj = new Date(dateVal);
-    return isValid(dateObj) ? format(dateObj, 'MMM d, yyyy') : "Unknown";
-  };
-
   return (
     <AppLayout>
       <div className="space-y-8">

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,0 +1,90 @@
+import { Router, type Request, type Response, type NextFunction } from "express";
+
+// Extend express-session to include user data
+declare module "express-session" {
+  interface SessionData {
+    user?: {
+      email: string;
+      name: string;
+    };
+  }
+}
+
+/**
+ * Creates an authentication router with login, logout, and session-check endpoints.
+ *
+ * In development mode, credentials are validated against environment variables
+ * (DEV_CLINICIAN_EMAIL / DEV_CLINICIAN_PASSWORD). In production, this serves
+ * as the auth gateway for all protected API routes.
+ */
+export function createAuthRouter(): Router {
+  const router = Router();
+
+  /**
+   * POST /api/auth/login
+   * Validates email/password against server-side env vars and creates a session.
+   */
+  router.post("/login", (req: Request, res: Response) => {
+    const { email, password } = req.body || {};
+
+    if (!email || !password) {
+      return res.status(400).json({ message: "Email and password are required." });
+    }
+
+    const devEmail = process.env.DEV_CLINICIAN_EMAIL || "";
+    const devPassword = process.env.DEV_CLINICIAN_PASSWORD || "";
+
+    if (email === devEmail && password === devPassword) {
+      req.session.user = {
+        email,
+        name: "Dr. Smith",
+      };
+
+      return res.json({
+        success: true,
+        user: { email, name: "Dr. Smith" },
+      });
+    }
+
+    return res.status(401).json({ message: "Invalid email or password." });
+  });
+
+  /**
+   * POST /api/auth/logout
+   * Destroys the current session and clears the session cookie.
+   */
+  router.post("/logout", (req: Request, res: Response) => {
+    req.session.destroy((err) => {
+      if (err) {
+        console.error("Session destruction failed:", err);
+        return res.status(500).json({ message: "Failed to logout." });
+      }
+      res.clearCookie("connect.sid");
+      return res.json({ success: true });
+    });
+  });
+
+  /**
+   * GET /api/auth/me
+   * Returns the current authenticated user's info if the session is valid.
+   */
+  router.get("/me", (req: Request, res: Response) => {
+    if (req.session.user) {
+      return res.json({ user: req.session.user });
+    }
+    return res.status(401).json({ message: "Not authenticated." });
+  });
+
+  return router;
+}
+
+/**
+ * Express middleware that blocks unauthenticated requests.
+ * Attach this to any route that requires a valid session.
+ */
+export function requireAuth(req: Request, res: Response, next: NextFunction) {
+  if (req.session?.user) {
+    return next();
+  }
+  return res.status(401).json({ message: "Authentication required." });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,9 @@
 import express, { type Request, Response, NextFunction } from "express";
+import session from "express-session";
+import createMemoryStore from "memorystore";
 import { DatabaseStartupError, verifyDatabaseConnection } from "./db";
 import { registerRoutes } from "./routes";
+import { createAuthRouter } from "./auth";
 import { serveStatic } from "./static";
 import { createServer } from "http";
 
@@ -12,6 +15,23 @@ declare module "http" {
     rawBody: unknown;
   }
 }
+
+const MemoryStore = createMemoryStore(session);
+
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET || "clinical-insight-engine-dev-secret",
+    resave: false,
+    saveUninitialized: false,
+    store: new MemoryStore({ checkPeriod: 86400000 }),
+    cookie: {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 24 * 60 * 60 * 1000, // 24 hours
+    },
+  }),
+);
 
 app.use(
   express.json({
@@ -72,6 +92,9 @@ app.use((req, res, next) => {
 
     process.exit(1);
   }
+
+  // Register auth routes BEFORE API routes so session is available
+  app.use("/api/auth", createAuthRouter());
 
   await registerRoutes(httpServer, app);
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,6 +2,8 @@ import type { Express } from "express";
 import type { Server } from "http";
 import { storage, type AssessmentCreateInput } from "./storage";
 import { api } from "@shared/routes";
+import { requireAuth } from "./auth";
+import { fileURLToPath } from "url";
 import { z } from "zod";
 import { existsSync } from "fs";
 import { writeFile, unlink } from "fs/promises";
@@ -10,7 +12,6 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import os from "os";
 import path from "path";
-import { fileURLToPath } from "url";
 import { rateLimit } from "express-rate-limit";
 
 const execFileAsync = promisify(execFile);
@@ -140,7 +141,7 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
   // Seed database on startup
   seedDatabase().catch(console.error);
   
-  app.post(api.assessments.create.path, rateLimiter, async (req, res) => {
+  app.post(api.assessments.create.path, requireAuth, rateLimiter, async (req, res) => {
     try {
       const input = api.assessments.create.input.parse(req.body);
       
@@ -225,7 +226,7 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
     }
   });
 
-  app.get(api.assessments.list.path, async (req, res) => {
+  app.get(api.assessments.list.path, requireAuth, async (req, res) => {
     try {
       const assessments = await storage.getAssessments();
       res.json(assessments);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -2,6 +2,11 @@
 import { getDb } from "./db"; // 1. Changed to import getDb instead of db
 import { assessments, type Assessment, type InsertAssessment, type AssessmentFactor } from "@shared/schema";
 
+export interface IStorage {
+  getAssessments(): Promise<Assessment[]>;
+  createAssessment(assessment: any): Promise<Assessment>; 
+}
+
 // Type for creating assessments with pre-computed model outputs (used in seeding)
 export type AssessmentCreateInput = InsertAssessment & {
   riskScore: string;
@@ -9,20 +14,6 @@ export type AssessmentCreateInput = InsertAssessment & {
   factors: AssessmentFactor[];
   confidenceInterval?: string;
   modelConfidence?: string;
-};
-
-export interface IStorage {
-  getAssessments(): Promise<Assessment[]>;
-  createAssessment(assessment: any): Promise<Assessment>; 
-}
-
-// Type for creating assessments with pre-computed model outputs (used in seeding)
-export type AssessmentCreateInput = InsertAssessment & { 
-  riskScore: string, 
-  riskCategory: string, 
-  factors: any,
-  confidenceInterval?: string,
-  modelConfidence?: string 
 };
 
 export class DatabaseStorage implements IStorage {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,21 +1,9 @@
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
-const mode = process.env.NODE_ENV === "production" ? "production" : "development";
-const env = loadEnv(mode, process.cwd(), "");
-const isDevelopment = mode === "development";
-
 export default defineConfig({
-  define: {
-    __DEV_CLINICIAN_EMAIL__: JSON.stringify(
-      isDevelopment ? env.DEV_CLINICIAN_EMAIL ?? "" : "",
-    ),
-    __DEV_CLINICIAN_PASSWORD__: JSON.stringify(
-      isDevelopment ? env.DEV_CLINICIAN_PASSWORD ?? "" : "",
-    ),
-  },
   plugins: [
     react(),
     runtimeErrorOverlay(),


### PR DESCRIPTION
## Summary

Implements proper server-side authentication for the assessment API routes. Previously, all auth logic was client-side (localStorage) and credentials were compiled into the Vite bundle, making them visible in DevTools.

## Changes

### New Files
- **server/auth.ts** - Authentication router with login/logout/me endpoints and `requireAuth` middleware

### Modified Files

| File | Change |
|------|--------|
| **server/index.ts** | Added express-session middleware with httpOnly cookies |
| **server/routes.ts** | Added `requireAuth` to POST and GET `/api/assessments` routes |
| **vite.config.ts** | Removed insecure `define` block leaking credentials into bundle |
| **AuthFlowModal.tsx** | Login now calls `POST /api/auth/login` (server-side validation) instead of client-side credential check |
| **AppLayout.tsx** | Auth check via `GET /api/auth/me` with session cookie, logout via `POST /api/auth/logout` |
| **storage.ts** | Fixed duplicate `AssessmentCreateInput` type definition |
| **History.tsx** | Fixed duplicate `formatAssessmentDate` declaration |

## Security Fixes

1. **No more client-side credential validation** - credentials checked server-side only
2. **No more localStorage auth** - auth state stored in httpOnly session cookies (invisible to JS)
3. **No more Vite credential globals** - `__DEV_CLINICIAN_EMAIL__` / `__DEV_CLINICIAN_PASSWORD__` removed from bundle
4. **API routes protected** - `requireAuth` middleware on all `/api/assessments` endpoints returns 401 without valid session

## Verification

- [x] `npm run check` passed with 0 errors
- [x] Pre-existing duplicate identifier bugs fixed

Closes #94