### PR TITLE
feat: add client-side route guards for authenticated pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { ProtectedRoute } from "@/components/ProtectedRoute";
 import NotFound from "@/pages/not-found";
 import Landing from "./pages/Landing";
 import Dashboard from "./pages/Dashboard";
@@ -14,8 +15,16 @@ function Router() {
   return (
     <Switch>
       <Route path="/" component={Landing} />
-      <Route path="/dashboard" component={Dashboard} />
-      <Route path="/history" component={History} />
+      <Route path="/dashboard">
+        <ProtectedRoute>
+          <Dashboard />
+        </ProtectedRoute>
+      </Route>
+      <Route path="/history">
+        <ProtectedRoute>
+          <History />
+        </ProtectedRoute>
+      </Route>
       <Route path="/login" component={LoginPage} />
       <Route path="/privacy-policy" component={PrivacyPolicy} />
       <Route path="/terms" component={Terms} />

--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -1,0 +1,26 @@
+import { type ReactNode } from "react";
+import { Redirect } from "wouter";
+import { Loader2 } from "lucide-react";
+import { useAuth } from "@/hooks/use-auth";
+
+interface ProtectedRouteProps {
+  children: ReactNode;
+}
+
+export function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const { isLoading, isAuthenticated } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Redirect to="/login" />;
+  }
+
+  return <>{children}</>;
+}

--- a/client/src/hooks/use-auth.ts
+++ b/client/src/hooks/use-auth.ts
@@ -1,0 +1,36 @@
+import { useQuery } from "@tanstack/react-query";
+
+interface AuthUser {
+  email: string;
+  name: string;
+}
+
+interface AuthState {
+  user: AuthUser | null;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+}
+
+export function useAuth(): AuthState {
+  const { data, isLoading } = useQuery<{ user: AuthUser } | null>({
+    queryKey: ["/api/auth/me"],
+    queryFn: async () => {
+      const res = await fetch("/api/auth/me", { credentials: "include" });
+      if (res.status === 401) {
+        return null;
+      }
+      if (!res.ok) {
+        throw new Error("Failed to check authentication status");
+      }
+      return await res.json();
+    },
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+
+  return {
+    user: data?.user ?? null,
+    isLoading,
+    isAuthenticated: !!data?.user,
+  };
+}


### PR DESCRIPTION
## Summary

Add a `ProtectedRoute` component and `useAuth` hook to prevent unauthenticated users from accessing the Dashboard and History pages. Unauthenticated visitors are now redirected to `/login` instead of seeing a broken UI with 401 error states.
 
## Changes

- **New file:** `client/src/hooks/use-auth.ts` — queries `/api/auth/me` to determine authentication state
- **New file:** `client/src/components/ProtectedRoute.tsx` — wrapper that shows a loading spinner while checking auth, redirects to `/login` if unauthenticated, or renders children if authenticated
- **Modified:** `client/src/App.tsx` — wrapped `/dashboard` and `/history` routes with `ProtectedRoute`

## Problem

The `/dashboard` and `/history` routes rendered their full UI (form fields, tables, layout) without any authentication check. While the server API endpoints are protected by `requireAuth` middleware, the client pages would show a broken state with error messages when API calls returned 401. Users had no clear indication they needed to log in.

## Solution

Created a `useAuth` hook using React Query (consistent with the existing `use-assessments.ts` pattern) that checks session status via `/api/auth/me`. The `ProtectedRoute` component uses this hook to:
1. Show a centered loading spinner while auth state is being determined
2. Redirect to `/login` if the user is not authenticated
3. Render the protected page content if authenticated

The hook uses `staleTime: 5 * 60 * 1000` to avoid excessive auth checks and `retry: false` to prevent retrying on 401 responses.

## Testing

- [x] Verified the hook correctly returns `null` on 401 without throwing
- [x] Verified `ProtectedRoute` renders children when authenticated
- [x] Verified redirect to `/login` when unauthenticated
- [x] No merge conflicts with main
- [x] Follows existing patterns (React Query, wouter Redirect, Lucide icons)

## Related Issue

Fixes #390