### PR TITLE
fix(security): guard OTP logging in email service with environment check

### DIFF
--- a/server/email.test.ts
+++ b/server/email.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { sendVerificationCode } from "./email";
+
+describe("sendVerificationCode", () => {
+  let logSpy: any;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not log OTP in production mode", async () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      await sendVerificationCode("test@example.com", "123456");
+      const loggedOutput = logSpy.mock.calls.map((call: any) => call.join(" ")).join(" ");
+      expect(loggedOutput).not.toContain("EMAIL VERIFICATION");
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+
+  it("logs OTP in non-production mode", async () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+    try {
+      await sendVerificationCode("test@example.com", "123456");
+      const loggedOutput = logSpy.mock.calls.map((call: any) => call.join(" ")).join(" ");
+      expect(loggedOutput).toContain("123456");
+      expect(loggedOutput).toContain("EMAIL VERIFICATION");
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+});

--- a/server/email.ts
+++ b/server/email.ts
@@ -74,7 +74,9 @@ export async function sendVerificationCode(
   email: string,
   code: string,
 ): Promise<void> {
-  logDevOtp(email, code);
+  if (process.env.NODE_ENV !== "production") {
+    logDevOtp(email, code);
+  }
 
   await sendEmail({
     to: email,


### PR DESCRIPTION
## Description

This PR fixes a security issue where sensitive one-time verification codes (OTPs) were being logged unconditionally in all environments. We add an environment guard to ensure they are only printed to the console in development/testing environments.

## Related Issue

Closes #525

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- **Added Environment Guard:** Added a `process.env.NODE_ENV !== "production"` check before calling `logDevOtp` in the `sendVerificationCode` function within [server/email.ts](file:///d:/work/Clinical-Insight-Engine/server/email.ts).
- **Unit Tests:** Created a new test file [server/email.test.ts](file:///d:/work/Clinical-Insight-Engine/server/email.test.ts) to verify that OTPs are logged in development mode but kept out of console logs when `NODE_ENV=production`.

## Screenshots (if applicable)

N/A (Security/logging change)

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass (aside from pre-existing upstream failures on main)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
