### PR TITLE
fix: add periodic cleanup interval to rateLimiter to prevent memory leak

### DIFF
--- a/server/middleware/rateLimiter.ts
+++ b/server/middleware/rateLimiter.ts
@@ -4,21 +4,34 @@ const requestStore = new Map<string, { count: number; resetTime: number }>();
 const WINDOW_MS = 60 * 1000;
 const MAX_REQUESTS = 60;
 
+// Periodic cleanup to prevent memory leak from unique IPs that never return.
+// Runs every minute to remove entries whose rate limit window has expired.
+const cleanupTimer = setInterval(() => {
+  const now = Date.now();
+  for (const [ip, record] of requestStore.entries()) {
+    if (now > record.resetTime) {
+      requestStore.delete(ip);
+    }
+  }
+}, WINDOW_MS);
+
+// Allow Node process to exit cleanly without waiting for the interval
+if (cleanupTimer.unref) {
+  cleanupTimer.unref();
+}
+
 export const publicApiRateLimiter = (req: Request, res: Response, next: NextFunction) => {
   const ip = req.ip || req.headers["x-forwarded-for"] || "unknown";
   const now = Date.now();
   const record = requestStore.get(ip as string);
-
   if (!record || now > record.resetTime) {
     requestStore.set(ip as string, { count: 1, resetTime: now + WINDOW_MS });
     return next();
   }
-
   if (record.count >= MAX_REQUESTS) {
     console.warn(`[RATE LIMIT EXCEEDED] DDoS protection triggered for IP: ${ip}`);
     return res.status(429).json({ error: "Too many requests. Public API limit exceeded." });
   }
-
   record.count += 1;
   next();
 };


### PR DESCRIPTION
Fixes #248
Fixes #249

## Describe the bug
`requestStore` in `server/middleware/rateLimiter.ts` grew unboundedly. Expired entries were only replaced when the same IP made a new request after the window expired. IPs that made requests and never returned would stay in the map forever, causing a memory leak under sustained traffic from many unique IPs.

## Fix
Added a `setInterval` that runs every 60 seconds to sweep and delete all entries where `now > record.resetTime`. Called `unref()` on the timer so it does not prevent the Node.js process from exiting cleanly.

## Type of change
- [x] Bug fix

## Related issues
Fixes #248
Fixes #249

## Screenshot
N/A — backend memory leak fix, no UI change

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.