### PR TITLE
fix: use separate rate limiter for preview and increase debounce to 1500ms

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -169,7 +169,7 @@ export default function Dashboard() {
       } finally {
         setPreviewPending(false);
       }
-    }, 500);
+    }, 1500);
 
     return () => {
       controller.abort();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -53,6 +53,22 @@ const assessmentLimiter = rateLimit({
   },
 });
 
+/**
+ * Separate, more permissive rate limiter for the preview endpoint.
+ * Preview is triggered automatically during form filling and should not
+ * block normal user interaction. Allows 15 requests per minute.
+ */
+const previewLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  limit: 15, // 15 requests per IP per window
+  standardHeaders: "draft-8",
+  legacyHeaders: false,
+  message: {
+    error: "Too many preview requests. Please wait a moment.",
+    retryAfter: 60,
+  },
+});
+
 function getPythonExecutable() {
   const candidates = process.platform === "win32"
     ? [
@@ -529,7 +545,7 @@ export async function registerRoutes(
     api.assessments.preview.path,
     requireAuth,
     requireVerified,
-    assessmentLimiter,
+    previewLimiter,
     async (req, res) => {
       const input = api.assessments.preview.input.parse(req.body);
       const tempFile = path.join(

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -80,6 +80,10 @@ export class DatabaseStorage implements IStorage {
           (assessments as any).modelConfidence ?? (assessments as any).model_confidence,
         createdAt:
           (assessments as any).createdAt ?? (assessments as any).created_at,
+        createdBy:
+          (assessments as any).createdBy ?? (assessments as any).created_by,
+        userId:
+          (assessments as any).userId ?? (assessments as any).user_id,
       })
       .from(assessments)
       .orderBy(desc((assessments as any).createdAt ?? (assessments as any).created_at))


### PR DESCRIPTION
## Description

Fixes 429 rate-limit errors that occur during normal form filling on the Dashboard. The preview endpoint shared the same strict rate limiter (5 req/min) as the create endpoint, causing users to hit rate limits just by filling out the form.
 
## Related Issue

Fixes #477

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- Added a separate `previewLimiter` (15 req/min) for the preview endpoint, distinct from the stricter `assessmentLimiter` (5 req/min) used for the create endpoint
- Increased client-side debounce from 500ms to 1500ms to reduce unnecessary preview requests during form filling
- Also includes a fix for a pre-existing `tsc` error in `server/storage.ts`

## Screenshots (if applicable)

N/A

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
