### PR TITLE
fix: remove unsafe-eval and unsafe-inline from CSP scriptSrc directive

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -83,9 +83,8 @@ app.use(
         defaultSrc: ["'self'"],
         scriptSrc: [
           "'self'",
-          "'unsafe-eval'",
-          "'unsafe-inline'",
-          (_req: any, res: any) => `'nonce-${res.locals.cspNonce}',`
+          "'strict-dynamic'",
+          (_req: any, res: any) => `'nonce-${res.locals.cspNonce}'`
         ],
         styleSrc: [
           "'self'",


### PR DESCRIPTION
## Description

Removes `'unsafe-eval'` and `'unsafe-inline'` from the Content-Security-Policy `scriptSrc` directive and fixes a syntax bug in the nonce function. Previously, the presence of `'unsafe-inline'` caused browsers to completely ignore the nonce — effectively disabling XSS protection despite the nonce middleware generating a cryptographic value per request.

## Related Issue

Fixes #448

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- Removed `'unsafe-eval'` from `scriptSrc` — prevents `eval()` and `Function()` XSS vectors
- Removed `'unsafe-inline'` from `scriptSrc` — allows the nonce to actually provide protection
- Added `'strict-dynamic'` — allows nonce-approved scripts to load child scripts (standard for module bundlers)
- Fixed trailing comma inside the nonce string that produced an invalid CSP value

## Screenshots (if applicable)

N/A — security header fix.

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed

## Validation

Verified that the CSP header now correctly relies on the nonce for script authorization. The `'strict-dynamic'` directive ensures that scripts loaded by nonce-approved entry points (e.g., Vite's bundled output) are also trusted, which is the standard approach for SPA applications using module bundlers.

Note: `'unsafe-inline'` is intentionally kept in `styleSrc` since Tailwind CSS and inline styles require it — this is standard practice and does not affect script security.
