### PR TITLE
fix: add client-side validation to RegisterForm in AuthFlowModal

### DIFF
--- a/client/src/components/AuthFlowModal.tsx
+++ b/client/src/components/AuthFlowModal.tsx
@@ -489,6 +489,23 @@ export function AuthFlowModal({ initialMode, isOpen, onClose }: AuthFlowModalPro
     const email = String(formData.get("email") ?? "");
     const password = String(formData.get("password") ?? "");
 
+
+    // Client-side validation
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!email || !emailRegex.test(email)) {
+      setError("Please enter a valid email address.");
+      return;
+    }
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters.");
+      return;
+    }
+    if (mode === "register") {
+      const fullNameVal = String(formData.get("fullName") ?? "");
+      const licenseNumberVal = String(formData.get("licenseNumber") ?? "");
+      if (!fullNameVal.trim()) { setError("Full name is required."); return; }
+      if (!licenseNumberVal.trim()) { setError("Medical license number is required."); return; }
+    }
     setIsLoading(true);
 
     try {


### PR DESCRIPTION
Fixes #251

## Describe the bug
`RegisterForm` in `AuthFlowModal.tsx` had no client-side validation — only HTML `required` attributes. Users with invalid emails or weak passwords got no immediate feedback. The form submitted, waited for the server, and only then surfaced an error — creating a poor UX for a clinical tool.

## Fix
Added client-side validation in `handleSubmit` before the fetch call:
- Email format check using regex — consistent with `server/auth.ts`
- Password minimum 8 characters — consistent with `server/auth.ts`
- `fullName` required check for register mode
- `licenseNumber` required check for register mode

Errors are surfaced immediately via `setError()` without a server round-trip.

## Type of change
- [x] Bug fix

## Related issue
Fixes #251

## Screenshot
N/A — validation UX improvement, no visual layout change

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.