### PR TITLE
ux: render dynamic clinician welcome name from session email

### DIFF
--- a/client/src/components/layout/AppLayout.tsx
+++ b/client/src/components/layout/AppLayout.tsx
@@ -93,15 +93,30 @@ export function AppLayout({ children }: AppLayoutProps) {
           </div>
 
           <div className="m-4 border-t border-slate-100 pt-4">
-            <div className="flex items-center gap-3 rounded-2xl bg-slate-50 p-3">
-              <div className="w-10 h-10 rounded-2xl bg-white flex items-center justify-center text-blue-700 font-black text-sm border border-slate-100 shadow-sm">
-                Dr
-              </div>
-              <div className="flex min-w-0 flex-col">
-                <span className="text-sm font-black text-[#1E293B] leading-tight">Dr. Smith</span>
-                <span className="text-xs text-slate-500 font-semibold">Cardiology</span>
-              </div>
-            </div>
+            {(() => {
+              const sessionStr = localStorage.getItem("cardioguard-auth-session");
+              let clinicianName = "Dr. Smith";
+              if (sessionStr) {
+                try {
+                  const session = JSON.parse(sessionStr);
+                  if (session.email) {
+                    const prefix = session.email.split("@")[0];
+                    clinicianName = "Dr. " + prefix.charAt(0).toUpperCase() + prefix.slice(1);
+                  }
+                } catch (e) {}
+              }
+              return (
+                <div className="flex items-center gap-3 rounded-2xl bg-slate-50 p-3">
+                  <div className="w-10 h-10 rounded-2xl bg-white flex items-center justify-center text-blue-700 font-black text-sm border border-slate-100 shadow-sm">
+                    Dr
+                  </div>
+                  <div className="flex min-w-0 flex-col">
+                    <span className="text-sm font-black text-[#1E293B] leading-tight">{clinicianName}</span>
+                    <span className="text-xs text-slate-500 font-semibold">Cardiology</span>
+                  </div>
+                </div>
+              );
+            })()}
             <button
               onClick={() => {
                 localStorage.removeItem("cardioguard-auth-session");


### PR DESCRIPTION
Parses the active session `cardioguard-auth-session` in local storage and extracts the email prefix to display the clinician's welcome name instead of using static hardcoded placeholders.

Fixes #135