### PR TITLE
feat(docker): add docker-compose and dockerfile for fast setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Node dependencies
+node_modules
+npm-debug.log*
+
+# Python environment
+.venv
+venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+
+# Production builds
+dist
+
+# OS files
+.DS_Store
+
+# Git
+.git
+.github
+
+# Configuration files
+.editorconfig
+.prettierrc
+.nvmrc
+components.json
+tsconfig.json
+postcss.config.js
+tailwind.config.ts
+vite.config.ts
+drizzle.config.ts
+
+# Environment secrets
+.env
+.env.local
+.env.development
+.env.production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM node:20-bookworm-slim
+
+# Set default runtime environment variables
+ENV NODE_ENV=development
+ENV PORT=3000
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Set working directory inside the container
+WORKDIR /app
+
+# Install system dependencies needed for node-postgres, python, and pip package compilation
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    python3-venv \
+    build-essential \
+    postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create Python virtual environment under /app/.venv to match getPythonExecutable candidate checks
+RUN python3 -m venv /app/.venv
+
+# Copy Python requirements and install in the virtual environment
+COPY requirements.txt ./
+RUN /app/.venv/bin/pip install --no-cache-dir -r requirements.txt
+
+# Copy package definition and install Node.js dependencies
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy all application source files
+COPY . .
+
+# Expose the default application port
+EXPOSE 3000
+
+# Run the development server by default (can be overridden in docker-compose)
+CMD ["npm", "run", "dev"]

--- a/README.md
+++ b/README.md
@@ -255,10 +255,52 @@ graph TB
 | Python | 3.10+ | `python3 --version` | [python.org](https://python.org) |
 | PostgreSQL | 14+ | `psql --version` | [postgresql.org](https://postgresql.org) |
 | Git | Any | `git --version` | [git-scm.com](https://git-scm.com) |
+| Docker | 20+ | `docker --version` | [docker.com](https://www.docker.com) |
+| Docker Compose | 2+ | `docker compose version` | bundled with Docker |
 
 ---
 
-## ⚙️ Installation & Setup
+## 🐳 Fast Setup with Docker (Recommended)
+
+If you have Docker installed, you can skip the manual installation of Node.js, Python, and PostgreSQL entirely. Running the application requires just a single command.
+
+### 1. Launching the App
+Simply run the following command in the project root:
+
+```bash
+docker compose up
+```
+
+This command will:
+* Spin up a PostgreSQL 16 database container with persistent storage.
+* Build the app container including Node.js 20 and a Python 3 virtual environment with all scikit-learn/pandas dependencies.
+* Wait for the database to be healthy, then run migrations (`npm run db:push`).
+* Automatically seed the database with sample clinical assessments (in development mode).
+* Launch the full-stack server with live-reloading (HMR) enabled.
+
+Once started, open your browser and navigate to:
+* **Web App & REST API:** [http://localhost:3000](http://localhost:3000)
+
+### 2. Stop the App
+To stop the services while preserving your data:
+```bash
+docker compose down
+```
+
+To stop the services and completely reset the database (deleting persistent volumes):
+```bash
+docker compose down -v
+```
+
+### 3. Rebuilding after Updates
+If you update `package.json` or `requirements.txt` dependencies, trigger a clean rebuild:
+```bash
+docker compose up --build
+```
+
+---
+
+## ⚙️ Manual Installation & Setup
 
 ### 1. 📥 Clone & Install
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: clinical-insight-db
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: clinical_insight_engine
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d clinical_insight_engine"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - app-network
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: clinical-insight-app
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: development
+      PORT: 3000
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/clinical_insight_engine
+      SESSION_SECRET: clinical-insight-engine-dev-secret
+    volumes:
+      # Mount the workspace directory to support hot-reloading in development
+      - .:/app
+      # Preserve container-internal node_modules and python virtual environment
+      - /app/node_modules
+      - /app/.venv
+    command: sh -c "npm run db:push && npm run dev"
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - app-network
+
+volumes:
+  db-data:
+    driver: local
+
+networks:
+  app-network:
+    driver: bridge


### PR DESCRIPTION
### Summary
This PR adds a complete Docker and Docker Compose environment to streamline local development. It eliminates the need to manually install and configure Node.js, Python 3, and PostgreSQL on the host machine.

### Key Additions
* **Dockerfile**: Combines Node.js 20 and Python 3 runtimes. Builds an isolated virtual environment at `.venv` to allow the Express child-process scripts (`analyze.py`) to resolve correctly.
* **docker-compose.yml**: Coordinates a PostgreSQL 16 database (`db`) and the Express/Vite server (`app`) services. Uses Postgres health checks to guarantee orderly service boot and automatically pushes database schemas on launch.
* **.dockerignore**: Excludes host dependency files to guarantee clean, platform-independent container builds.
* **README.md**: Prominently adds Docker-based instructions for starting, stopping, and resetting the development stack.

closes #243
