### PR TITLE
fix: replace developer-facing 404 message with user-friendly copy

### DIFF
--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -1,6 +1,6 @@
+import { Link } from "wouter";
 import { Card, CardContent } from "@/components/ui/card";
 import { AlertCircle } from "lucide-react";
-
 export default function NotFound() {
   return (
     <div className="min-h-screen w-full flex items-center justify-center bg-gray-50">
@@ -10,10 +10,15 @@ export default function NotFound() {
             <AlertCircle className="h-8 w-8 text-red-500" />
             <h1 className="text-2xl font-bold text-gray-900">404 Page Not Found</h1>
           </div>
-
           <p className="mt-4 text-sm text-gray-600">
-            Did you forget to add the page to the router?
+            The page you&apos;re looking for doesn&apos;t exist or has been moved.
           </p>
+          <Link
+            href="/dashboard"
+            className="mt-6 inline-flex items-center justify-center rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-bold text-white shadow-sm transition-all duration-200 hover:bg-blue-700 focus:outline-none focus:ring-4 focus:ring-blue-200"
+          >
+            Back to Dashboard
+          </Link>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
Fixes #198
 
## Description
`client/src/pages/not-found.tsx` displayed a developer-facing message to end users on the 404 page:

> "Did you forget to add the page to the router?"

This message is meaningless to clinicians using the app and exposes internal implementation details about the routing architecture. It should never be visible in production.

**Changes:**
- Removed "Did you forget to add the page to the router?" message
- Replaced with user-friendly copy: "The page you're looking for doesn't exist or has been moved."
- Added a "Back to Dashboard" link using `wouter`'s `Link` component so clinicians can navigate back without using the browser back button

**Files changed:** `client/src/pages/not-found.tsx` only

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Build passes with no new errors (`npm run build`)
- Navigate to any non-existent route — user-friendly message and Back to Dashboard button render correctly
- Developer routing message no longer visible

## Checklist
- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new TypeScript errors in modified files
- [x] I have tested these changes locally