### PR TITLE
fix: replace in-memory session store with PostgreSQL-backed store

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -2,9 +2,8 @@ import crypto from "crypto";
 import express, { type Request, Response, NextFunction } from "express";
 import helmet from "helmet";
 import session from "express-session";
-import crypto from "crypto";
-import createMemoryStore from "memorystore";
-import { DatabaseStartupError, verifyDatabaseConnection, closePool } from "./db";
+import connectPgSimple from "connect-pg-simple";
+import { DatabaseStartupError, verifyDatabaseConnection, closePool, getPool } from "./db";
 import { registerRoutes } from "./routes";
 import { createAuthRouter } from "./auth";
 import { serveStatic } from "./static";
@@ -25,14 +24,18 @@ declare module "express" {
   }
 }
 
-const MemoryStore = createMemoryStore(session);
+const PgSession = connectPgSimple(session);
 
 app.use(
   session({
     secret: process.env.SESSION_SECRET || "clinical-insight-engine-dev-secret",
     resave: false,
     saveUninitialized: false,
-    store: new MemoryStore({ checkPeriod: 86400000 }),
+    store: new PgSession({
+      pool: getPool(),
+      tableName: "session",
+      createTableIfMissing: true,
+    }),
     cookie: {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",


### PR DESCRIPTION
Fixes #195
 
## Description
`server/index.ts` used `memorystore` for session storage, which clears all sessions on every server restart, crash, or deployment. Any logged-in clinician would be immediately logged out whenever the server restarted — a known limitation of in-memory stores not suitable for production use.

This PR replaces `memorystore` with `connect-pg-simple`, reusing the existing PostgreSQL pool from `db.ts` so sessions persist across server restarts.

Additionally fixed a pre-existing bug: `crypto` was imported twice at the top of `server/index.ts`.

**Changes:**
- Removed `memorystore` import and `MemoryStore` instantiation
- Removed duplicate `crypto` import
- Added `connect-pg-simple` session store using existing `getPool()` from `db.ts`
- `createTableIfMissing: true` auto-creates the `session` table on first run — no manual migration needed
- All other session config (secret, cookie, maxAge) remains unchanged

**Files changed:** `server/index.ts` only

**Note:** `connect-pg-simple` and `@types/connect-pg-simple` were already present in `package.json` — no new dependencies added.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Build passes with no new errors (`npm run build`)
- Session store initializes using existing `DATABASE_URL` pool
- `createTableIfMissing: true` ensures zero-config setup for new environments
- Duplicate `crypto` import removed — no TypeScript errors

## Checklist
- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new TypeScript errors in modified files
- [x] I have tested these changes locally