### PR TITLE
fix: add focus trap and Escape key handler to AuthFlowModal

### DIFF
--- a/client/src/components/AuthFlowModal.tsx
+++ b/client/src/components/AuthFlowModal.tsx
@@ -530,6 +530,7 @@ export function AuthFlowModal({ initialMode, isOpen, onClose }: AuthFlowModalPro
   const [devOtp, setDevOtp] = useState<string | undefined>(undefined);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -547,6 +548,58 @@ export function AuthFlowModal({ initialMode, isOpen, onClose }: AuthFlowModalPro
       document.body.style.overflow = originalOverflow;
     };
   }, [initialMode, isOpen]);
+
+  // Escape key handler and focus trap
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+
+      // Focus trap: cycle focus within the modal
+      if (event.key === "Tab" && modalRef.current) {
+        const focusableElements = modalRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusableElements.length === 0) return;
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (event.shiftKey) {
+          if (document.activeElement === firstElement) {
+            event.preventDefault();
+            lastElement.focus();
+          }
+        } else {
+          if (document.activeElement === lastElement) {
+            event.preventDefault();
+            firstElement.focus();
+          }
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    // Auto-focus first focusable element in modal
+    const timer = setTimeout(() => {
+      if (modalRef.current) {
+        const firstFocusable = modalRef.current.querySelector<HTMLElement>(
+          'input, button, [href], select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        firstFocusable?.focus();
+      }
+    }, 100);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      clearTimeout(timer);
+    };
+  }, [isOpen, onClose]);
 
   if (!isOpen) return null;
 
@@ -626,7 +679,7 @@ export function AuthFlowModal({ initialMode, isOpen, onClose }: AuthFlowModalPro
   };
 
   return (
-    <div className="fixed inset-0 z-[80] overflow-y-auto bg-slate-950/50 px-4 py-6 backdrop-blur-sm" role="dialog" aria-modal="true" aria-labelledby="auth-title">
+    <div ref={modalRef} className="fixed inset-0 z-[80] overflow-y-auto bg-slate-950/50 px-4 py-6 backdrop-blur-sm" role="dialog" aria-modal="true" aria-labelledby="auth-title">
       <motion.div
         initial={{ opacity: 0, y: 20, scale: 0.98 }}
         animate={{ opacity: 1, y: 0, scale: 1 }}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -80,6 +80,10 @@ export class DatabaseStorage implements IStorage {
           (assessments as any).modelConfidence ?? (assessments as any).model_confidence,
         createdAt:
           (assessments as any).createdAt ?? (assessments as any).created_at,
+        createdBy:
+          (assessments as any).createdBy ?? (assessments as any).created_by,
+        userId:
+          (assessments as any).userId ?? (assessments as any).user_id,
       })
       .from(assessments)
       .orderBy(desc((assessments as any).createdAt ?? (assessments as any).created_at))


### PR DESCRIPTION
## Description

Adds a keyboard focus trap and Escape key handler to the `AuthFlowModal` component. Previously, keyboard users could Tab outside the modal into the page content behind it, and pressing Escape did nothing.  

## Related Issue

Fixes #475

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- Added `useEffect` that listens for `keydown` events when the modal is open
- Pressing Escape closes the modal via `onClose()`
- Tab/Shift+Tab cycles focus within the modal (focus trap)
- Auto-focuses the first interactive element when the modal opens
- Added `modalRef` to the modal container for DOM querying
- Also includes a fix for a pre-existing `tsc` error in `server/storage.ts`

## Screenshots (if applicable)

N/A — accessibility/keyboard interaction fix.

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
