### PR TITLE
fix: extend advancedFilter to search riskScore, hypertension and heartDisease fields

### DIFF
--- a/client/src/utils/search_filters.ts
+++ b/client/src/utils/search_filters.ts
@@ -1,7 +1,13 @@
 import type { Assessment } from "@shared/schema";
 
+/**
+ * Filters assessments by a search term across all clinically relevant fields.
+ * Searches: gender, riskCategory, smokingHistory, age, bmi, hba1cLevel,
+ * bloodGlucoseLevel, riskScore, hypertension (yes/no), heartDisease (yes/no).
+ */
 export function advancedFilter(assessments: Assessment[], query: string): Assessment[] {
-  const term = query.toLowerCase();
+  const term = query.toLowerCase().trim();
+  if (!term) return assessments;
   return assessments.filter(a =>
     a.gender.toLowerCase().includes(term) ||
     a.riskCategory.toLowerCase().includes(term) ||
@@ -9,6 +15,9 @@ export function advancedFilter(assessments: Assessment[], query: string): Assess
     String(a.age).includes(term) ||
     String(a.bmi).includes(term) ||
     String(a.hba1cLevel).includes(term) ||
-    String(a.bloodGlucoseLevel).includes(term)
+    String(a.bloodGlucoseLevel).includes(term) ||
+    String(a.riskScore).includes(term) ||
+    (term === "yes" && (a.hypertension || a.heartDisease)) ||
+    (term === "no" && (!a.hypertension || !a.heartDisease))
   );
 }


### PR DESCRIPTION
Fixes #252

## Describe the bug
`advancedFilter` in `search_filters.ts` only searched 7 fields — missing `riskScore`, `hypertension`, and `heartDisease`, which are all visible columns in the History table. Users searching for "high" risk score, "yes" hypertension, or "no" heart disease got no results despite the data being present.

## Fix
- Added `riskScore` string search
- Added `yes`/`no` search support for `hypertension` and `heartDisease` boolean fields
- Added early return for empty query to avoid unnecessary filtering overhead
- Added JSDoc comment documenting all searchable fields

## Type of change
- [x] Bug fix

## Related issue
Fixes #252

## Screenshot
N/A — filter logic improvement, no visual layout change

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.