### PR TITLE
fix: connect LoginPage to POST /api/auth/login backend endpoint

### DIFF
--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,10 +1,12 @@
 import { useState } from "react";
+import { useLocation } from "wouter";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [rememberMe, setRememberMe] = useState(false);
+  const [, setLocation] = useLocation();
   const [errors, setErrors] = useState<{ email?: string; password?: string }>({});
   const [isLoading, setIsLoading] = useState(false);
 
@@ -23,7 +25,7 @@ export default function LoginPage() {
     return newErrors;
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const validationErrors = validate();
     if (Object.keys(validationErrors).length > 0) {
@@ -32,11 +34,24 @@ export default function LoginPage() {
     }
     setErrors({});
     setIsLoading(true);
-    // Simulate API call (no backend needed for now)
-    setTimeout(() => {
+    try {
+      const res = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ email, password }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setErrors({ email: data.message || "Invalid email or password." });
+        return;
+      }
+      setLocation("/dashboard");
+    } catch {
+      setErrors({ email: "Unable to connect to server. Please try again." });
+    } finally {
       setIsLoading(false);
-      alert("Login successful! (Frontend only - no backend connected yet)");
-    }, 1500);
+    }
   };
 
   return (


### PR DESCRIPTION
## Description
`client/src/pages/LoginPage.tsx` was simulating login with a `setTimeout` and `alert()` instead of calling the real backend auth endpoint. This PR replaces the simulation with a real `fetch` call to `POST /api/auth/login`, adds proper error handling, and redirects to `/dashboard` on successful login.

## Related Issue
Closes #160 

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Replace `setTimeout`/`alert` simulation with real `fetch` call to `POST /api/auth/login`
- Add `async/await` error handling for network and auth failures
- Redirect to `/dashboard` on successful login using wouter's `useLocation`
- Display server error message on failed login attempt

## Screenshots (if applicable)
N/A — no UI change, only wiring up existing form to backend.

## Testing
- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors