### PR TITLE
fix(ml): calculate 95% confidence interval on logit scale using covariance matrix

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -86,7 +86,7 @@ def generate_correlation_heatmap(df, output_path="correlation_heatmap.png"):
 def train_model_pipeline():
     """Loads data, preprocesses it, and trains a logistic regression model from scratch."""
     if not os.path.exists(DATA_FILE):
-        return None, None, None
+        return None, None, None, None
     
     df = pd.read_csv(DATA_FILE)
     
@@ -116,7 +116,23 @@ def train_model_pipeline():
     model = LogisticRegression(class_weight='balanced')
     model.fit(X_scaled, y)
     
-    return model, scaler, features
+    # Compute covariance matrix of coefficients (accounting for balanced class weights)
+    X_design = np.hstack([np.ones((X_scaled.shape[0], 1)), X_scaled])
+    p = model.predict_proba(X_scaled)[:, 1]
+    
+    classes = np.unique(y)
+    class_weights = len(y) / (len(classes) * np.bincount(y))
+    sample_weights = np.array([class_weights[c] for c in y])
+    
+    D = sample_weights * p * (1 - p)
+    I = np.dot(X_design.T * D, X_design)
+    C = getattr(model, 'C', 1.0)
+    I_reg = np.eye(X_design.shape[1])
+    I_reg[0, 0] = 0.0  # Do not regularize intercept
+    I += (1.0 / C) * I_reg
+    cov_beta = np.linalg.inv(I)
+    
+    return model, scaler, features, cov_beta
 
 
 def _compute_dataset_hash(filepath: str) -> str | None:
@@ -200,12 +216,12 @@ def save_pretrained_model():
         print("Could not acquire lock for saving model.", file=sys.stderr)
         return False
     try:
-        model, scaler, features = train_model_pipeline()
+        model, scaler, features, cov_beta = train_model_pipeline()
         if model is None:
             print("Failed to train model. Ensure diabetes_dataset.csv is present.", file=sys.stderr)
             return False
         dataset_hash = _compute_dataset_hash(DATA_FILE)
-        _atomic_write(MODEL_FILE, (model, scaler, features, dataset_hash))
+        _atomic_write(MODEL_FILE, (model, scaler, features, dataset_hash, cov_beta))
         print(f"Model successfully serialized to {MODEL_FILE}", file=sys.stderr)
         return True
     finally:
@@ -231,8 +247,9 @@ def get_model():
             if isinstance(model_data, tuple) and len(model_data) >= 3:
                 model, scaler, features = model_data[:3]
                 cached_hash = model_data[3] if len(model_data) >= 4 else None
-                if current_hash is not None and current_hash == cached_hash:
-                    return model, scaler, features
+                cov_beta = model_data[4] if len(model_data) >= 5 else None
+                if current_hash is not None and current_hash == cached_hash and cov_beta is not None:
+                    return model, scaler, features, cov_beta
                 print("Dataset has changed. Retraining model...", file=sys.stderr)
         except Exception as e:
             print(f"Failed to load pre-trained model: {e}", file=sys.stderr)
@@ -240,7 +257,7 @@ def get_model():
     # Acquire lock before retraining and writing
     if not _acquire_lock():
         print("Could not acquire lock for model retraining.", file=sys.stderr)
-        return None, None, None
+        return None, None, None, None
 
     try:
         # Double-check after acquiring lock: another process may have
@@ -250,21 +267,22 @@ def get_model():
                 model_data = joblib.load(MODEL_FILE)
                 if isinstance(model_data, tuple) and len(model_data) >= 3:
                     cached_hash = model_data[3] if len(model_data) >= 4 else None
-                    if current_hash is not None and current_hash == cached_hash:
-                        return model_data[0], model_data[1], model_data[2]
+                    cov_beta = model_data[4] if len(model_data) >= 5 else None
+                    if current_hash is not None and current_hash == cached_hash and cov_beta is not None:
+                        return model_data[0], model_data[1], model_data[2], cov_beta
             except Exception:
                 pass
 
         # No valid cache — train from scratch and atomically write
-        model, scaler, features = train_model_pipeline()
+        model, scaler, features, cov_beta = train_model_pipeline()
         if model is not None:
-            _atomic_write(MODEL_FILE, (model, scaler, features, current_hash))
+            _atomic_write(MODEL_FILE, (model, scaler, features, current_hash, cov_beta))
             print(f"Model trained and saved to {MODEL_FILE}", file=sys.stderr)
-        return model, scaler, features
+        return model, scaler, features, cov_beta
     finally:
         _release_lock()
 
-def interpret_prediction(model, scaler, features, input_data):
+def interpret_prediction(model, scaler, features, input_data, cov_beta=None):
     """Interprets a single patient's data, yielding clinician and patient views."""
     if model is None:
         return {"error": "Dataset missing. Please ensure diabetes_dataset.csv is present."}
@@ -292,15 +310,34 @@ def interpret_prediction(model, scaler, features, input_data):
     # Calculate feature contributions for this individual (coefficient * scaled value)
     contributions = model.coef_[0] * X_input[0]
     
