### PR TITLE
fix: remove duplicate conflicting properties from AssessmentCreateInput type

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -9,7 +9,7 @@ import { desc, eq } from "drizzle-orm";
 
 export interface IStorage {
   getAssessments(limit?: number, offset?: number, createdBy?: string): Promise<Assessment[]>;
-  createAssessment(assessment: any): Promise<Assessment>;
+  createAssessment(assessment: AssessmentCreateInput): Promise<Assessment>;
 }
 
 export type AssessmentCreateInput = InsertAssessment & {
@@ -18,13 +18,7 @@ export type AssessmentCreateInput = InsertAssessment & {
   factors: AssessmentFactor[];
   confidenceInterval?: string;
   modelConfidence?: number;
-  createdBy?: string;
   createdBy: string;
-  riskScore: string;
-  riskCategory: string;
-  factors: AssessmentFactor[];
-  confidenceInterval?: string;
-  modelConfidence?: string;
 };
 
 export class DatabaseStorage implements IStorage {


### PR DESCRIPTION
## Description

Fixes duplicate and conflicting field declarations in the `AssessmentCreateInput` type in `server/storage.ts`. The type previously declared `riskScore` as both `number` and `string`, `modelConfidence` as both `number` and `string`, and `createdBy` as both optional and required. This made the type misleading and broke TypeScript's ability to catch type errors.

## Related Issue

Fixes #452

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- Removed duplicate `createdBy`, `riskScore`, `riskCategory`, `factors`, `confidenceInterval`, and `modelConfidence` field declarations
- Kept correct types that match the database schema (`riskScore: number`, `modelConfidence?: number`, `createdBy: string`)
- Updated `IStorage` interface to use `AssessmentCreateInput` instead of `any` for the `createAssessment` parameter

## Screenshots (if applicable)

N/A — server-side type fix.

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed

## Validation

`npm run check` produces only pre-existing type definition errors (missing `@types/node` and `vite/client` in the local environment — unrelated to this change). The fix is a pure type-level correction with no runtime behavior change.
