### PR TITLE
fix: remove duplicate filter conditions in History.tsx

### DIFF
--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -26,11 +26,6 @@ export default function History() {
       String(a.age).includes(term) ||
       String(a.bmi).includes(term) ||
       String(a.hba1cLevel).includes(term) ||
-      String(a.bloodGlucoseLevel).includes(term) ||
-      a.smokingHistory.toLowerCase().includes(term) ||
-      String(a.age).includes(term) ||
-      String(a.bmi).includes(term) ||
-      String(a.hba1cLevel).includes(term) ||
       String(a.bloodGlucoseLevel).includes(term)
     );
   }) || [];


### PR DESCRIPTION
## Description
The `filteredAssessments` filter function in `client/src/pages/History.tsx` contained 5 duplicate conditions introduced as a copy-paste error from a previous PR that extended the search filters. These duplicate conditions were evaluated on every keystroke in the search box despite being identical to conditions already evaluated earlier in the same expression. This PR removes them.

## Related Issue
Closes #153 

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Remove 5 duplicate filter conditions from `filteredAssessments` in `History.tsx`
- Each field (`smokingHistory`, `age`, `bmi`, `hba1cLevel`, `bloodGlucoseLevel`) now appears only once in the filter
- No functional change — search behaviour is identical

## Screenshots (if applicable)
N/A — no UI change.

## Testing
- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors