### PR TITLE
fix: auto-backfill labels for merged PRs missing issue labels

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,14 +1,16 @@
 name: Sync Labels from Issue to PR
 
 # Automatically copies labels from linked issues to the PR.
-# Also supports manual backfill for already-closed PRs.
+# Also supports manual backfill for already-closed/merged PRs.
+# When triggered via workflow_dispatch without a pr_number,
+# auto-discovers recently merged PRs that are missing issue labels.
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize, closed]
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "PR number to backfill labels for"
+        description: "PR number to backfill labels for (leave empty to auto-backfill all recently merged PRs)"
         required: false
         type: number
 
@@ -23,100 +25,168 @@ jobs:
     name: Copy labels from linked issues to PR
     runs-on: ubuntu-latest
     steps:
-      - name: Apply issue labels to PR
+      - name: Apply issue labels to PR(s)
         uses: actions/github-script@v9
         env:
-          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number || '' }}
         with:
           script: |
-            const prNumber = parseInt(process.env.PR_NUMBER);
-            if (!prNumber) {
-              core.info('No PR number available — nothing to do.');
-              return;
-            }
-
             const { owner, repo } = context.repo;
+            const explicitPr = process.env.PR_NUMBER;
 
-            // Fetch the PR body to find linked issues.
-            let body;
-            try {
-              const { data: pr } = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: prNumber,
-              });
-              body = pr.body || '';
-            } catch (err) {
-              core.warning(`Could not fetch PR #${prNumber}: ${err.message}`);
-              return;
-            }
+            /**
+             * For a given PR number, find linked issues via
+             * "Fixes/Closes/Resolves #NNN" in the PR body,
+             * collect all labels from those issues, and add
+             * any that the PR is missing.
+             */
+            async function processPr(prNumber) {
+              core.info(`Processing PR #${prNumber}...`);
 
-            // Collect issue numbers from
-            // "Fixes/Closes/Resolves #NNN" (case-insensitive).
-            const pattern = /(?:fixes|closes|resolves)\s+#(\d+)/gi;
-            const issueNumbers = [];
-            let match;
-            while ((match = pattern.exec(body)) !== null) {
-              issueNumbers.push(parseInt(match[1], 10));
-            }
-
-            if (issueNumbers.length === 0) {
-              core.info('No linked issues found in PR body — nothing to do.');
-              return;
-            }
-
-            core.info(`Linked issues: ${issueNumbers.join(', ')}`);
-
-            // Fetch labels from every referenced issue;
-            // ignore missing/invalid ones.
-            const labelSet = new Set();
-            for (const issueNumber of issueNumbers) {
+              let body;
               try {
-                const { data: issue } = await github.rest.issues.get({
-                  owner,
-                  repo,
-                  issue_number: issueNumber,
+                const { data: pr } = await github.rest.pulls.get({
+                  owner, repo, pull_number: prNumber,
                 });
-                for (const label of issue.labels) {
-                  labelSet.add(typeof label === 'string' ? label : label.name);
-                }
+                body = pr.body || '';
               } catch (err) {
-                // Non-existent or inaccessible issue — skip gracefully.
-                core.warning(
-                  `Could not fetch issue #${issueNumber}: ${err.message}`
+                core.warning(`Could not fetch PR #${prNumber}: ${err.message}`);
+                return;
+              }
+
+              // Collect issue numbers from "Fixes/Closes/Resolves #NNN"
+              const pattern = /(?:fixes|closes|resolves)\s+#(\d+)/gi;
+              const issueNumbers = [];
+              let match;
+              while ((match = pattern.exec(body)) !== null) {
+                issueNumbers.push(parseInt(match[1], 10));
+              }
+
+              if (issueNumbers.length === 0) {
+                core.info(`PR #${prNumber} has no linked issues — skipping.`);
+                return;
+              }
+
+              core.info(`PR #${prNumber} linked issues: ${issueNumbers.join(', ')}`);
+
+              // Collect labels from all referenced issues
+              const labelSet = new Set();
+              for (const issueNumber of issueNumbers) {
+                try {
+                  const { data: issue } = await github.rest.issues.get({
+                    owner, repo, issue_number: issueNumber,
+                  });
+                  for (const label of issue.labels) {
+                    labelSet.add(typeof label === 'string' ? label : label.name);
+                  }
+                } catch (err) {
+                  core.warning(
+                    `Could not fetch issue #${issueNumber}: ${err.message}`
+                  );
+                }
+              }
+
+              if (labelSet.size === 0) {
+                core.info(
+                  `Linked issues for PR #${prNumber} carry no labels — skipping.`
                 );
+                return;
+              }
+
+              // Determine which labels the PR does not already have
+              const { data: prData } = await github.rest.pulls.get({
+                owner, repo, pull_number: prNumber,
+              });
+              const existingLabels = new Set(
+                prData.labels.map((l) => (typeof l === 'string' ? l : l.name))
+              );
+              const toAdd = [...labelSet].filter((l) => !existingLabels.has(l));
+
+              if (toAdd.length === 0) {
+                core.info(`PR #${prNumber} already has all issue labels — nothing to add.`);
+                return;
+              }
+
+              core.info(`Adding labels to PR #${prNumber}: ${toAdd.join(', ')}`);
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: prNumber, labels: toAdd,
+              });
+            }
+
+            // ─── Mode 1: explicit PR number (manual backfill) ──────────────
+            if (explicitPr) {
+              const prNumber = parseInt(explicitPr, 10);
+              if (!isNaN(prNumber)) {
+                await processPr(prNumber);
+                return;
               }
             }
 
-            if (labelSet.size === 0) {
-              core.info(
-                'Referenced issues carry no labels — nothing to apply.'
-              );
-              return;
+            // ─── Mode 2: pull_request_target event ─────────────────────────
+            if (context.payload.pull_request) {
+              const prNumber = context.payload.pull_request.number;
+              if (prNumber) {
+                await processPr(prNumber);
+                return;
+              }
             }
 
-            // Determine which labels the PR does not already have.
-            const { data: prData } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: prNumber,
-            });
-            const existingLabels = new Set(
-              prData.labels.map((l) => (typeof l === 'string' ? l : l.name))
-            );
-            const toAdd = [...labelSet].filter((l) => !existingLabels.has(l));
+            // ─── Mode 3: auto-backfill (no PR number given) ────────────────
+            // Discover merged PRs from the last 90 days that reference issues
+            // via Fixes/Closes/Resolves but are missing issue labels.
+            core.info('No specific PR number — auto-discovering merged PRs needing backfill...');
 
-            if (toAdd.length === 0) {
-              core.info('PR already has all issue labels — nothing to add.');
-              return;
+            const backfillPattern = /(?:fixes|closes|resolves)\s+#(\d+)/gi;
+            const ninetyDaysAgo = new Date();
+            ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+
+            let processed = 0;
+            let page = 1;
+            let hasMore = true;
+
+            while (hasMore) {
+              const { data: prs } = await github.rest.pulls.list({
+                owner, repo,
+                state: 'closed',
+                sort: 'updated',
+                direction: 'desc',
+                per_page: 100,
+                page,
+              });
+
+              if (prs.length === 0) {
+                hasMore = false;
+                break;
+              }
+
+              for (const pr of prs) {
+                // Skip PRs not merged or outside the 90-day window
+                if (!pr.merged_at) continue;
+                if (new Date(pr.merged_at) < ninetyDaysAgo) {
+                  hasMore = false; // further pages are even older
+                  break;
+                }
+
+                // Skip PRs that already have labels
+                if (pr.labels && pr.labels.length > 0) continue;
+
+                // Check if PR body references an issue
+                const body = pr.body || '';
+                backfillPattern.lastIndex = 0;
+                const hasRef = backfillPattern.test(body);
+                if (!hasRef) continue;
+
+                core.info(`Found unlabeled merged PR #${pr.number} with issue reference — backfilling...`);
+                await processPr(pr.number);
+                processed++;
+              }
+
+              if (!hasMore) break;
+              page++;
             }
 
-            core.info(
-              `Adding labels to PR #${prNumber}: ${toAdd.join(', ')}`
-            );
-            await github.rest.issues.addLabels({
-              owner,
-              repo,
-              issue_number: prNumber,
-              labels: toAdd,
-            });
+            if (processed === 0) {
+              core.info('No unlabeled merged PRs with issue references found in the last 90 days.');
+            } else {
+              core.info(`Backfill complete. Processed ${processed} PR(s).`);
+            }


### PR DESCRIPTION
## Description

The sync-labels workflow already copies issue labels to PRs on `pull_request_target` events, but **merged PRs that were created before the workflow existed** (or where the event was missed) never get labels. PRs #69, #92, and many others have `Fixes #NNN` in their body but zero labels.

This update adds **Mode 3 — auto-backfill**: when `workflow_dispatch` is triggered **without** a specific `pr_number`, it auto-discovers all merged PRs from the last 90 days that:
1. Have `Fixes/Closes/Resolves #NNN` in the body
2. Currently have **no labels**
...and backfills them from the linked issues.

## Related Issue

Improves the auto-label workflow (originally #168)

## Type of Change

- [x] 🔧 Chore / Tooling / Config

## Changes Made

- Extracted per-PR logic into `processPr()` helper function
- **Mode 1** (explicit `pr_number` via `workflow_dispatch`): unchanged
- **Mode 2** (`pull_request_target` event): unchanged
- **Mode 3** (new — `workflow_dispatch` without `pr_number`): iterates merged PRs (last 90 days, 100 per page), skips those already having labels, and backfills those referencing issues

## Testing

- [x] I have tested these changes locally (YAML validated)
- [x] Run the workflow on the upstream repo via `workflow_dispatch` (no `pr_number`) to backfill #69, #92, etc.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code