### PR TITLE
fix: wire loggingAnomalyMiddleware into server/index.ts

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -8,6 +8,7 @@ import { registerRoutes } from "./routes";
 import { createAuthRouter } from "./auth";
 import { serveStatic } from "./static";
 import { createServer } from "http";
+import { loggingAnomalyMiddleware } from "./middleware/loggingAnomaly";
 
 const app = express();
 const httpServer = createServer(app);
@@ -68,6 +69,7 @@ app.use(
 );
 
 app.use(express.urlencoded({ extended: false }));
+app.use(loggingAnomalyMiddleware);
 
 // Nonce middleware - generates a unique cryptographic nonce per request for CSP
 app.use((_req, res, next) => {


### PR DESCRIPTION
Fixes #250

## Describe the bug
`loggingAnomalyMiddleware` in `server/middleware/loggingAnomaly.ts` was exported but never imported or applied anywhere in the codebase. No request logging or anomaly detection was actually happening despite the middleware being fully implemented.

## Fix
- Import `loggingAnomalyMiddleware` in `server/index.ts`
- Apply it as a global middleware after `express.urlencoded`
- All requests are now logged with method, path, status, duration, and IP
- Slow requests (>500ms) and 5xx errors trigger anomaly warnings

## Type of change
- [x] Bug fix

## Related issue
Fixes #250

## Screenshot
N/A — backend middleware fix, no UI change

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.