### PR TITLE
fix: restrict seedDatabase to development environment only

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -175,8 +175,10 @@ export async function registerRoutes(
   httpServer: Server,
   app: Express
 ): Promise<Server> {
-  // Seed database on startup
-  seedDatabase().catch(console.error);
+  // Seed database on startup — development only to prevent fake data in production
+  if (process.env.NODE_ENV !== "production") {
+    seedDatabase().catch(console.error);
+  }
 
   app.post(
     api.assessments.create.path,


### PR DESCRIPTION
Fixes #197

## Description
`server/routes.ts` called `seedDatabase()` on every server startup unconditionally. The function only checks if the assessments table is empty — so if a clinician deleted all real patient assessments, the next server restart would silently re-populate the database with 3 fake sample patients (Male/45, Female/62, Male/58) with hardcoded risk scores. A clinician could unknowingly act on this fake data in a production environment. 

The fix wraps the `seedDatabase()` call in a `NODE_ENV !== "production"` guard so fake sample data is only inserted in development. Production deployments start with a clean database.

**Changes:**
- Wrapped `seedDatabase().catch(console.error)` in `if (process.env.NODE_ENV !== "production")`
- No changes to the `seedDatabase` function itself
- One line change in `server/routes.ts`

**Files changed:** `server/routes.ts` only

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Build passes with no new errors (`npm run build`)
- In development (`NODE_ENV=development`): seed runs as before on empty database
- In production (`NODE_ENV=production`): seed is skipped entirely

## Checklist
- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new TypeScript errors in modified files
- [x] I have tested these changes locally