### PR TITLE
fix: add dark mode modifiers to Reload and Export buttons in History table

### DIFF
--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -515,14 +515,14 @@ export default function History() {
                         <div className="flex items-center gap-2">
                           <button
                             onClick={() => reloadToForm(assessment)}
-                            className="inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-semibold bg-white border border-slate-100 hover:shadow-sm focus:outline-none focus:ring-4 focus:ring-blue-100"
+                            className="inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-semibold bg-white dark:bg-slate-800 border border-slate-100 dark:border-slate-700 text-slate-900 dark:text-slate-100 hover:shadow-sm focus:outline-none focus:ring-4 focus:ring-blue-100 dark:focus:ring-blue-900"
                           >
                             <RotateCw className="w-4 h-4" />
                             Reload
                           </button>
                           <button
                             onClick={() => exportAsPdf(assessment)}
-                            className="inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-semibold bg-white border border-slate-100 hover:shadow-sm focus:outline-none focus:ring-4 focus:ring-blue-100"
+                            className="inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-semibold bg-white dark:bg-slate-800 border border-slate-100 dark:border-slate-700 text-slate-900 dark:text-slate-100 hover:shadow-sm focus:outline-none focus:ring-4 focus:ring-blue-100 dark:focus:ring-blue-900"
                           >
                             <FileText className="w-4 h-4" />
                             Export


### PR DESCRIPTION
Fixes #533

## Describe the bug
The Reload and Export action buttons in the Patient History table used hardcoded `bg-white` and no explicit text color class. In dark mode the buttons became invisible — the white background blended into the dark table row and the text had no contrast.

## Fix
Added Tailwind `dark:` modifiers to both buttons:
- `dark:bg-slate-800` — dark background instead of white
- `dark:border-slate-700` — visible border in dark theme
- `dark:text-slate-100` — high contrast text in dark mode
- `dark:focus:ring-blue-900` — visible focus ring in dark mode

## Type of change
- [x] Bug fix

## Related issue
Fixes #533

## Screenshot
N/A — dark mode visibility fix, buttons now readable in both themes

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.