### PR TITLE
fix: correct advancedFilter to use actual Assessment fields instead of non-existent 'name'

### DIFF
--- a/client/src/utils/search_filters.ts
+++ b/client/src/utils/search_filters.ts
@@ -1,3 +1,14 @@
-export function advancedFilter(patients: any[], query: string) {
-  return patients.filter(p => p.name.includes(query) || p.age.toString() === query);
+import type { Assessment } from "@shared/schema";
+
+export function advancedFilter(assessments: Assessment[], query: string): Assessment[] {
+  const term = query.toLowerCase();
+  return assessments.filter(a =>
+    a.gender.toLowerCase().includes(term) ||
+    a.riskCategory.toLowerCase().includes(term) ||
+    a.smokingHistory.toLowerCase().includes(term) ||
+    String(a.age).includes(term) ||
+    String(a.bmi).includes(term) ||
+    String(a.hba1cLevel).includes(term) ||
+    String(a.bloodGlucoseLevel).includes(term)
+  );
 }


### PR DESCRIPTION
## Description
`client/src/utils/search_filters.ts` had an `advancedFilter` function referencing `p.name` — a field that doesn't exist on the `Assessment` model. This caused the name filter to always return `undefined`, silently producing no results. The function also used `any[]` instead of the proper `Assessment` type. This PR fixes both issues and aligns the filter fields with the existing search implementation in `History.tsx`.

## Related Issue
Closes #161 

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Replace `p.name` (non-existent field) with actual Assessment fields
- Add proper `Assessment` type import instead of `any[]`
- Filter on `gender`, `riskCategory`, `smokingHistory`, `age`, `bmi`, `hba1cLevel`, `bloodGlucoseLevel`
- Consistent with existing search implementation in `History.tsx`

## Screenshots (if applicable)
N/A — no UI change.

## Testing
- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors