### PR TITLE
fix: replace alert() with useToast notification in History.tsx exportAsPdf

### DIFF
--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -1,4 +1,5 @@
 import { AppLayout } from "@/components/layout/AppLayout";
+import { useToast } from "@/hooks/use-toast";
 import { useAssessments } from "@/hooks/use-assessments";
 import { format, isValid } from "date-fns";
 import { Loader2, Search, Calendar, User, Activity } from "lucide-react";
@@ -11,6 +12,7 @@ import { advancedFilter } from "@/utils/search_filters";
 
 export default function History() {
   const { data: assessments, isLoading, error } = useAssessments();
+  const { toast } = useToast();
   const [searchTerm, setSearchTerm] = useState("");
   const [sortBy, setSortBy] = useState<string>("date-desc");
 
@@ -49,7 +51,11 @@ export default function History() {
 
     const w = window.open("", "_blank", "noopener,noreferrer");
     if (!w) {
-      alert("Please allow popups to enable PDF export.");
+      toast({
+        title: "Popups blocked",
+        description: "Please allow popups for this site to enable PDF export.",
+        variant: "destructive",
+      });
       return;
     }
 


### PR DESCRIPTION
Fixes #258

## Describe the bug
`exportAsPdf` in `History.tsx` used a native browser `alert()` dialog when the popup was blocked. `alert()` is blocking, cannot be styled, and is visually inconsistent with the rest of the application which uses inline error messages and styled UI components.

## Fix
- Import `useToast` from `@/hooks/use-toast`
- Replace `alert()` with a `toast()` call using `variant: "destructive"`
- Shows a styled toast notification with title "Popups blocked" and a descriptive message

## Type of change
- [x] Bug fix

## Related issue
Fixes #258

## Screenshot
N/A — error notification style change, no layout change

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.