### PR TITLE
fix: rate limit auth verification routes

### DIFF
--- a/client/src/components/layout/AppLayout.tsx
+++ b/client/src/components/layout/AppLayout.tsx
@@ -16,6 +16,7 @@ interface AppLayoutProps {
 
 export function AppLayout({ children }: AppLayoutProps) {
   const [location, setLocation] = useLocation();
+  const { toast } = useToast();
   const [user, setUser] = useState<{ email: string; name?: string } | null>(null);
   const [checking, setChecking] = useState(true);
   const [networkError, setNetworkError] = useState(false);

--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -3,15 +3,12 @@ import RiskTrendChart from "@/components/RiskTrendChart";
 import { useToast } from "@/hooks/use-toast";
 import { useAssessments } from "@/hooks/use-assessments";
 import { format, isValid } from "date-fns";
-import { Loader2, Search, X, Activity, FileText, RotateCw, GitCompare, Download } from "lucide-react";
-import { Loader2, Search, Calendar, User, Activity, X, SlidersHorizontal } from "lucide-react";
+import { Loader2, Search, X, Activity, FileText, RotateCw, GitCompare, Download, Calendar, User, SlidersHorizontal } from "lucide-react";
 import { useState, useEffect } from "react";
 import StatusPill from "@/components/ui/StatusPill";
 import ConfidenceRange from "@/components/ui/ConfidenceRange";
 import { useLocation } from "wouter";
-import { advancedFilter } from "@/utils/search_filters";
 import { safeParseDate } from "@/utils/date_fix";
-import { useToast } from "@/hooks/use-toast";
 import {
   advancedFilter,
   hasActiveMetricFilters,

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useLocation } from "wouter";
 
 export default function LoginPage() {

--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { scryptSync, randomInt, randomBytes, timingSafeEqual } from "crypto";
+import { getOtpRateLimitKey } from "./auth";
 
 /**
  * Password hashing utilities (inlined from auth.ts for isolated testing).
@@ -54,5 +55,25 @@ describe("OTP generation", () => {
       expect(otp.length).toBe(6);
       expect(/^\d{6}$/.test(otp)).toBe(true);
     }
+  });
+});
+
+describe("OTP rate-limit keys", () => {
+  it("keys OTP attempts by normalized email", () => {
+    const key = getOtpRateLimitKey({
+      body: { email: "  Doctor@Example.COM " },
+      ip: "203.0.113.10",
+    });
+
+    expect(key).toBe("otp:doctor@example.com");
+  });
+
+  it("falls back to the client IP when email is missing", () => {
+    const key = getOtpRateLimitKey({
+      body: {},
+      ip: "203.0.113.10",
+    });
+
+    expect(key).toContain("203.0.113.10");
   });
 });

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,6 +1,6 @@
 import { Router, type Request, type Response, type NextFunction } from "express";
 import { randomInt, randomBytes, scryptSync, timingSafeEqual } from "crypto";
-import rateLimit from "express-rate-limit";
+import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { storage } from "./storage";
 import { getDb } from "./db";
 import { eq, and, gte } from "drizzle-orm";
@@ -57,9 +57,44 @@ interface PendingOtp {
  */
 const pendingOtps = new Map<string, PendingOtp>();
 
+function normalizeRateLimitEmail(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+/**
+ * Builds a stable OTP rate-limit key from the submitted email when present,
+ * falling back to the client IP for malformed or incomplete requests.
+ */
+export function getOtpRateLimitKey(req: Pick<Request, "body" | "ip">): string {
+  const email = normalizeRateLimitEmail(req.body?.email);
+
+  if (email) {
+    return `otp:${email}`;
+  }
+
+  return `otp:ip:${ipKeyGenerator(req.ip ?? "unknown")}`;
+}
+
 /**
  * Rate limiters for verification endpoints.
  */
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  limit: 10,
+  standardHeaders: "draft-8",
+  legacyHeaders: false,
+  message: { error: "Too many authentication attempts. Please try again later." },
+});
+
+const otpLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  limit: 5,
+  standardHeaders: "draft-8",
+  legacyHeaders: false,
+  keyGenerator: getOtpRateLimitKey,
+  message: { error: "Too many OTP verification attempts. Please try again later." },
+});
+
 const verifyEmailLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
   limit: 10,
@@ -105,7 +140,7 @@ export function createAuthRouter(): Router {
    * Validates registration fields, creates a new user account,
    * generates a verification OTP, and sends it to the user's email.
    */
-  router.post("/register", async (req: Request, res: Response) => {
+  router.post("/register", authLimiter, async (req: Request, res: Response) => {
     const { fullName, licenseNumber } = req.body || {};
     const email = (req.body?.email ?? "").trim().toLowerCase();
     const password = req.body?.password ?? "";
@@ -192,7 +227,7 @@ export function createAuthRouter(): Router {
    * POST /api/auth/login
    * Validates email/password and sends a verification OTP.
    */
-  router.post("/login", async (req: Request, res: Response) => {
+  router.post("/login", authLimiter, async (req: Request, res: Response) => {
     const rawEmail = req.body?.email ?? "";
     const email = rawEmail.trim().toLowerCase();
     const password = req.body?.password ?? "";
@@ -261,7 +296,7 @@ export function createAuthRouter(): Router {
    * POST /api/auth/verify-otp
    * Verifies the OTP sent after login/register and establishes a session.
    */
-  router.post("/verify-otp", async (req: Request, res: Response) => {
+  router.post("/verify-otp", otpLimiter, async (req: Request, res: Response) => {
     const { otp } = req.body || {};
     const email = (req.body?.email ?? "").trim().toLowerCase();
 
@@ -570,5 +605,3 @@ export async function requireVerified(req: Request, res: Response, next: NextFun
     return res.status(500).json({ message: "Failed to verify user status." });
   }
 }
-
-

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -78,8 +78,6 @@ export class DatabaseStorage implements IStorage {
           (assessments as any).confidenceInterval ?? (assessments as any).confidence_interval,
         modelConfidence:
           (assessments as any).modelConfidence ?? (assessments as any).model_confidence,
-        createdBy:
-          (assessments as any).createdBy ?? (assessments as any).created_by,
         createdAt:
           (assessments as any).createdAt ?? (assessments as any).created_at,
         createdBy:


### PR DESCRIPTION
## Summary
- add a 10 per 15 minute limiter to register and login routes
- add a stricter 5 per 15 minute OTP verification limiter keyed by normalized email, with IP fallback for malformed requests
- cover the OTP limiter keying behavior in auth unit tests
- remove a duplicate `createdBy` mapping that was blocking the existing TypeScript check

## Validation
- `npm run check`
- `npm test -- server/auth.test.ts` (7 passed)
- `git diff --check`

Fixes #492