### PR TITLE
chore: add .editorconfig file for consistent editor settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Adds `.editorconfig` to enforce standard editor styles (indentation, charset, whitespace, line-endings) across various IDEs.

Fixes #118