### PR TITLE
Add ESLint configuration for static analysis

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,34 @@
+{
+  "root": true,
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2022": true
+  },
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "extends": [
+    "eslint:recommended"
+  ],
+  "ignorePatterns": [
+    "dist/",
+    "build/",
+    "coverage/",
+    "node_modules/",
+    "*.config.js",
+    "*.config.ts"
+  ],
+  "rules": {
+    "no-unused-vars": "warn",
+    "no-console": "off",
+    "eqeqeq": [
+      "warn",
+      "always"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a root `.eslintrc.json` for baseline static analysis
- configure browser, Node, ES module, and JSX parsing support
- ignore generated/build folders and treat unused variables as warnings

Closes #240

## Testing
- ESLint was not run locally in this sandbox.
