### PR TITLE
fix: remove duplicate conflicting properties from AssessmentCreateInput type

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -18,13 +18,7 @@ export type AssessmentCreateInput = InsertAssessment & {
   factors: AssessmentFactor[];
   confidenceInterval?: string;
   modelConfidence?: number;
-  createdBy?: string;
   createdBy: string;
-  riskScore: string;
-  riskCategory: string;
-  factors: AssessmentFactor[];
-  confidenceInterval?: string;
-  modelConfidence?: string;
 };
 
 export class DatabaseStorage implements IStorage {


### PR DESCRIPTION
 ## Summary

Remove duplicate and conflicting property declarations from the `AssessmentCreateInput` type in `server/storage.ts` that caused TypeScript type unsoundness.

## Changes

- Removed duplicate `createdBy` declaration (was declared as both optional and required)
- Removed duplicate `riskScore` declaration (was declared as both `number` and `string`)
- Removed duplicate `riskCategory`, `factors`, `confidenceInterval` declarations
- Removed duplicate `modelConfidence` declaration (was declared as both `number` and `string`)

## Problem

The `AssessmentCreateInput` type had the same properties declared multiple times with conflicting types. In TypeScript, intersection types with conflicting property types resolve to `never`, making the type unusable in a type-safe way. The code only worked because `createAssessment` casts the input to `any`.

## Solution

Consolidated the type to have each property declared exactly once with the correct type that matches how `server/routes.ts` constructs the assessment object before insertion.

## Testing

- [x] Verified the file is syntactically correct
- [x] No merge conflicts with main
- [x] The `as any` cast is retained for now as removing it requires a broader refactor of how `InsertAssessment` intersects with runtime-computed fields

## Related Issue

Fixes #387