### PR TITLE
fix: update LoginPage password minimum length from 6 to 8 characters

### DIFF
--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -19,8 +19,8 @@ export default function LoginPage() {
     }
     if (!password) {
       newErrors.password = "Password is required";
-    } else if (password.length < 6) {
-      newErrors.password = "Password must be at least 6 characters";
+    } else if (password.length < 8) {
+      newErrors.password = "Password must be at least 8 characters";
     }
     return newErrors;
   };


### PR DESCRIPTION
Fixes #246

## Describe the bug
`LoginPage.tsx` validated passwords with a minimum length of 6 characters, but `server/auth.ts` rejects passwords shorter than 8 characters. A user entering a 6 or 7 character password passed client-side validation, the form submitted, and the server returned a 400 error — with no clear feedback to the user about why it failed.

## Fix
Changed `password.length < 6` to `password.length < 8` and updated the error message to "Password must be at least 8 characters" — aligning client-side validation with the server requirement in `server/auth.ts`.

## Type of change
- [x] Bug fix

## Related issue
Fixes #246

## Screenshot
N/A — validation message change, no visual UI change

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.