### PR TITLE
feat: add /api/health endpoint for monitoring and orchestration

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -139,7 +139,24 @@ function rateLimiter(req: any, res: any, next: any) {
 export async function registerRoutes(httpServer: Server, app: Express): Promise<Server> {
   // Seed database on startup
   seedDatabase().catch(console.error);
-  
+
+  // Health check endpoint for monitoring and orchestration
+  app.get("/api/health", async (_req, res) => {
+    try {
+      await storage.getAssessments();
+      res.json({
+        status: "healthy",
+        timestamp: new Date().toISOString(),
+        version: process.env.npm_package_version || "1.0.0",
+      });
+    } catch (e) {
+      res.status(503).json({
+        status: "unhealthy",
+        error: String(e),
+      });
+    }
+  });
+
   app.post(api.assessments.create.path, rateLimiter, async (req, res) => {
     try {
       const input = api.assessments.create.input.parse(req.body);


### PR DESCRIPTION
## Summary

Adds a `GET /api/health` endpoint for use with Docker/Kubernetes probes, load balancers, and monitoring tools (Prometheus, Datadog, etc.).
 
## Changes

| File | Change |
|------|--------|
| **server/routes.ts** | Added `/api/health` GET route that verifies DB connectivity via `storage.getAssessments()` |

## Response Examples

**Healthy (200 OK):**
```json
{
  "status": "healthy",
  "timestamp": "2026-05-27T10:30:00.000Z",
  "version": "1.0.0"
}
```
**Unhealthy (503 Service Unavailable):**
```json
{
  "status": "unhealthy",
  "error": "Database connection failed"
}
```

**Verification**
- `npm run check` passes (same 3 pre-existing errors in AuthFlowModal.tsx — unrelated)

Closes #97

