### PR TITLE
feat: add interactive risk trend analytics chart to Patient History

### DIFF
--- a/client/src/components/RiskTrendChart.tsx
+++ b/client/src/components/RiskTrendChart.tsx
@@ -1,0 +1,141 @@
+import { useMemo, useState } from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  ReferenceLine,
+} from "recharts";
+import { format, isValid } from "date-fns";
+
+interface Assessment {
+  id: number;
+  createdAt: any;
+  riskScore: any;
+  bmi: any;
+  hba1cLevel: any;
+  bloodGlucoseLevel: any;
+  riskCategory: string;
+}
+
+interface Props {
+  assessments: Assessment[];
+}
+
+const METRICS = [
+  { key: "riskScore", label: "Risk Score (%)", color: "#2563EB", active: true },
+  { key: "bmi", label: "BMI", color: "#06B6D4", active: false },
+  { key: "hba1cLevel", label: "HbA1c (%)", color: "#10B981", active: false },
+  { key: "bloodGlucoseLevel", label: "Blood Glucose", color: "#F59E0B", active: false },
+];
+
+function getRiskColor(score: number) {
+  if (score >= 50) return "#EF4444";
+  if (score >= 20) return "#F59E0B";
+  return "#10B981";
+}
+
+export default function RiskTrendChart({ assessments }: Props) {
+  const [activeMetrics, setActiveMetrics] = useState<Record<string, boolean>>(
+    Object.fromEntries(METRICS.map(m => [m.key, m.active]))
+  );
+
+  const chartData = useMemo(() => {
+    return [...assessments]
+      .sort((a, b) => new Date(a.createdAt || 0).getTime() - new Date(b.createdAt || 0).getTime())
+      .map(a => ({
+        date: isValid(new Date(a.createdAt)) ? format(new Date(a.createdAt), "MMM d") : "?",
+        riskScore: Number(Number(a.riskScore).toFixed(1)),
+        bmi: Number(Number(a.bmi).toFixed(1)),
+        hba1cLevel: Number(Number(a.hba1cLevel).toFixed(1)),
+        bloodGlucoseLevel: Number(Number(a.bloodGlucoseLevel).toFixed(1)),
+        riskCategory: a.riskCategory,
+      }));
+  }, [assessments]);
+
+  function toggleMetric(key: string) {
+    setActiveMetrics(prev => ({ ...prev, [key]: !prev[key] }));
+  }
+
+  if (chartData.length < 2) {
+    return (
+      <div className="bg-card border border-border rounded-2xl p-6 text-center text-muted-foreground text-sm">
+        At least 2 assessments are needed to display trend analytics.
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-card border border-border rounded-2xl p-6 shadow-sm">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
+        <div>
+          <h2 className="text-lg font-black text-foreground">Risk Trend Analytics</h2>
+          <p className="text-sm text-muted-foreground mt-0.5">Historical metabolic vector trends over time</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {METRICS.map(({ key, label, color }) => (
+            <button
+              key={key}
+              onClick={() => toggleMetric(key)}
+              className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold border transition-all ${
+                activeMetrics[key]
+                  ? "text-white border-transparent"
+                  : "bg-transparent text-muted-foreground border-border hover:border-foreground/30"
+              }`}
+              style={activeMetrics[key] ? { backgroundColor: color, borderColor: color } : {}}
+            >
+              <span className="w-2 h-2 rounded-full" style={{ backgroundColor: color }} />
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <ResponsiveContainer width="100%" height={280}>
+        <LineChart data={chartData} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+          <XAxis dataKey="date" tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} />
+          <YAxis tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} />
+          <Tooltip
+            contentStyle={{
+              background: "hsl(var(--card))",
+              border: "1px solid hsl(var(--border))",
+              borderRadius: "12px",
+              fontSize: "12px",
+            }}
+          />
+          <Legend wrapperStyle={{ fontSize: "12px" }} />
+          {/* Risk threshold reference lines */}
+          {activeMetrics["riskScore"] && (
+            <>
+              <ReferenceLine y={50} stroke="#EF4444" strokeDasharray="4 4" label={{ value: "High", fontSize: 10, fill: "#EF4444" }} />
+              <ReferenceLine y={20} stroke="#F59E0B" strokeDasharray="4 4" label={{ value: "Moderate", fontSize: 10, fill: "#F59E0B" }} />
+            </>
+          )}
+          {METRICS.map(({ key, label, color }) =>
+            activeMetrics[key] ? (
+              <Line
+                key={key}
+                type="monotone"
+                dataKey={key}
+                name={label}
+                stroke={color}
+                strokeWidth={2.5}
+                dot={(props: any) => {
+                  const { cx, cy, payload } = props;
+                  const dotColor = key === "riskScore" ? getRiskColor(payload.riskScore) : color;
+                  return <circle key={`dot-${cx}-${cy}`} cx={cx} cy={cy} r={4} fill={dotColor} stroke="white" strokeWidth={1.5} />;
+                }}
+                activeDot={{ r: 6 }}
+              />
+            ) : null
+          )}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -1,4 +1,5 @@
 import { AppLayout } from "@/components/layout/AppLayout";
+import RiskTrendChart from "@/components/RiskTrendChart";
 import { useToast } from "@/hooks/use-toast";
 import { useAssessments } from "@/hooks/use-assessments";
 import { format, isValid } from "date-fns";
@@ -195,7 +196,6 @@ export default function History() {
   const [sortBy, setSortBy] = useState<string>("date-desc");
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [compareModalOpen, setCompareModalOpen] = useState(false);
-  const { toast } = useToast();
   const [, setLocation] = useLocation();
   const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
   const [metricInputs, setMetricInputs] = useState<MetricInputState>(emptyMetricInputs);
@@ -433,6 +433,10 @@ export default function History() {
               </div>
             )}
           </section>
+        )}
+
+        {!isLoading && !error && assessments && assessments.length >= 2 && (
+          <RiskTrendChart assessments={filteredAssessments.length > 0 ? filteredAssessments : assessments} />
         )}
 
         {isLoading ? (


### PR DESCRIPTION
Fixes #457

## Description

Integrates an interactive time-series line chart directly above the Patient History table, giving clinicians a visual overview of how risk scores and metabolic vectors trend over time.

### Part 1 — Analytics Canvas Integration
- Added `RiskTrendChart` component using Recharts `LineChart`
- Positioned above the history table as the primary visual element on the page
- Chart data is sorted chronologically and memoized to prevent rendering lag
- Responsive canvas scales gracefully across all viewport sizes
- Shows a fallback message when fewer than 2 assessments exist

### Part 2 — Interactive Vector Toggles
- Four toggle chips above the chart: Risk Score, BMI, HbA1c, Blood Glucose
- Clicking a chip toggles the corresponding trend line on/off
- Each metric has a distinct color for easy identification

### Conditional Styling
- Risk Score dots are conditionally colored: red (HIGH ≥50%), amber (MODERATE ≥20%), green (LOW)
- Reference lines at 20% (Moderate threshold) and 50% (High threshold)
- Chart re-renders reactively when search or filter state changes

## Type of change
- [x] New feature

## Related issue
Fixes #457

## Screenshot
N/A — interactive line chart with metric toggles above the history table

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.