### PR TITLE
fix: replace false compliance claims in SecurityNotice with accurate descriptions

### DIFF
--- a/client/src/components/AuthFlowModal.tsx
+++ b/client/src/components/AuthFlowModal.tsx
@@ -98,9 +98,9 @@ function SecurityNotice() {
       <div className="flex items-start gap-3">
         <LockKeyhole className="mt-0.5 h-5 w-5 shrink-0 text-[#2563EB]" aria-hidden="true" />
         <div>
-          <p className="text-sm font-bold text-[#1E293B]">Your data is encrypted end-to-end using AES-256 standards.</p>
+          <p className="text-sm font-bold text-[#1E293B]">Your session is protected with secure HTTP-only cookies and server-side authentication.</p>
           <div className="mt-3 flex flex-wrap gap-2">
-            {["HIPAA Compliant", "GDPR Secure"].map((badge) => (
+            {["Session Auth", "HTTP-only Cookies", "Demo Environment"].map((badge) => (
               <span key={badge} className="rounded-full bg-white px-3 py-1 text-xs font-bold text-slate-600 ring-1 ring-slate-200">
                 {badge}
               </span>


### PR DESCRIPTION
Fixes #196

## Description
The `SecurityNotice` component in `AuthFlowModal.tsx` displayed three false security claims to users on every login and registration screen: 

- "Your data is encrypted end-to-end using AES-256 standards." — the app uses standard HTTPS session cookies, not AES-256 encryption
- "HIPAA Compliant" — no HIPAA compliance infrastructure exists
- "GDPR Secure" — no GDPR compliance mechanisms exist

Displaying false compliance claims on a clinical tool handling patient health data is misleading and a potential legal liability.

**Changes:**
- Replaced false AES-256 encryption claim with accurate description: "Your session is protected with secure HTTP-only cookies and server-side authentication."
- Replaced "HIPAA Compliant" and "GDPR Secure" badges with accurate labels: "Session Auth", "HTTP-only Cookies", "Demo Environment"
- No structural or styling changes — only the text content was updated

**Files changed:** `client/src/components/AuthFlowModal.tsx` only

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Build passes with no new errors (`npm run build`)
- Verified "AES-256", "HIPAA", and "GDPR" no longer appear anywhere in the component
- SecurityNotice renders correctly with updated text and badges

## Checklist
- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new TypeScript errors in modified files
- [x] I have tested these changes locally