### PR TITLE
fix: correct 3 mismatched closing tags in AuthFlowModal.tsx

### DIFF
--- a/client/src/components/AuthFlowModal.tsx
+++ b/client/src/components/AuthFlowModal.tsx
@@ -111,7 +111,7 @@ function SecurityNotice() {
           </div>
         </div>
       </div>
-    </form>
+    </div>
   );
 }
 
@@ -126,7 +126,7 @@ function DevelopmentNotice() {
           Development Environment: Use local .env.local seeded clinician credentials to bypass or test dashboard integrations.
         </p>
       </div>
-    </form>
+    </div>
   );
 }
 
@@ -529,6 +529,6 @@ export function AuthFlowModal({ initialMode, isOpen, onClose }: AuthFlowModalPro
           </div>
         </section>
       </motion.div>
-    </form>
+    </div>
   );
 }


### PR DESCRIPTION
## Description

Three JSX closing tags in `AuthFlowModal.tsx` incorrectly used `</form>` instead of `</div>`, causing 3 TypeScript compile errors (`npm run check` failed with TS17002).

**Fixes:**
1. `SecurityNotice()` component (line 114): `</form>` → `</div>` 
2. `DevelopmentNotice()` component (line 129): `</form>` → `</div>`
3. Main `AuthFlowModal` return (line 532): `</form>` → `</div>`

## Related Issue

Closes #126

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Replaced `</form>` with `</div>` in `SecurityNotice()` component closing tag
- Replaced `</form>` with `</div>` in `DevelopmentNotice()` component closing tag
- Replaced `</form>` with `</div>` in main `AuthFlowModal` return closing tag

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors