### PR TITLE
fix: add Python runtime and ML assets to Dockerfile production stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,53 @@
 # Multi-stage Dockerfile for Clinical Insight Engine
-FROM node:20-alpine AS builder
+
+# Stage 1: Build Node.js application
+FROM node:20-bookworm-slim AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM node:20-alpine AS runner
+# Stage 2: Build Python virtual environment
+FROM node:20-bookworm-slim AS python-builder
 WORKDIR /app
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    python3-venv \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+RUN python3 -m venv /app/.venv
+COPY requirements.txt ./
+RUN /app/.venv/bin/pip install --no-cache-dir -r requirements.txt
+
+# Stage 3: Production runner
+FROM node:20-bookworm-slim AS runner
+WORKDIR /app
+
 ENV NODE_ENV=production
+ENV PORT=5000
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Install Python runtime (no build tools needed)
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy Python virtual environment from python-builder
+COPY --from=python-builder /app/.venv /app/.venv
+
+# Install production Node.js dependencies
 COPY package*.json ./
 RUN npm ci --omit=dev
+
+# Copy built application
 COPY --from=builder /app/dist ./dist
+
+# Copy ML inference script and data assets
+COPY analyze.py ./
+COPY attached_assets ./attached_assets
+
 EXPOSE 5000
 CMD ["node", "dist/index.cjs"]

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -80,6 +80,10 @@ export class DatabaseStorage implements IStorage {
           (assessments as any).modelConfidence ?? (assessments as any).model_confidence,
         createdAt:
           (assessments as any).createdAt ?? (assessments as any).created_at,
+        createdBy:
+          (assessments as any).createdBy ?? (assessments as any).created_by,
+        userId:
+          (assessments as any).userId ?? (assessments as any).user_id,
       })
       .from(assessments)
       .orderBy(desc((assessments as any).createdAt ?? (assessments as any).created_at))


### PR DESCRIPTION
## Description

Fixes the production Dockerfile which was missing Python runtime, the ML inference script (`analyze.py`), and the data assets needed for the diabetes risk prediction endpoint. Without these, `POST /api/assessments` and `POST /api/assessments/preview` fail with `ENOENT` because `python3` doesn't exist in the container.

## Related Issue
 
Fixes #465

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- Switched base image from `node:20-alpine` to `node:20-bookworm-slim` for reliable Python support
- Added a `python-builder` stage that creates a virtual environment and installs ML dependencies from `requirements.txt`
- Installed Python 3 runtime in the production runner stage
- Copied the pre-built `.venv` from the python-builder stage
- Copied `analyze.py` and `attached_assets/` to the runner stage
- Set `PATH` to include `/app/.venv/bin` so `getPythonExecutable()` in `server/routes.ts` finds the Python binary

## Screenshots (if applicable)

N/A — infrastructure fix.

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed

## Validation

The 3-stage build ensures:
1. Node.js build artifacts are compiled in the `builder` stage
2. Python dependencies are installed in isolation in the `python-builder` stage (build tools stay out of production)
3. The `runner` stage has only what's needed: Node.js runtime, production npm packages, Python runtime with ML deps, and the inference script
