### PR TITLE
fix: replace misleading "Watch Video" button with accurate "See Features" label

### DIFF
--- a/client/src/components/CardioGuardLanding.tsx
+++ b/client/src/components/CardioGuardLanding.tsx
@@ -10,7 +10,6 @@ import {
   Linkedin,
   LockKeyhole,
   Mail,
-  PlayCircle,
   ShieldCheck,
   Stethoscope,
   Workflow,
@@ -255,8 +254,7 @@ export function CardioGuardLanding() {
                   href="#features"
                   className="inline-flex items-center justify-center gap-2 rounded-2xl border border-slate-300 bg-white/80 px-7 py-4 text-base font-black text-[#1E293B] shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-[#2563EB] hover:text-[#2563EB] hover:shadow-lg focus:outline-none focus:ring-4 focus:ring-blue-100"
                 >
-                  <PlayCircle className="h-5 w-5 text-[#2563EB]" aria-hidden="true" />
-                  Watch Video
+                  See Features
                 </a>
               </div>
 


### PR DESCRIPTION
Fixes #202

## Description
The "Watch Video" button in the hero section of `CardioGuardLanding.tsx` used a `PlayCircle` icon and the label "Watch Video", strongly implying a demo video would play. In reality, clicking it simply scrolled to the `#features` section — no video exists.

This is misleading to users, particularly clinicians evaluating the tool who expect to see a product demo.

**Changes:**
- Replaced "Watch Video" label with "See Features" — accurately describes what the button does
- Removed the `PlayCircle` icon since there is no video to play
- Removed unused `PlayCircle` import from lucide-react

The `href="#features"` anchor is kept unchanged since scrolling to the features section is the correct behaviour.

**Files changed:** `client/src/components/CardioGuardLanding.tsx` only

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Build passes with no new errors (`npm run build`)
- Button correctly scrolls to the features section
- No misleading video play implication remains
- `PlayCircle` no longer imported — no unused import warnings

## Checklist
- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new TypeScript errors in modified files
- [x] I have tested these changes locally