### PR TITLE
chore: add .gitattributes file to manage line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Auto normalize line endings
+* text=auto eol=lf
+
+# Custom overrides
+*.ts text
+*.tsx text
+*.json text
+*.md text


### PR DESCRIPTION
Adds `.gitattributes` to handle cross-platform line ending normalization (LF line endings) across codebase files.

Fixes #119