### PR TITLE
fix: remove form options that are rejected by Zod schema validation

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -236,8 +236,8 @@ export default function Dashboard() {
                     <div className="mt-4 space-y-4">
                       <div className="space-y-2">
                         <label className={labelClass}>Gender</label>
-                        <div className="grid grid-cols-3 gap-1 rounded-2xl bg-slate-100 p-1">
-                          {["Male", "Female", "Other"].map((g) => (
+                        <div className="grid grid-cols-2 gap-1 rounded-2xl bg-slate-100 p-1">
+                          {["Male", "Female"].map((g) => (
                             <label key={g} className="flex-1 cursor-pointer">
                               <input type="radio" value={g} {...register("gender")} className="peer sr-only" />
                               <div className="text-center px-3 py-3 rounded-xl transition-all duration-200 font-bold text-sm text-slate-500 hover:text-blue-700 peer-checked:bg-white peer-checked:text-blue-700 peer-checked:shadow-sm">
@@ -262,8 +262,6 @@ export default function Dashboard() {
                           <option value="No Info">No Info</option>
                           <option value="current">current</option>
                           <option value="former">former</option>
-                          <option value="ever">ever</option>
-                          <option value="not current">not current</option>
                         </select>
                         {errors.smokingHistory && <p className="text-sm text-red-600 mt-1">{errors.smokingHistory.message}</p>}
                       </div>


### PR DESCRIPTION
## Description

Removes form options from the Dashboard assessment form that are not accepted by the backend Zod schema validation. Previously, selecting "Other" for gender or "ever"/"not current" for smoking history would pass client-side form rendering but fail with a 400 validation error on submit.

## Related Issue

Fixes #451

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- Removed "Other" from gender radio buttons (schema only accepts `"Male"` | `"Female"`)
- Changed gender grid from 3-column to 2-column layout to match the two valid options
- Removed "ever" and "not current" from smoking history select (schema only accepts `"never"` | `"No Info"` | `"current"` | `"former"`)

## Screenshots (if applicable)

N/A — the form now only shows options that the backend will accept.

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed

## Validation

Verified that the remaining form options (`"Male"`, `"Female"` for gender; `"never"`, `"No Info"`, `"current"`, `"former"` for smoking history) exactly match the Zod enum values defined in `shared/schema.ts`.
