### PR TITLE
fix: correct migration SQL types and add missing columns

### DIFF
--- a/migrations/0000_marvelous_talisman.sql
+++ b/migrations/0000_marvelous_talisman.sql
@@ -5,15 +5,17 @@ CREATE TABLE "assessments" (
 	"hypertension" boolean NOT NULL,
 	"heart_disease" boolean NOT NULL,
 	"smoking_history" text NOT NULL,
-	"bmi" text NOT NULL,
-	"hba1c_level" text NOT NULL,
-	"blood_glucose_level" text NOT NULL,
-	"risk_score" text NOT NULL,
+	"bmi" double precision NOT NULL,
+	"hba1c_level" double precision NOT NULL,
+	"blood_glucose_level" double precision NOT NULL,
+	"risk_score" double precision NOT NULL,
 	"risk_category" text NOT NULL,
 	"factors" jsonb NOT NULL,
 	"confidence_interval" jsonb,
-	"model_confidence" text,
-	"created_at" timestamp DEFAULT now()
+	"model_confidence" double precision,
+	"created_at" timestamp DEFAULT now(),
+	"created_by" text,
+	"user_id" text
 );
 --> statement-breakpoint
 CREATE TABLE "login_audit_logs" (

--- a/migrations/meta/0000_snapshot.json
+++ b/migrations/meta/0000_snapshot.json
@@ -46,25 +46,25 @@
         },
         "bmi": {
           "name": "bmi",
-          "type": "text",
+          "type": "double precision",
           "primaryKey": false,
           "notNull": true
         },
         "hba1c_level": {
           "name": "hba1c_level",
-          "type": "text",
+          "type": "double precision",
           "primaryKey": false,
           "notNull": true
         },
         "blood_glucose_level": {
           "name": "blood_glucose_level",
-          "type": "text",
+          "type": "double precision",
           "primaryKey": false,
           "notNull": true
         },
         "risk_score": {
           "name": "risk_score",
-          "type": "text",
+          "type": "double precision",
           "primaryKey": false,
           "notNull": true
         },
@@ -88,7 +88,7 @@
         },
         "model_confidence": {
           "name": "model_confidence",
-          "type": "text",
+          "type": "double precision",
           "primaryKey": false,
           "notNull": false
         },
@@ -98,6 +98,18 @@
           "primaryKey": false,
           "notNull": false,
           "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {},


### PR DESCRIPTION
## Summary

The initial Drizzle migration \`0000_marvelous_talisman.sql\` used \`text\` as the column type for several numeric fields (\`bmi\`, \`hba1c_level\`, \`blood_glucose_level\`, \`risk_score\`, \`model_confidence\`) instead of \`double precision\`. It also omitted the \`created_by\` and \`user_id\` columns that are present in the \`shared/schema.ts\` table definition.

Fixes #329 

## Impact

- \`npm run db:push\` and \`npm run db:generate\` produce incorrect SQL from the snapshot
- Numeric columns stored as \`text\` cause sorting/filtering issues (e.g., ordering by risk_score does a lexicographic sort: \"9\" > \"100\")
- Assessments cannot be attributed to a user without \`created_by\` / \`user_id\`

## Changes

### \`migrations/0000_marvelous_talisman.sql\`

| Column | Before | After |
|---|---|---|
| \`bmi\` | \`text NOT NULL\` | \`double precision NOT NULL\` |
| \`hba1c_level\` | \`text NOT NULL\` | \`double precision NOT NULL\` |
| \`blood_glucose_level\` | \`text NOT NULL\` | \`double precision NOT NULL\` |
| \`risk_score\` | \`text NOT NULL\` | \`double precision NOT NULL\` |
| \`model_confidence\` | \`text\` | \`double precision\` |
| \`created_by\` | *(missing)* | \`text\` |
| \`user_id\` | *(missing)* | \`text\` |

### \`migrations/meta/0000_snapshot.json\`

Updated the \`tables.public.assessments.columns\` entries to reflect the same type changes and add the two new column definitions. This keeps the snapshot in sync with the SQL migration and the TypeScript schema.

## Upgrade Path

For an existing database with the wrong types:

1. Take a backup
2. Run manual ALTER TABLE statements to cast columns:
   ```sql
   ALTER TABLE assessments ALTER COLUMN bmi TYPE double precision USING bmi::double precision;
   ALTER TABLE assessments ALTER COLUMN hba1c_level TYPE double precision USING hba1c_level::double precision;
   ALTER TABLE assessments ALTER COLUMN blood_glucose_level TYPE double precision USING blood_glucose_level::double precision;
   ALTER TABLE assessments ALTER COLUMN risk_score TYPE double precision USING risk_score::double precision;
   ALTER TABLE assessments ALTER COLUMN model_confidence TYPE double precision USING model_confidence::double precision;
   ALTER TABLE assessments ADD COLUMN created_by text;
   ALTER TABLE assessments ADD COLUMN user_id text;
   ```

For a fresh database, the corrected migration runs cleanly from scratch.


