### PR TITLE
fix: remove "Other" gender from Zod schema to match ML model training data

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -169,7 +169,7 @@ export default function Dashboard() {
                 <div className="space-y-2">
                   <label className={labelClass}>Gender</label>
                   <div className="grid grid-cols-3 gap-1 rounded-2xl bg-slate-100 p-1">
-                    {["Male", "Female", "Other"].map((g) => (
+                    {["Male", "Female"].map((g) => (
                       <label key={g} className="flex-1 cursor-pointer">
                         <input type="radio" value={g} {...register("gender")} className="peer sr-only" />
                         <div className="text-center px-3 py-3 rounded-xl transition-all duration-200 font-bold text-sm text-slate-500 hover:text-blue-700 peer-checked:bg-white peer-checked:text-blue-700 peer-checked:shadow-sm">

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -10,7 +10,7 @@ export type AssessmentFactor = {
 
 export const assessments = pgTable("assessments", {
   id: serial("id").primaryKey(),
-  gender: text("gender").notNull(), // 'Male', 'Female', 'Other'
+  gender: text("gender").notNull(), // 'Male', 'Female'
   age: integer("age").notNull(),
   hypertension: boolean("hypertension").notNull(),
   heartDisease: boolean("heart_disease").notNull(),
@@ -30,7 +30,7 @@ export const assessments = pgTable("assessments", {
 });
 
 export const insertAssessmentSchema = createInsertSchema(assessments, {
-  gender: z.enum(["Male", "Female", "Other"], { required_error: "Please select a gender" }),
+  gender: z.enum(["Male", "Female"], { required_error: "Please select a gender" }),
   age: z.coerce.number().min(1, "Age must be greater than 0").max(120, "Age is too high"),
   hypertension: z.boolean().default(false),
   heartDisease: z.boolean().default(false),


### PR DESCRIPTION
Fixes #201

## Description
`shared/schema.ts` accepted `"Other"` as a valid gender value, but `analyze.py` explicitly drops all `"Other"` gender rows during training:

```python
df = df[df['gender'] != 'Other']
```

The model is trained with only a binary `gender_Male` feature (1 for Male, 0 for Female). When a patient with `gender: "Other"` was submitted, `gender_Male` was set to 0 — identical to Female — so the model silently treated every "Other" patient as Female with no error or warning, producing potentially incorrect risk scores.

**Changes:**
- Removed `"Other"` from the `gender` Zod enum in `shared/schema.ts`
- Updated schema column comment to reflect supported values: `'Male', 'Female'`
- Removed `"Other"` radio option from the Dashboard.tsx gender selector
- Valid values now: `"Male"`, `"Female"` — matching `analyze.py` training data

**Files changed:** `shared/schema.ts`, `client/src/pages/Dashboard.tsx`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Build passes with no new errors (`npm run build`)
- Dashboard gender selector now shows only Male and Female options
- Submitting `gender: "Other"` is now rejected by schema validation
- Risk scores for Male and Female patients are unaffected

## Checklist
- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new TypeScript errors in modified files
- [x] I have tested these changes locally