### PR TITLE
Add missing .env.example with DATABASE_URL placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Server
+PORT=3000
+
+# API
+API_URL=http://localhost:5000
+
+# Database (if applicable)
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/clinical_insight_engine
+
+# Authentication
+SECRET_KEY=your-secret-key
+JWT_SECRET=your-jwt-secret
+
+# Other
+NODE_ENV=development


### PR DESCRIPTION
This PR adds the missing `.env.example` file as referenced in the README.
 
Changes:
- Added `.env.example` containing the `DATABASE_URL` placeholder documented in the setup guide.

Closes #14