### PR TITLE
[Bug] Fix 14 tsc errors on main — auth.ts, storage.ts, rateLimiter.ts (#344)

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -109,11 +109,6 @@ export function createAuthRouter(): Router {
       return res.status(400).json({ message: "Password must be at least 8 characters." });
     }
 
-    const existing = await storage.getUserByEmail(email);
-    if (existing) {
-      return res.status(409).json({ message: "An account with this email already exists." });
-    }
-
     // Check DB for existing user
     try {
       const db = getDb();
@@ -126,12 +121,6 @@ export function createAuthRouter(): Router {
       if (existingDbUser) {
         return res.status(409).json({ message: "An account with this email already exists." });
       }
-    registeredUsers.set(email, {
-      fullName,
-      email,
-      passwordHash,
-      medicalLicenseNumber: licenseNumber,
-    });
 
       // Create DB user
       const passwordHash = hashPassword(password);
@@ -193,29 +182,19 @@ export function createAuthRouter(): Router {
     if (email === devEmail && password === devPassword) {
       userFullName = "Dr. Smith";
     } else {
-      // Check in-memory store (legacy)
-      const registeredUser = registeredUsers.get(email);
-      if (registeredUser && bcrypt.compareSync(password, registeredUser.password)) {
-        userName = registeredUser.fullName;
-      }
+      try {
+        const db = getDb();
+        const [dbUser] = await db
+          .select()
+          .from(users)
+          .where(eq(users.email, email))
+          .limit(1);
 
-      // Also check DB
-      if (!userName) {
-        try {
-          const db = getDb();
-          const [dbUser] = await db
-            .select()
-            .from(users)
-            .where(eq(users.email, email))
-            .limit(1);
-
-          if (dbUser && verifyPassword(password, dbUser.passwordHash)) {
-            userName = dbUser.fullName;
-          }
-        } catch (err) {
-          // DB not available — fall back to in-memory only
-          console.warn("DB unavailable for login, using in-memory only.");
+        if (dbUser && verifyPassword(password, dbUser.passwordHash)) {
+          userFullName = dbUser.fullName;
         }
+      } catch (err) {
+        console.warn("DB unavailable for login.");
       }
     }
 
@@ -274,7 +253,12 @@ export function createAuthRouter(): Router {
       name = "Dr. Smith";
       id = "dev";
     } else {
-      const user = await storage.getUserByEmail(email);
+      const db = getDb();
+      const [user] = await db
+        .select()
+        .from(users)
+        .where(eq(users.email, email))
+        .limit(1);
       if (!user) {
         return res.status(404).json({ message: "User not found." });
       }
@@ -327,7 +311,7 @@ export function createAuthRouter(): Router {
 
       // If already verified, return success
       if (user.emailVerified) {
-        req.session.user = { email: user.email, name: user.fullName };
+        req.session.user = { id: user.id, email: user.email, name: user.fullName };
         return res.json({ success: true, message: "Email already verified." });
       }
 
@@ -391,7 +375,7 @@ export function createAuthRouter(): Router {
         .where(eq(users.id, user.id));
 
       // Create session
-      req.session.user = { email: user.email, name: user.fullName };
+      req.session.user = { id: user.id, email: user.email, name: user.fullName };
 
       return res.json({ success: true, message: "Email verified successfully." });
     } catch (err) {

--- a/server/middleware/rateLimiter.ts
+++ b/server/middleware/rateLimiter.ts
@@ -6,11 +6,11 @@ const MAX_REQUESTS = 60;
 const MAX_TRACKED_CLIENTS = 1000;
 
 function pruneExpiredRecords(now: number) {
-  for (const [clientId, record] of requestStore.entries()) {
+  requestStore.forEach((record, clientId) => {
     if (now > record.resetTime) {
       requestStore.delete(clientId);
     }
-  }
+  });
 }
 
 function trimRequestStore(now: number) {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -8,7 +8,7 @@ import {
   type User,
   type InsertUser
 } from "@shared/schema";
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 
 export interface IStorage {
   getAssessments(limit?: number, offset?: number, createdBy?: string): Promise<Assessment[]>;
@@ -35,13 +35,18 @@ export class DatabaseStorage implements IStorage {
   ): Promise<Assessment[]> {
     const db = getDb();
 
-    let query = db
+    const filters: any[] = [];
+    if (createdBy) {
+      filters.push(eq(assessments.createdBy, createdBy));
+    }
+
+    const query = db
       .select()
       .from(assessments)
       .orderBy(desc(assessments.createdAt));
 
-    if (createdBy) {
-      query = query.where(eq(assessments.createdBy, createdBy));
+    if (filters.length > 0) {
+      return await query.where(and(...filters)).limit(limit).offset(offset);
     }
 
     return await query.limit(limit).offset(offset);


### PR DESCRIPTION
## Description

Fixes #344 — TypeScript type-check is completely broken on `main` with 14 errors across 3 files after merging the auth refactor and email OTP changes.

`npm run check` (tsc) now passes with zero errors. All 16 existing tests continue to pass.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Root Cause

The merge of the auth refactor (#319) left behind orphaned legacy code from the old in-memory auth system. References to `storage`, `registeredUsers`, `bcrypt`, and an undeclared `userName` variable were never cleaned up.

## What Changed

### `server/auth.ts` (12 errors fixed)
- Removed dead `storage.getUserByEmail()` call — redundant in-memory check before DB duplicate check
- Removed orphaned `registeredUsers.set()` block — dead code referencing `passwordHash` before declaration
- Cleaned login route — removed `registeredUsers.get()` + `bcrypt.compareSync()` legacy path; login now uses DB-only path
- Fixed `userName` → `userFullName` — was referencing undeclared variable
- Replaced `storage.getUserByEmail()` with direct DB query using `getDb()`
- Added missing `id` field to `req.session.user` in verify-email and resend routes

### `server/middleware/rateLimiter.ts` (1 error fixed)
- Replaced `for...of` on `MapIterator` with `.forEach()` to avoid `downlevelIteration` requirement

### `server/storage.ts` (1 error fixed)
- Restructured conditional `.where()` — split into two return paths using `and()` filter array pattern

## How Has This Been Tested

- [x] `npm run check` — zero tsc errors
- [x] `npm test` — 16/16 tests pass across 5 test files

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] Existing tests continue to pass