### PR TITLE
fix: replace "Request a Demo" button with mailto link instead of opening register modal

### DIFF
--- a/client/src/components/CardioGuardLanding.tsx
+++ b/client/src/components/CardioGuardLanding.tsx
@@ -243,14 +243,13 @@ export function CardioGuardLanding() {
               </p>
 
               <div className="mt-9 flex flex-col gap-4 sm:flex-row">
-                <button
-                  type="button"
-                  onClick={() => setAuthMode("register")}
+                
+                  href="mailto:hello@cardioguard.ai"
                   className="inline-flex items-center justify-center gap-2 rounded-2xl bg-[#2563EB] px-7 py-4 text-base font-black text-white shadow-xl shadow-blue-600/20 transition-all duration-200 hover:-translate-y-0.5 hover:scale-[1.02] hover:bg-blue-700 hover:shadow-2xl hover:shadow-blue-600/30 focus:outline-none focus:ring-4 focus:ring-blue-200"
                 >
                   Request a Demo
                   <ArrowRight className="h-5 w-5" aria-hidden="true" />
-                </button>
+                </a>
                 <a
                   href="#features"
                   className="inline-flex items-center justify-center gap-2 rounded-2xl border border-slate-300 bg-white/80 px-7 py-4 text-base font-black text-[#1E293B] shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-[#2563EB] hover:text-[#2563EB] hover:shadow-lg focus:outline-none focus:ring-4 focus:ring-blue-100"


### PR DESCRIPTION
Fixes #204

## Description
The "Request a Demo" button in the hero section of `CardioGuardLanding.tsx` called `setAuthMode("register")`, which opened the account registration modal instead of a demo request form. This is misleading to prospective clinic users who expect to fill out a contact or demo request form.

The fix replaces the button with a `mailto:hello@cardioguard.ai` anchor link — consistent with the "Contact Sales" button already present in the pricing section of the same page.

**Changes:**
- Replaced `<button onClick={() => setAuthMode("register")}>` with `<a href="mailto:hello@cardioguard.ai">`
- All existing styles preserved unchanged
- `ArrowRight` icon retained

**Files changed:** `client/src/components/CardioGuardLanding.tsx` only

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Build passes with no new errors (`npm run build`)
- Clicking "Request a Demo" now opens the user's mail client with hello@cardioguard.ai
- Registration modal no longer opens on "Request a Demo" click
- Consistent behaviour with "Contact Sales" button in the pricing section

## Checklist
- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new TypeScript errors in modified files
- [x] I have tested these changes locally