### PR TITLE
fix(env): remove unused SECRET_KEY/JWT_SECRET, add missing SMTP_* vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,11 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/clinical_insight_engi
 
 # Authentication
 SESSION_SECRET=replace-with-a-long-random-session-secret
-SECRET_KEY=your-secret-key
-JWT_SECRET=your-jwt-secret
+
+# Email (SMTP) — optional, falls back to console logging if unset
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+EMAIL_FROM=noreply@clinicalinsight.dev
 
 # Elasticsearch
 ELASTICSEARCH_URL=http://localhost:9200


### PR DESCRIPTION
## Summary

Cleans up \.env.example\ by removing config keys that are never read and adding keys that are actively consumed but undocumented.

## Changes

1. **Remove** \SECRET_KEY\ and \JWT_SECRET\ (lines 12-13) — zero references in the codebase (\g\ confirms no \process.env.SECRET_KEY\ or \process.env.JWT_SECRET\)
2. **Add** \SMTP_HOST\, \SMTP_PORT\, \EMAIL_FROM\ — actively consumed by \server/email.ts\ for email delivery but missing from the example

## Testing
- \SECRET_KEY\ and \JWT_SECRET\ no longer appear in \.env.example\
- \SMTP_HOST\, \SMTP_PORT\, \EMAIL_FROM\ now documented
- \server/email.ts\ unchanged (var names match)

Closes #421