### PR TITLE
fix: replace staleTime Infinity with 30s and enable refetchOnWindowFocus

### DIFF
--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -46,8 +46,8 @@ export const queryClient = new QueryClient({
     queries: {
       queryFn: getQueryFn({ on401: "throw" }),
       refetchInterval: false,
-      refetchOnWindowFocus: false,
-      staleTime: Infinity,
+      refetchOnWindowFocus: true,
+      staleTime: 30 * 1000, // 30 seconds
       retry: false,
     },
     mutations: {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -80,6 +80,10 @@ export class DatabaseStorage implements IStorage {
           (assessments as any).modelConfidence ?? (assessments as any).model_confidence,
         createdAt:
           (assessments as any).createdAt ?? (assessments as any).created_at,
+        createdBy:
+          (assessments as any).createdBy ?? (assessments as any).created_by,
+        userId:
+          (assessments as any).userId ?? (assessments as any).user_id,
       })
       .from(assessments)
       .orderBy(desc((assessments as any).createdAt ?? (assessments as any).created_at))


### PR DESCRIPTION
## Description

Replaces `staleTime: Infinity` with `staleTime: 30 * 1000` (30 seconds) and enables `refetchOnWindowFocus: true` in the global React Query client configuration. Previously, data fetched once was never considered stale, meaning the assessments list would not update when switching tabs or navigating back to the History page. 

## Related Issue

Fixes #479

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- Changed `staleTime` from `Infinity` to `30 * 1000` (30 seconds)
- Changed `refetchOnWindowFocus` from `false` to `true`
- Also includes a fix for a pre-existing `tsc` error in `server/storage.ts`

## Screenshots (if applicable)

N/A

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed

## Validation

With 30s staleTime, cached data is served instantly for quick navigations (e.g., Dashboard → History → Dashboard) but refreshes when the user returns to a tab after being away. This matches the expected behavior for a clinical application where data freshness matters.
