### PR TITLE
fix: protect assessment API routes with requireAuth middleware

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,6 +1,7 @@
 import type { Express } from "express";
 import type { Server } from "http";
 import { storage, type AssessmentCreateInput } from "./storage";
+import { requireAuth } from "./auth";
 import { api } from "@shared/routes";
 import { z } from "zod";
 import { existsSync } from "fs";
@@ -176,6 +177,7 @@ export async function registerRoutes(
 
   app.post(
     api.assessments.create.path,
+    requireAuth,
     assessmentLimiter,
     async (req, res) => {
       let requestFingerprint: string | null = null;
@@ -304,7 +306,7 @@ export async function registerRoutes(
     }
   );
 
-  app.get(api.assessments.list.path, async (req, res) => {
+  app.get(api.assessments.list.path, requireAuth, async (req, res) => {
     try {
       const assessments = await storage.getAssessments();
 


### PR DESCRIPTION
## Description
The two assessment API endpoints (`GET /api/assessments` and `POST /api/assessments`) had no authentication middleware, allowing any unauthenticated caller to list all patient assessments or submit new ones by hitting the API directly. `requireAuth` was already implemented and exported in `server/auth.ts` but never imported or applied to these routes. This PR adds it.

## Related Issue
Closes #152 

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Import `requireAuth` from `./auth` in `server/routes.ts`
- Apply `requireAuth` to `POST /api/assessments` before `assessmentLimiter`
- Apply `requireAuth` to `GET /api/assessments`

## Screenshots (if applicable)
N/A — backend middleware change, no UI impact.

## Testing
- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors