### PR TITLE
fix: remove redundant duplicated route guard useEffect from AppLayout

### DIFF
--- a/client/src/components/layout/AppLayout.tsx
+++ b/client/src/components/layout/AppLayout.tsx
@@ -31,22 +31,6 @@ export function AppLayout({ children }: AppLayoutProps) {
     }
   }, [setLocation]);
 
-  useEffect(() => {
-    const sessionStr = localStorage.getItem("cardioguard-auth-session");
-    if (!sessionStr) {
-      setLocation("/");
-    } else {
-      try {
-        const session = JSON.parse(sessionStr);
-        if (!session.authenticated) {
-          setLocation("/");
-        }
-      } catch (e) {
-        setLocation("/");
-      }
-    }
-  }, [setLocation]);
-
   const navItems = [
     { href: "/dashboard", label: "New Assessment", icon: Activity },
     { href: "/history", label: "Patient History", icon: ClipboardList },


### PR DESCRIPTION
Eliminates duplicate routing validation hooks inside AppLayout.tsx, preventing dual wouter path evaluations and rendering side-effects.

Fixes #137