### PR TITLE
fix: remove unused handleDbError dead code from server/db_fix.ts

### DIFF
--- a/server/db_fix.ts
+++ b/server/db_fix.ts
@@ -1,6 +1,0 @@
-// Ensures process exits cleanly on db error
-import process from 'process';
-export function handleDbError(err: Error) {
-  console.error('DB Error:', err);
-  process.exit(1);
-}


### PR DESCRIPTION
Fixes #305

## Describe the bug
`server/db_fix.ts` exported `handleDbError` but it was never imported or used anywhere in the codebase. Searching for `handleDbError` or `db_fix` returned only its definition — no import or usage existed in `server/index.ts`, `server/routes.ts`, `server/db.ts`, or anywhere else.

The project already has proper database error handling via the `DatabaseStartupError` class in `server/db.ts`, making `db_fix.ts` entirely redundant.

## Fix
Deleted `server/db_fix.ts` — dead code removal, no functional change.

## Type of change
- [x] Bug fix

## Related issue
Fixes #305

## Screenshot
N/A — dead code removal, no runtime behavior change

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.