### PR TITLE
fix: resolve DATA_FILE and MODEL_FILE relative to script directory

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -16,6 +16,17 @@ LOCK_FILE = MODEL_FILE + ".lock"
 LOCK_TIMEOUT = 60
 LOCK_POLL_INTERVAL = 0.1
 
+# Resolve paths relative to this script's directory so the files are
+# found regardless of the working directory (e.g., in Docker or when
+# spawned by the Node.js server from a different CWD).
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_FILE = os.path.join(SCRIPT_DIR, "attached_assets", "diabetes_dataset.csv")
+# Fall back to the legacy location if attached_assets doesn't have it
+if not os.path.exists(DATA_FILE):
+    DATA_FILE = os.path.join(SCRIPT_DIR, "diabetes_dataset.csv")
+MODEL_FILE = os.path.join(SCRIPT_DIR, "diabetes_model.joblib")
+LOCK_FILE = MODEL_FILE + ".lock"
+
 def create_synthetic_data():
     """Generates synthetic dataset to mimic the provided assignment data."""
     np.random.seed(42)

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -80,6 +80,10 @@ export class DatabaseStorage implements IStorage {
           (assessments as any).modelConfidence ?? (assessments as any).model_confidence,
         createdAt:
           (assessments as any).createdAt ?? (assessments as any).created_at,
+        createdBy:
+          (assessments as any).createdBy ?? (assessments as any).created_by,
+        userId:
+          (assessments as any).userId ?? (assessments as any).user_id,
       })
       .from(assessments)
       .orderBy(desc((assessments as any).createdAt ?? (assessments as any).created_at))


### PR DESCRIPTION
## Description

Fixes `analyze.py` to resolve `DATA_FILE` and `MODEL_FILE` relative to the script's own directory instead of the process working directory. Previously, the script used bare relative paths (`"diabetes_dataset.csv"`) which break when the Node.js server spawns the Python subprocess from a different CWD (e.g., in Docker where CWD is `/app` but the dataset is in `/app/attached_assets/`).
 
## Related Issue

Fixes #478

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- Computed `SCRIPT_DIR` using `os.path.dirname(os.path.abspath(__file__))`
- Resolved `DATA_FILE` to `attached_assets/diabetes_dataset.csv` relative to the script directory
- Added fallback to legacy location (`diabetes_dataset.csv` in script dir) for backward compatibility
- Resolved `MODEL_FILE` and `LOCK_FILE` relative to the script directory
- Also includes a fix for a pre-existing `tsc` error in `server/storage.ts`

## Screenshots (if applicable)

N/A

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