-    # Calculate confidence interval using the standard error of the predicted probability.
-    # For a Bernoulli proportion p, SE = sqrt(p * (1 - p)).
-    # Multiplying by 1.96 gives an approximate 95% CI.
-    # This produces a wider interval for borderline predictions (p near 0.5)
-    # and a narrower interval for high-confidence predictions (p near 0 or 1).
-    se = (prob * (1 - prob)) ** 0.5
-    margin = round(1.96 * se * 100, 1)
-    lower_ci = round(max(0, risk_score - margin), 1)
-    upper_ci = round(min(100, risk_score + margin), 1)
+    # Calculate confidence interval
+    if cov_beta is not None:
+        # Calculate standard error of the linear predictor (logit) z_0
+        # prepending 1 for intercept
+        x0 = np.insert(X_input[0], 0, 1.0)
+        variance = x0.dot(cov_beta).dot(x0)
+        se_logit = np.sqrt(max(0.0, variance))
+        
+        # Linear predictor value z0
+        z0 = model.decision_function(X_input)[0]
+        
+        # Calculate 95% CI on logit scale
+        lower_logit = z0 - 1.96 * se_logit
+        upper_logit = z0 + 1.96 * se_logit
+        
+        # Inverse logit (sigmoid function) to map back to probability scale [0, 1]
+        lower_prob = 1.0 / (1.0 + np.exp(-lower_logit))
+        upper_prob = 1.0 / (1.0 + np.exp(-upper_logit))
+        
+        lower_ci = round(max(0.0, min(100.0, lower_prob * 100)), 1)
+        upper_ci = round(max(0.0, min(100.0, upper_prob * 100)), 1)
+    else:
+        # Fallback to binomial standard error if cov_beta is not available
+        se = (prob * (1 - prob)) ** 0.5
+        margin = round(1.96 * se * 100, 1)
+        lower_ci = round(max(0.0, risk_score - margin), 1)
+        upper_ci = round(min(100.0, risk_score + margin), 1)
+        
     confidence_interval = f"{lower_ci}% - {upper_ci}%"
 
     # Get top 3 factors
@@ -358,8 +395,8 @@ if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] == "predict_file":
         with open(sys.argv[2], 'r') as f:
             data = json.load(f)
-        model, scaler, features = get_model()
-        result = interpret_prediction(model, scaler, features, data)
+        model, scaler, features, cov_beta = get_model()
+        result = interpret_prediction(model, scaler, features, data, cov_beta)
         print(json.dumps(result))
     elif len(sys.argv) > 1 and sys.argv[1] == "train":
         if not os.path.exists(DATA_FILE):
@@ -367,7 +404,7 @@ if __name__ == "__main__":
             create_synthetic_data()
         success = save_pretrained_model()
         if success:
-            model, scaler, features = get_model()
+            model, scaler, features, cov_beta = get_model()
             print(f"Features used: {features}")
             print(f"Model Coefficients (Weights): {model.coef_[0]}")
     else:
@@ -376,7 +413,7 @@ if __name__ == "__main__":
         if not os.path.exists(DATA_FILE):
             print("Dataset not found. Creating synthetic dataset...")
             create_synthetic_data()
-        model, scaler, features = get_model()
+        model, scaler, features, cov_beta = get_model()
         if model is None:
             print("Failed to load dataset.")
         else:


### PR DESCRIPTION
### 🐛 Bug Fix: Correct 95% Confidence Interval Calculation for Predictions

Fixes #349

#### 📝 Summary
The 95% confidence interval for the predicted risk score in `analyze.py` was being calculated incorrectly by treating the predicted probability $p$ as a sample proportion and calculating a binomial standard error. This PR implements the mathematically correct method of calculating the standard error of predictions on the logit scale using the parameter covariance matrix, then mapping back to the probability scale.

---

#### 🛠️ Changes Made
1. **Covariance Matrix Estimation:**
   - Updated `train_model_pipeline()` to calculate the coefficient covariance matrix $\text{Cov}(\beta) = (X^T D X + \lambda I)^{-1}$ at train time.
   - Accurately accounted for `class_weight='balanced'` sample weights $w_i$ and the L2 regularization parameter ($C$) in the Hessian calculation.
   - Returned `cov_beta` as the 4th element from the training pipeline.
2. **Model Serialization:**
   - Serialized and loaded `cov_beta` into `MODEL_FILE` alongside the model, scaler, and features.
3. **Logit-Scale Confidence Interval:**
   - Updated `interpret_prediction()` to compute the standard error of predictions on the logit scale: $SE_{z_0} = \sqrt{x_0^T \text{Cov}(\beta) x_0}$.
   - Transformed the logit confidence interval bounds ($z_0 \pm 1.96 \cdot SE_{z_0}$) back to the probability scale using the sigmoid function.
   - Handled a clean fallback to binomial standard error calculation if `cov_beta` is not available.

---

#### 🧪 Verification & Testing
- Ran model retraining:
  ```bash
  python analyze.py train
