### PR TITLE
fix: align smoking history values between Zod schema and ML training data

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -208,8 +208,6 @@ export default function Dashboard() {
                     <option value="No Info">No Info</option>
                     <option value="current">current</option>
                     <option value="former">former</option>
-                    <option value="ever">ever</option>
-                    <option value="not current">not current</option>
                   </select>
                   {errors.smokingHistory && <p className="text-sm text-red-600 mt-1">{errors.smokingHistory.message}</p>}
                 </div>

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -34,7 +34,7 @@ export const insertAssessmentSchema = createInsertSchema(assessments, {
   age: z.coerce.number().min(1, "Age must be greater than 0").max(120, "Age is too high"),
   hypertension: z.boolean().default(false),
   heartDisease: z.boolean().default(false),
-  smokingHistory: z.enum(["never", "No Info", "current", "former", "ever", "not current"], { required_error: "Please select smoking history" }),
+  smokingHistory: z.enum(["never", "No Info", "current", "former"], { required_error: "Please select smoking history" }),
   bmi: z.coerce.number().min(10, "BMI must be between 10 and 60").max(60, "BMI must be between 10 and 60"),
   hba1cLevel: z.coerce.number().min(3, "HbA1c must be between 3 and 15").max(15, "HbA1c must be between 3 and 15"),
   bloodGlucoseLevel: z.coerce.number().min(50, "Blood glucose must be between 50 and 400").max(400, "Blood glucose must be between 50 and 400"),


### PR DESCRIPTION
Fixes #199

## Description 
The Zod validation schema in `shared/schema.ts` accepted 6 smoking history values:
`"never"`, `"No Info"`, `"current"`, `"former"`, `"ever"`, `"not current"`

But the ML training data in `analyze.py` only generates 4:
`"never"`, `"No Info"`, `"current"`, `"former"`

The values `"ever"` and `"not current"` were never present in the training data, so their one-hot encoded columns (`smoke_ever`, `smoke_not current`) were never created as model features. When a patient was submitted with `smokingHistory: "ever"` or `smokingHistory: "not current"`, the smoking history was silently ignored in the risk calculation — producing an incorrect risk score with no error or warning.

The fix restricts both the Zod schema and the frontend dropdown to only the 4 values present in the training data. This is safer than adding `"ever"` and `"not current"` to the training data, which would require retraining the model.

**Changes:**
- Removed `"ever"` and `"not current"` from the `smokingHistory` Zod enum in `shared/schema.ts`
- Removed `"ever"` and `"not current"` `<option>` elements from the Dashboard.tsx dropdown
- Valid values are now: `"never"`, `"No Info"`, `"current"`, `"former"` — matching `analyze.py`

**Files changed:** `shared/schema.ts`, `client/src/pages/Dashboard.tsx`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Build passes with no new errors (`npm run build`)
- Dashboard smoking history dropdown now shows only 4 valid options
- Submitting an assessment with any valid smoking history value produces correct risk scores
- `"ever"` and `"not current"` no longer accepted by schema validation

## Checklist
- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new TypeScript errors in modified files
- [x] I have tested these changes locally