### PR TITLE
fix: protect PHI by using restricted temp dir instead of world-readable os.tmpdir()

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4,7 +4,7 @@ import { storage, type AssessmentCreateInput } from "./storage";
 import { api } from "@shared/routes";
 import { z } from "zod";
 import { existsSync } from "fs";
-import { writeFile, unlink } from "fs/promises";
+import { mkdtemp, writeFile, unlink, rm } from "fs/promises";
 import { randomUUID } from "crypto";
 import { execFile } from "child_process";
 import { promisify } from "util";
@@ -144,10 +144,12 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
     try {
       const input = api.assessments.create.input.parse(req.body);
       
-      // Save input to a temporary file to pass to the Python script
-      const tempFile = path.join(os.tmpdir(), `${randomUUID()}.json`);
+      // Save input to a temp dir with restricted permissions (0o700) instead of
+      // world-readable os.tmpdir() to protect PHI from other system users/processes
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "clin-"));
+      const tempFile = path.join(tempDir, `${randomUUID()}.json`);
       await writeFile(tempFile, JSON.stringify(input));
-      
+
       try {
         // Call Python script to perform the logistic regression analysis
          const { stdout, stderr } = await execFileAsync(
@@ -157,7 +159,7 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
             timeout: 30000
           }
         );
-        
+
         let prediction;
         try {
           prediction = JSON.parse(stdout.trim());
@@ -170,10 +172,10 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
           console.error("Failed to parse python output:", stdout, stderr);
           throw new Error("Failed to process prediction.");
         }
-        
+
         // Ensure non-diagnostic framing in response
         prediction.disclaimer = "DISCLAIMER: This is a clinical decision support tool and is not a medical diagnosis. Please consult with a healthcare professional for clinical decisions.";
-        
+
         // Save the assessment to the database
         const assessment = await storage.createAssessment({
           ...input,
@@ -186,7 +188,7 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
               ? undefined
               : String(prediction.modelConfidence)
         });
-        
+
         // Return both the DB assessment record and the rich prediction data (with advice)
         res.status(201).json({ ...assessment, prediction });
 
@@ -205,9 +207,8 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
         });
 
       } finally {
-        try {
-          await unlink(tempFile);
-        } catch (e) {}
+        // Securely clean up the restricted temp directory and all its contents
+        await rm(tempDir, { recursive: true, force: true }).catch(() => {});
       }
 
     } catch (err) {


### PR DESCRIPTION
## Description

Patient health information (PHI) was being written directly to `os.tmpdir()` which is world-readable on Unix systems (`/tmp` has `drwxrwxrwx`). Any other user or process on the system could read these temporary files containing medical assessment data (gender, age, hypertension, heart disease, BMI, HbA1c, blood glucose).

Now uses `fs.mkdtemp()` which creates a directory with `0o700` permissions — owner-only access.

## Related Issue

Closes #98

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Replaced `os.tmpdir()` + `writeFile` with `fs.mkdtemp()` to create a restricted temp directory (`0o700`)
- Updated cleanup in `finally` block to use `rm()` with `recursive: true` to remove the entire directory
- Updated imports to include `mkdtemp` and `rm` from `fs/promises`

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors