### PR TITLE
ci: add TypeScript type-check workflow (Fixes #333)

### DIFF
--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -1,0 +1,30 @@
+name: TypeScript Type Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  type-check:
+    name: Type check (tsc)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run type check
+        run: npm run check


### PR DESCRIPTION
## Description

Adds a GitHub Actions workflow that runs `npm run check` (tsc) on every push to main and every pull request targeting main, preventing TypeScript errors from slipping through.

## Related Issue

Closes #333

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [x] 🔧 Chore / Tooling / Config

## Changes Made

- Created `.github/workflows/type-check.yml` with a `type-check` job that:
  - Checks out the repository
  - Sets up Node.js v20 (from `.nvmrc`) with npm caching
  - Runs `npm ci` for clean, reproducible installs
  - Executes `npm run check` (tsc) to catch type errors

## Screenshots (if applicable)

N/A

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors