### PR TITLE
fix: throw clear startup error when OAuth2 env vars are missing or incomplete

### DIFF
--- a/server/auth/oauth2.ts
+++ b/server/auth/oauth2.ts
@@ -1,0 +1,48 @@
+import passport from "passport";
+import { Strategy as OAuth2Strategy } from "passport-oauth2";
+
+const OAUTH2_AUTH_URL = process.env.OAUTH2_AUTH_URL;
+const OAUTH2_TOKEN_URL = process.env.OAUTH2_TOKEN_URL;
+const OAUTH2_CLIENT_ID = process.env.OAUTH2_CLIENT_ID;
+const OAUTH2_CLIENT_SECRET = process.env.OAUTH2_CLIENT_SECRET;
+const OAUTH2_CALLBACK_URL = process.env.OAUTH2_CALLBACK_URL;
+
+if (
+  OAUTH2_AUTH_URL &&
+  OAUTH2_TOKEN_URL &&
+  OAUTH2_CLIENT_ID &&
+  OAUTH2_CLIENT_SECRET &&
+  OAUTH2_CALLBACK_URL
+) {
+  passport.use(
+    new OAuth2Strategy(
+      {
+        authorizationURL: OAUTH2_AUTH_URL,
+        tokenURL: OAUTH2_TOKEN_URL,
+        clientID: OAUTH2_CLIENT_ID,
+        clientSecret: OAUTH2_CLIENT_SECRET,
+        callbackURL: OAUTH2_CALLBACK_URL,
+      },
+      (accessToken: string, refreshToken: string, profile: any, cb: any) => {
+        return cb(null, { id: "clinician-id", profile });
+      }
+    )
+  );
+} else if (
+  OAUTH2_AUTH_URL ||
+  OAUTH2_TOKEN_URL ||
+  OAUTH2_CLIENT_ID ||
+  OAUTH2_CLIENT_SECRET ||
+  OAUTH2_CALLBACK_URL
+) {
+  const missing = [
+    !OAUTH2_AUTH_URL && "OAUTH2_AUTH_URL",
+    !OAUTH2_TOKEN_URL && "OAUTH2_TOKEN_URL",
+    !OAUTH2_CLIENT_ID && "OAUTH2_CLIENT_ID",
+    !OAUTH2_CLIENT_SECRET && "OAUTH2_CLIENT_SECRET",
+    !OAUTH2_CALLBACK_URL && "OAUTH2_CALLBACK_URL",
+  ].filter(Boolean);
+  throw new Error(
+    `Incomplete OAuth2 configuration. Missing environment variables: ${missing.join(", ")}`
+  );
+}


### PR DESCRIPTION
Fixes #247

## Describe the bug
All OAuth2 configuration values in `server/auth/oauth2.ts` fell back to hardcoded dummy strings when environment variables were not set. The server started without complaint but OAuth2 login silently failed or attempted to connect to `https://provider.com` with invalid credentials — masking misconfiguration entirely.

## Fix
Three cases are now handled:
- **All 5 env vars present** → initialize OAuth2 strategy as before
- **Some but not all env vars set** → throw a clear startup error listing exactly which variables are missing
- **None set** → skip OAuth2 setup silently (OAuth2 simply not configured for this deployment)

## Type of change
- [x] Bug fix

## Related issue
Fixes #247

## Screenshot
N/A — backend configuration fix, no UI change

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.