### PR TITLE
fix: merge duplicate JSON objects in .eslintrc.json into valid config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,38 +1,14 @@
 {
-  "env": {
-    "browser": true,
-    "es2021": true,
-    "node": true
-  },
-  "extends": [
-    "eslint:recommended",
-    "plugin:react/recommended"
-  ],
-  "parserOptions": {
-    "ecmaFeatures": {
-      "jsx": true
-    },
-    "ecmaVersion": "latest",
-    "sourceType": "module"
-  },
-  "plugins": [
-    "react"
-  ],
-  "rules": {
-    "react/react-in-jsx-scope": "off",
-    "no-unused-vars": "warn",
-    "no-console": "off"
-  },
-  "settings": {
-    "react": {
-      "version": "detect"
-    }
   "root": true,
   "env": {
     "browser": true,
     "node": true,
     "es2022": true
   },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended"
+  ],
   "parserOptions": {
     "ecmaVersion": "latest",
     "sourceType": "module",
@@ -40,9 +16,14 @@
       "jsx": true
     }
   },
-  "extends": [
-    "eslint:recommended"
+  "plugins": [
+    "react"
   ],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
   "ignorePatterns": [
     "dist/",
     "build/",
@@ -52,6 +33,7 @@
     "*.config.ts"
   ],
   "rules": {
+    "react/react-in-jsx-scope": "off",
     "no-unused-vars": "warn",
     "no-console": "off",
     "eqeqeq": [


### PR DESCRIPTION
## Summary

Fix the malformed `.eslintrc.json` file which contained two separate JSON configuration objects merged together without proper structure, making ESLint completely non-functional.
 
## Changes

- Merged the two duplicate JSON root objects into a single valid configuration
- Preserved all meaningful settings from both blocks: React plugin, `root: true`, `ignorePatterns`, `eqeqeq` rule
- Upgraded `env.es2021` to `env.es2022` (from the second block)
- Kept the `settings.react.version: "detect"` configuration with proper closing brace

## Problem

The `.eslintrc.json` file had duplicate top-level keys (`env`, `parserOptions`, `extends`, `rules`) and was missing a closing brace for the `settings` object before the second configuration block began. This is invalid JSON — ESLint fails to parse it entirely, meaning no linting runs in the project.

## Solution

Consolidated both configuration blocks into one valid JSON object that retains all rules and settings from both.

## Testing

- [x] Validated output is valid JSON via `node -e "JSON.parse(...)"`
- [x] No merge conflicts with main

## Related Issue

Fixes #386