### PR TITLE
fix: auto-fill OTP and show dev notice when devOtp returned in response

### DIFF
--- a/client/src/components/AuthFlowModal.tsx
+++ b/client/src/components/AuthFlowModal.tsx
@@ -330,8 +330,8 @@ function RegisterForm({ onSubmit, onSwitch }: { onSubmit: (event: FormEvent<HTML
   );
 }
 
-function OtpForm({ onVerify, email }: { onVerify: () => void; email: string }) {
-  const [otp, setOtp] = useState(["", "", "", "", "", ""]);
+function OtpForm({ onVerify, email, devOtp }: { onVerify: () => void; email: string; devOtp?: string }) {
+  const [otp, setOtp] = useState(devOtp ? devOtp.split("").slice(0, 6) : ["", "", "", "", "", ""]);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const inputRefs = useRef<Array<HTMLInputElement | null>>([]);
@@ -399,6 +399,11 @@ function OtpForm({ onVerify, email }: { onVerify: () => void; email: string }) {
       <p className="mx-auto mt-3 max-w-md text-sm leading-6 text-slate-500">
         We&apos;ve sent a secure verification code to your email.
       </p>
+      {devOtp && (
+        <div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm font-semibold text-amber-700">
+          🔧 Dev mode: OTP auto-filled — <span className="font-mono">{devOtp}</span>
+        </div>
+      )}
       {error && (
         <div className="mt-4 rounded-xl border border-red-200 bg-red-50 p-3 text-sm font-semibold text-red-700">
           {error}
@@ -458,6 +463,7 @@ export function AuthFlowModal({ initialMode, isOpen, onClose }: AuthFlowModalPro
   const [loginEmail, setLoginEmail] = useState("");
   const [loginPassword, setLoginPassword] = useState("");
   const [pendingEmail, setPendingEmail] = useState("");
+  const [devOtp, setDevOtp] = useState<string | undefined>(undefined);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -520,7 +526,9 @@ export function AuthFlowModal({ initialMode, isOpen, onClose }: AuthFlowModalPro
         }
       }
 
+      const responseData = await (response as Response).json?.();
       setPendingEmail(email);
+      if (responseData?.devOtp) setDevOtp(responseData.devOtp);
       setStep("otp");
     } catch (err: any) {
       setError(err.message || "Authentication failed. Please try again.");
@@ -590,7 +598,7 @@ export function AuthFlowModal({ initialMode, isOpen, onClose }: AuthFlowModalPro
               </motion.div>
             ) : (
               <motion.div key="otp" initial={{ opacity: 0, x: 12 }} animate={{ opacity: 1, x: 0 }} transition={{ duration: 0.2 }}>
-                <OtpForm onVerify={handleVerify} email={pendingEmail} />
+                <OtpForm onVerify={handleVerify} email={pendingEmail} devOtp={devOtp} />
                 <button
                   type="button"
                   onClick={() => setStep("form")}


### PR DESCRIPTION
Fixes #245

## Describe the bug
`AuthFlowModal.tsx` never read `devOtp` from the login/register response. In development mode, the server returns `devOtp` in the response body so developers can test without a real email service — but the frontend ignored it entirely. Developers had to manually check the server terminal logs for the `[DEV] OTP for ...:` line to find the code.

## Fix
- Added `devOtp` prop to `OtpForm` — auto-fills the 6 OTP input fields when present
- Added `devOtp` state to the parent modal — read from the login/register response
- Show an amber dev notice banner displaying the OTP code when `devOtp` is present

## Type of change
- [x] Bug fix

## Related issue
Fixes #245

## Screenshot
When in dev mode, the OTP step now shows:
**🔧 Dev mode: OTP auto-filled — 123456**

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.