### PR TITLE
ux: update footer GitHub social icon to point to repository profile

### DIFF
--- a/client/src/components/CardioGuardLanding.tsx
+++ b/client/src/components/CardioGuardLanding.tsx
@@ -60,7 +60,7 @@ const footerLinks = [
 
 const socialLinks = [
   { href: "https://www.linkedin.com", icon: Linkedin, label: "LinkedIn" },
-  { href: "https://github.com", icon: Github, label: "GitHub" },
+  { href: "https://github.com/gopaljilab/Clinical-Insight-Engine", icon: Github, label: "GitHub" },
   { href: "mailto:hello@cardioguard.ai", icon: Mail, label: "Email" },
 ];
 


### PR DESCRIPTION
Corrects the generic GitHub landing link pointing to standard GitHub homepage to point directly to CardioGuard's repository URL.

Fixes #136