### PR TITLE
fix: remove unsafe-inline from CSP scriptSrc so nonce is enforced

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -76,17 +76,22 @@ app.use((_req, res, next) => {
 });
 
 // Security headers via helmet
+const scriptSrcDirective: Array<string | ((req: any, res: any) => string)> = [
+  "'self'",
+  (_req: any, res: any) => `'nonce-${res.locals.cspNonce}'`
+];
+
+// Vite HMR requires eval in development mode
+if (process.env.NODE_ENV !== "production") {
+  scriptSrcDirective.push("'unsafe-eval'");
+}
+
 app.use(
   helmet({
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],
-        scriptSrc: [
-          "'self'",
-          "'unsafe-eval'",
-          "'unsafe-inline'",
-          (_req: any, res: any) => `'nonce-${res.locals.cspNonce}',`
-        ],
+        scriptSrc: scriptSrcDirective,
         styleSrc: [
           "'self'",
           "'unsafe-inline'",


### PR DESCRIPTION
## Summary

Fix the Content Security Policy configuration so the per-request cryptographic nonce actually provides XSS protection. Previously, `'unsafe-inline'` and `'unsafe-eval'` in `scriptSrc` caused browsers to ignore the nonce entirely (per CSP spec). Also fixes a trailing comma bug in the nonce token string.
 
## Changes

- Removed `'unsafe-inline'` from `scriptSrc` — this was defeating the nonce mechanism
- Removed `'unsafe-eval'` from production CSP
- Added `'unsafe-eval'` conditionally in development only (required for Vite HMR)
- Fixed trailing comma inside the nonce token string (`'nonce-abc123'` instead of `'nonce-abc123',`)
- Extracted `scriptSrcDirective` into a variable for clarity

## Problem

The CSP header included both `'unsafe-inline'` and a nonce in `scriptSrc`. Per the CSP Level 2+ specification, when `'unsafe-inline'` is present, browsers ignore nonce and hash sources entirely. The nonce generation middleware and injection in `vite.ts`/`static.ts` were providing zero security benefit.

Additionally, the nonce string had a trailing comma (`'nonce-${nonce}',`) making it an invalid CSP token even if `'unsafe-inline'` were removed.

## Solution

- Production: strict nonce-only `scriptSrc` — only scripts with the correct nonce attribute execute
- Development: nonce + `'unsafe-eval'` (Vite HMR uses `new Function()` internally)
- Both `vite.ts` and `static.ts` already inject the nonce into `<script>` tags, so no additional changes needed there

## Testing

- [x] Verified the nonce injection in `server/vite.ts` and `server/static.ts` already handles script tag nonce attributes
- [x] No merge conflicts with main
- [x] Cannot run full server locally without PostgreSQL — noted per contribution guidelines

## Related Issue

Fixes #388