### PR TITLE
fix: validate Elasticsearch env vars and remove insecure defaults (#235)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,9 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/clinical_insight_engi
 SECRET_KEY=your-secret-key
 JWT_SECRET=your-jwt-secret
 
+# Elasticsearch
+ELASTICSEARCH_URL=http://localhost:9200
+ELASTICSEARCH_API_KEY=your-elasticsearch-api-key
+
 # Other
 NODE_ENV=development

--- a/server/utils/elasticsearch.ts
+++ b/server/utils/elasticsearch.ts
@@ -1,13 +1,27 @@
 import { Client } from "@elastic/elasticsearch";
 
-const esClient = new Client({
-  node: process.env.ELASTICSEARCH_URL || "http://localhost:9200",
-  auth: {
-    apiKey: process.env.ELASTICSEARCH_API_KEY || "api-key"
-  }
-});
+const { ELASTICSEARCH_URL, ELASTICSEARCH_API_KEY } = process.env;
+
+let esClient: Client | null = null;
+
+if (!ELASTICSEARCH_URL || !ELASTICSEARCH_API_KEY) {
+  console.error(
+    "Elasticsearch is disabled: ELASTICSEARCH_URL and ELASTICSEARCH_API_KEY must be set."
+  );
+} else {
+  esClient = new Client({
+    node: ELASTICSEARCH_URL,
+    auth: {
+      apiKey: ELASTICSEARCH_API_KEY
+    }
+  });
+}
 
 export const indexMedicalDocument = async (id: string, doc: any) => {
+  if (!esClient) {
+    console.error("Elasticsearch indexing skipped: client is not configured.");
+    return;
+  }
   try {
     await esClient.index({
       index: "medical_records",
@@ -20,6 +34,10 @@ export const indexMedicalDocument = async (id: string, doc: any) => {
 };
 
 export const searchMedicalDocuments = async (queryText: string) => {
+  if (!esClient) {
+    console.error("Elasticsearch search skipped: client is not configured.");
+    return [];
+  }
   try {
     const result = await esClient.search({
       index: "medical_records",


### PR DESCRIPTION
## Description
Removes insecure Elasticsearch fallback credentials and adds environment variable validation to prevent silent initialization with default runtime values.

Fixes #235

### Changes made
- Removed hardcoded fallback values:
  - `http://localhost:9200`
  - `"api-key"`
- Added validation for:
  - `ELASTICSEARCH_URL`
  - `ELASTICSEARCH_API_KEY`
- Prevented Elasticsearch client initialization when required environment variables are missing
- Updated `.env.example` with required Elasticsearch variables

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code