### PR TITLE
fix: add periodic cleanup for expired OTP entries to prevent memory leak

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -58,6 +58,22 @@ interface PendingOtp {
 const pendingOtps = new Map<string, PendingOtp>();
 
 /**
+ * Periodically removes expired OTP entries to prevent unbounded memory growth.
+ * Runs every 5 minutes.
+ */
+const otpCleanupTimer = setInterval(() => {
+  const now = Date.now();
+  for (const [email, otp] of pendingOtps) {
+    if (now > otp.expiresAt) {
+      pendingOtps.delete(email);
+    }
+  }
+}, 5 * 60 * 1000);
+if (otpCleanupTimer.unref) {
+  otpCleanupTimer.unref();
+}
+
+/**
  * Rate limiters for verification endpoints.
  */
 const verifyEmailLimiter = rateLimit({

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -80,6 +80,10 @@ export class DatabaseStorage implements IStorage {
           (assessments as any).modelConfidence ?? (assessments as any).model_confidence,
         createdAt:
           (assessments as any).createdAt ?? (assessments as any).created_at,
+        createdBy:
+          (assessments as any).createdBy ?? (assessments as any).created_by,
+        userId:
+          (assessments as any).userId ?? (assessments as any).user_id,
       })
       .from(assessments)
       .orderBy(desc((assessments as any).createdAt ?? (assessments as any).created_at))


### PR DESCRIPTION
## Description

Adds periodic cleanup for the `pendingOtps` Map in `server/auth.ts`. Previously, OTP entries were only removed on successful verification or when a user attempted to verify an expired code. Entries for users who abandoned the flow (requested OTP but never verified) accumulated indefinitely, causing unbounded memory growth. 

## Related Issue

Fixes #480

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- Added a `setInterval` (every 5 minutes) that iterates `pendingOtps` and deletes entries where `Date.now() > expiresAt`
- Used `.unref()` on the timer so it doesn't prevent graceful process exit
- Also includes a fix for a pre-existing `tsc` error in `server/storage.ts`

## Screenshots (if applicable)

N/A

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed

## Validation

This follows the same pattern already used in `server/middleware/rateLimiter.ts` for cleaning up expired rate limit entries. OTP entries have a 10-minute expiry, so the 5-minute cleanup interval ensures no entry lives more than ~15 minutes past its expiry.
