### PR TITLE
fix: add ErrorBoundary to prevent white screen on render crashes (Fixes #149)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,8 @@ import History from "./pages/History";
 import LoginPage from "./pages/LoginPage";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import Terms from "./pages/Terms";
+import { ErrorBoundary } from "./components/ErrorBoundary";
+
 function Router() {
   return (
     <Switch>
@@ -28,7 +30,9 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <Toaster />
-        <Router />
+        <ErrorBoundary>
+          <Router />
+        </ErrorBoundary>
       </TooltipProvider>
     </QueryClientProvider>
   );

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,0 +1,65 @@
+import React, { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error("[ErrorBoundary] Uncaught render error:", error);
+    console.error("[ErrorBoundary] Component stack:", errorInfo.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <div className="flex min-h-screen items-center justify-center bg-background p-8">
+          <div className="max-w-md text-center">
+            <div className="mb-6 text-6xl">⚠️</div>
+            <h1 className="mb-2 text-2xl font-bold text-foreground">
+              Something went wrong
+            </h1>
+            <p className="mb-6 text-muted-foreground">
+              An unexpected error occurred. Please try refreshing the page.
+            </p>
+            <pre className="mb-6 max-h-32 overflow-auto rounded-md bg-muted p-4 text-left text-sm text-muted-foreground">
+              {this.state.error?.message}
+            </pre>
+            <button
+              onClick={() => {
+                this.setState({ hasError: false, error: null });
+                window.location.reload();
+              }}
+              className="rounded-md bg-primary px-6 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Refresh Page
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Description

Any unhandled render error (null dereference, failed API parsing, unexpected data shape) crashed the entire UI to a white screen with no feedback.

Added an `ErrorBoundary` class component wrapping `<Router />` so render errors are caught gracefully, a fallback UI is shown, and the error is logged.

## Related Issue

Closes #149

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **New**: `client/src/components/ErrorBoundary.tsx`
  - Class component using `getDerivedStateFromError` + `componentDidCatch`
  - Catches render errors anywhere in the component tree below it
  - Shows centered fallback UI with: warning icon, error message in a scrollable `<pre>`, and a "Refresh Page" button
  - Logs the error and component stack to console
  - Accepts optional `fallback` prop for custom error UI
- **Edit**: `client/src/App.tsx` — imported `ErrorBoundary`, wrapped `<Router />` inside it

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (11/11)
- [x] No new TypeScript errors

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code