### PR TITLE
fix: clear localStorage draft immediately after loading and validate keys before applying

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -92,22 +92,29 @@ export default function Dashboard() {
 
   const parsedForPreview = useMemo(() => formSchema.safeParse(watchedValues), [watchedValues]);
 
-  // Load draft from localStorage on mount
+  // Load draft from localStorage on mount — clear immediately after loading
+  // so it only pre-fills the form once (not on every subsequent visit)
   useEffect(() => {
     try {
       const raw = localStorage.getItem("clinical-insight-assessment-draft");
       if (!raw) return;
+      // Remove immediately so stale draft never pre-fills on next visit
+      localStorage.removeItem("clinical-insight-assessment-draft");
       const draft = JSON.parse(raw);
-      if (draft) {
+      if (draft && typeof draft === "object") {
+        const allowedKeys = [
+          "gender", "age", "hypertension", "heartDisease",
+          "smokingHistory", "bmi", "hba1cLevel", "bloodGlucoseLevel",
+        ];
         Object.entries(draft).forEach(([k, v]) => {
+          if (!allowedKeys.includes(k)) return;
           try {
-            // @ts-ignore
-            setValue(k as any, v, { shouldDirty: true });
+            setValue(k as keyof FormData, v as any, { shouldDirty: true });
           } catch (e) {}
         });
       }
     } catch (e) {
-      // ignore
+      // ignore malformed draft
     }
   }, [setValue]);
 


### PR DESCRIPTION
Fixes #256

## Describe the bug
`Dashboard.tsx` loaded the assessment draft from localStorage but never cleared it after reading. The draft persisted indefinitely and pre-filled the form on every visit — even when the user had no intention of reloading a previous assessment. Additionally, any arbitrary key-value pair in the draft was applied to the form with `@ts-ignore` suppressing TypeScript safety entirely.

## Fix
- Call `localStorage.removeItem("clinical-insight-assessment-draft")` immediately after reading the draft — so it only pre-fills the form once
- Validate keys against an explicit `allowedKeys` allowlist before calling `setValue`
- Remove `@ts-ignore` — use `keyof FormData` for type-safe `setValue` calls

## Type of change
- [x] Bug fix

## Related issue
Fixes #256

## Screenshot
N/A — form behavior fix, no visual layout change

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.