### PR TITLE
feat: add workflow to sync labels from linked issues to PR

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,17 +1,122 @@
 name: Sync Labels from Issue to PR
 
+# Automatically copies labels from linked issues to the PR.
+# Also supports manual backfill for already-closed PRs.
 on:
   pull_request_target:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened, synchronize, closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to backfill labels for"
+        required: false
+        type: number
+
+# Minimal permissions: read issues to get their labels, write PR labels.
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   copy-labels:
+    name: Copy labels from linked issues to PR
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
     steps:
-      - name: Copy Labels
-        uses: michalvankodev/copy-issue-labels@v1.3.0
+      - name: Apply issue labels to PR
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER);
+            if (!prNumber) {
+              core.info('No PR number available — nothing to do.');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+
+            // Fetch the PR body to find linked issues.
+            let body;
+            try {
+              const { data: pr } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: prNumber,
+              });
+              body = pr.body || '';
+            } catch (err) {
+              core.warning(`Could not fetch PR #${prNumber}: ${err.message}`);
+              return;
+            }
+
+            // Collect issue numbers from
+            // "Fixes/Closes/Resolves #NNN" (case-insensitive).
+            const pattern = /(?:fixes|closes|resolves)\s+#(\d+)/gi;
+            const issueNumbers = [];
+            let match;
+            while ((match = pattern.exec(body)) !== null) {
+              issueNumbers.push(parseInt(match[1], 10));
+            }
+
+            if (issueNumbers.length === 0) {
+              core.info('No linked issues found in PR body — nothing to do.');
+              return;
+            }
+
+            core.info(`Linked issues: ${issueNumbers.join(', ')}`);
+
+            // Fetch labels from every referenced issue;
+            // ignore missing/invalid ones.
+            const labelSet = new Set();
+            for (const issueNumber of issueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                });
+                for (const label of issue.labels) {
+                  labelSet.add(typeof label === 'string' ? label : label.name);
+                }
+              } catch (err) {
+                // Non-existent or inaccessible issue — skip gracefully.
+                core.warning(
+                  `Could not fetch issue #${issueNumber}: ${err.message}`
+                );
+              }
+            }
+
+            if (labelSet.size === 0) {
+              core.info(
+                'Referenced issues carry no labels — nothing to apply.'
+              );
+              return;
+            }
+
+            // Determine which labels the PR does not already have.
+            const { data: prData } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+            const existingLabels = new Set(
+              prData.labels.map((l) => (typeof l === 'string' ? l : l.name))
+            );
+            const toAdd = [...labelSet].filter((l) => !existingLabels.has(l));
+
+            if (toAdd.length === 0) {
+              core.info('PR already has all issue labels — nothing to add.');
+              return;
+            }
+
+            core.info(
+              `Adding labels to PR #${prNumber}: ${toAdd.join(', ')}`
+            );
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: prNumber,
+              labels: toAdd,
+            });


### PR DESCRIPTION
## Description

Updates the existing `sync-labels.yml` workflow to:
- Trigger on `closed` events (so merged PRs also get labels from their linked issues)
- Support `workflow_dispatch` for manual backfill of already-closed PRs
- Replace the third-party `michalvankodev/copy-issue-labels` action with `actions/github-script@v9` (official, more secure, no external token exposure)

## Related Issue

Closes #168

## Type of Change

- [ ] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Updated `.github/workflows/sync-labels.yml`:
  - Added `closed` to `pull_request_target` trigger types
  - Added `workflow_dispatch` with `pr_number` input for manual backfill
  - Replaced `michalvankodev/copy-issue-labels@v1.3.0` with `actions/github-script@v9`
  - Custom script scans PR body for `Fixes/Closes/Resolves #NNN` patterns
  - Fetches labels from each linked issue via GitHub API
  - Applies only labels the PR doesn't already have
  - Uses `PR_NUMBER` env var to handle both auto and manual modes

## Testing

- [ ] I have tested these changes locally

Workflow is YAML-only. No effect on application code.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors