### PR TITLE
fix: standardize port to 5000 across docker-compose.yml and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Server
-PORT=3000
+PORT=5000
 
 # API
 API_URL=http://localhost:5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,10 +24,10 @@ services:
       dockerfile: Dockerfile
     container_name: clinical-insight-app
     ports:
-      - "3000:3000"
+      - "5000:5000"
     environment:
       NODE_ENV: development
-      PORT: 3000
+      PORT: 5000
       DATABASE_URL: postgresql://postgres:postgres@db:5432/clinical_insight_engine
       SESSION_SECRET: clinical-insight-engine-dev-secret
     volumes:


### PR DESCRIPTION
## Summary

Standardizes the application port to 5000 across all configuration surfaces to eliminate inconsistency.

## Problem

The app server (server/index.ts) defaults to PORT || "5000", but Docker Compose was hardcoded to 3000 and .env.example had PORT=3000 while API_URL=http://localhost:5000 - three conflicting signals.

## Changes

| File | Before | After |
|------|--------|-------|
| docker-compose.yml (port mapping) | 3000:3000 | 5000:5000 |
| docker-compose.yml (PORT env) | 3000 | 5000 |
| .env.example (PORT) | 3000 | 5000 |
| server/index.ts | "5000" (unchanged) | "5000" |

## Testing
- npm run dev binds on port 5000 (default, no change needed)
- docker-compose up now maps port 5000 instead of 3000
- API_URL in .env.example already pointed to 5000 - no change needed

Closes #418
