### PR TITLE
fix: scope GET /api/assessments to authenticated clinician only

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -260,7 +260,8 @@ export async function registerRoutes(
             modelConfidence:
               prediction.modelConfidence == null
                 ? undefined
-                : String(prediction.modelConfidence)
+                : String(prediction.modelConfidence),
+            createdBy: userId
           });
 
           // Return both the DB assessment record and the rich prediction data
@@ -317,7 +318,8 @@ export async function registerRoutes(
 
   app.get(api.assessments.list.path, requireAuth, async (req, res) => {
     try {
-      const assessments = await storage.getAssessments();
+      const userEmail = req.session.user?.email;
+      const assessments = await storage.getAssessments(50, 0, userEmail);
 
       res.json(assessments);
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -5,28 +5,35 @@ import {
   type InsertAssessment,
   type AssessmentFactor
 } from "@shared/schema";
-import { desc } from "drizzle-orm";
-
+import { desc, eq } from "drizzle-orm";
 export interface IStorage {
-  getAssessments(limit?: number, offset?: number): Promise<Assessment[]>;
+  getAssessments(limit?: number, offset?: number, createdBy?: string): Promise<Assessment[]>;
   createAssessment(assessment: any): Promise<Assessment>;
 }
-
 export type AssessmentCreateInput = InsertAssessment & {
   riskScore: string;
   riskCategory: string;
   factors: AssessmentFactor[];
   confidenceInterval?: string;
   modelConfidence?: string;
+  createdBy?: string;
 };
-
 export class DatabaseStorage implements IStorage {
   async getAssessments(
     limit: number = 50,
-    offset: number = 0
+    offset: number = 0,
+    createdBy?: string
   ): Promise<Assessment[]> {
     const db = getDb();
-
+    if (createdBy) {
+      return await db
+        .select()
+        .from(assessments)
+        .where(eq(assessments.createdBy, createdBy))
+        .orderBy(desc(assessments.createdAt))
+        .limit(limit)
+        .offset(offset);
+    }
     return await db
       .select()
       .from(assessments)
@@ -34,19 +41,15 @@ export class DatabaseStorage implements IStorage {
       .limit(limit)
       .offset(offset);
   }
-
   async createAssessment(
     assessment: AssessmentCreateInput
   ): Promise<Assessment> {
     const db = getDb();
-
     const [created] = await db
       .insert(assessments)
       .values(assessment)
       .returning();
-
     return created;
   }
 }
-
 export const storage = new DatabaseStorage();

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -26,6 +26,7 @@ export const assessments = pgTable("assessments", {
   confidenceInterval: jsonb("confidence_interval").$type<string | null>(),
   modelConfidence: text("model_confidence"),
   
+  createdBy: text("created_by"),
   createdAt: timestamp("created_at").defaultNow(),
 });
 


### PR DESCRIPTION
Fixes #230

## Description 
`GET /api/assessments` called `storage.getAssessments()` with no user filtering, returning every assessment in the database regardless of which clinician was logged in. Clinician A could see all of Clinician B's patient assessments — a serious privacy issue for a clinical tool handling sensitive patient health data.
 
**Changes:**
- Added `createdBy` column (`text("created_by")`) to the `assessments` table in `shared/schema.ts`
- Updated `storage.getAssessments()` to accept an optional `createdBy` parameter and filter with `WHERE created_by = ?` when provided
- Added `eq` import from `drizzle-orm` in `server/storage.ts`
- Updated `AssessmentCreateInput` type to include optional `createdBy` field
- Pass `userId` (session email) as `createdBy` when creating a new assessment in `server/routes.ts`
- Filter assessments by `req.session.user?.email` in the `GET /api/assessments` handler

**Files changed:** `shared/schema.ts`, `server/storage.ts`, `server/routes.ts`

**Note:** A database migration (`npm run db:push`) is required to add the `created_by` column to the existing assessments table.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Build passes with no new errors (`npm run build`)
- Creating an assessment stores the clinician's session email as `createdBy`
- `GET /api/assessments` returns only the authenticated clinician's assessments
- Clinicians can no longer see each other's patient data

## Checklist
- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new TypeScript errors in modified files
- [x] I have tested these changes locally