### PR TITLE
fix: surface clinicianAdvice and patientAdvice from ML prediction in AssessmentResult

### DIFF
--- a/client/src/components/AssessmentResult.tsx
+++ b/client/src/components/AssessmentResult.tsx
@@ -91,12 +91,12 @@ export function AssessmentResult({ assessment }: AssessmentResultProps) {
   const riskScore = Number(assessment.riskScore).toFixed(1);
   const positiveFactors = factors.filter((f: any) => f.impact === "positive");
   const protectiveFactors = factors.filter((f: any) => f.impact !== "positive");
-  const patientGuidance = [
+  const patientGuidance = assessment.prediction?.patientAdvice ?? [
     "Review these results with a qualified clinician before making medical decisions.",
     "Focus first on the highlighted risk factors that can be changed through care planning.",
     "Track BMI, HbA1c, and blood glucose over time so future assessments have context.",
   ];
-  const clinicianActions = [
+  const clinicianActions = assessment.prediction?.clinicianAdvice ?? [
     "Confirm risk category against the patient's full history and current medication profile.",
     "Use the factor breakdown to prioritize follow-up labs, counselling, or referrals.",
     "Compare this assessment with prior visits to identify meaningful trajectory changes.",

--- a/shared/routes.ts
+++ b/shared/routes.ts
@@ -71,6 +71,19 @@ export function buildUrl(path: string, params?: Record<string, string | number>)
 }
 
 export type AssessmentInput = z.infer<typeof api.assessments.create.input>;
-export type AssessmentResponse = z.infer<typeof api.assessments.create.responses[201]>;
+export type PredictionAdvice = {
+  clinicianAdvice?: string[];
+  patientAdvice?: string[];
+};
+
+export type AssessmentResponse = z.infer<typeof api.assessments.create.responses[201]> & {
+  prediction?: PredictionAdvice & {
+    riskScore?: number;
+    riskCategory?: string;
+    confidenceInterval?: string | null;
+    modelConfidence?: number | null;
+    disclaimer?: string;
+  };
+};
 export type AssessmentsListResponse = z.infer<typeof api.assessments.list.responses[200]>;
 export type AssessmentPreviewResponse = z.infer<typeof api.assessments.preview.responses[200]>;


### PR DESCRIPTION
Fixes #253

## Describe the bug
`analyze.py` generates tailored `clinicianAdvice` and `patientAdvice` arrays in every prediction result, but they were silently discarded — never stored, never typed, never rendered. `AssessmentResult.tsx` showed hardcoded generic guidance instead of the ML-generated tailored advice.

## Fix
- Extended `AssessmentResponse` type in `shared/routes.ts` with a `PredictionAdvice` type covering `clinicianAdvice` and `patientAdvice`
- Updated `AssessmentResult.tsx` to use `assessment.prediction?.clinicianAdvice` and `assessment.prediction?.patientAdvice` when available
- Falls back to hardcoded defaults when prediction advice is not present (backward compatible)

The `prediction` object is already returned by the server in the assessment creation response — no backend changes needed.

## Type of change
- [x] Bug fix

## Related issue
Fixes #253

## Screenshot
N/A — the clinician and patient advice panels now show ML-generated tailored guidance instead of hardcoded text

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.