### PR TITLE
fix(history): Handle missing assessment data in PDF export (#630)

### DIFF
--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -178,16 +178,33 @@ export default function History() {
     }
   }
 
-  function exportAsPdf(assessment: any) {
+  function handleExportPDF(assessment: any) {
+    if (!assessment) return;
+
     const patientName = assessment.patientName || "Unknown Patient";
-    const html = `<!doctype html><html><head><meta charset="utf-8"><title>Assessment ${assessment.id}</title><meta name="viewport" content="width=device-width,initial-scale=1"><style>body{font-family:system-ui, -apple-system, Segoe UI, Roboto, Arial; padding:24px; color:#0f172a} h1{font-size:20px} .kv{margin:6px 0} .pill{display:inline-block;padding:6px 10px;border-radius:999px;background:#f3f4f6;color:#111827;font-weight:700} table{width:100%;border-collapse:collapse;margin-top:12px} td{padding:6px;border-bottom:1px solid #e6e6e6}</style></head><body><h1>Assessment Summary</h1><p class="kv"><strong>Patient:</strong> ${patientName}</p><p class="kv"><strong>Date:</strong> ${new Date(assessment.createdAt).toLocaleString()}</p><p class="kv"><strong>Risk Score:</strong> ${Number(assessment.riskScore).toFixed(1)}%</p><p class="kv"><strong>Category:</strong> <span class="pill">${assessment.riskCategory}</span></p><h2 style="margin-top:18px;font-size:16px">Vitals & Inputs</h2><table><tbody><tr><td>Age</td><td>${assessment.age}</td></tr><tr><td>BMI</td><td>${assessment.bmi}</td></tr><tr><td>HbA1c</td><td>${assessment.hba1cLevel}%</td></tr><tr><td>Blood Glucose</td><td>${assessment.bloodGlucoseLevel}</td></tr><tr><td>Hypertension</td><td>${assessment.hypertension ? "Yes" : "No"}</td></tr><tr><td>Heart Disease</td><td>${assessment.heartDisease ? "Yes" : "No"}</td></tr><tr><td>Smoking</td><td>${assessment.smokingHistory}</td></tr></tbody></table><h2 style="margin-top:18px;font-size:16px">Top Factors</h2><ul>${(
+    const date = assessment.createdAt ? new Date(assessment.createdAt).toLocaleString() : "Unknown Date";
+    const age = assessment.age ?? "N/A";
+    const bmi = assessment.bmi ?? "N/A";
+    const hba1cLevel = assessment.hba1cLevel ?? "N/A";
+    const bloodGlucoseLevel = assessment.bloodGlucoseLevel ?? "N/A";
+    const hypertension = assessment.hypertension === true ? "Yes" : assessment.hypertension === false ? "No" : "N/A";
+    const heartDisease = assessment.heartDisease === true ? "Yes" : assessment.heartDisease === false ? "No" : "N/A";
+    const smokingHistory = assessment.smokingHistory || "N/A";
+    
+    const riskScore = assessment.riskScore
+      ? `${Number(assessment.riskScore).toFixed(1)}%`
+      : "N/A";
+      
+    const category = assessment.riskCategory || "Unknown";
+
+    const html = `<!doctype html><html><head><meta charset="utf-8"><title>Assessment ${assessment.id || 'Export'}</title><meta name="viewport" content="width=device-width,initial-scale=1"><style>body{font-family:system-ui, -apple-system, Segoe UI, Roboto, Arial; padding:24px; color:#0f172a} h1{font-size:20px} .kv{margin:6px 0} .pill{display:inline-block;padding:6px 10px;border-radius:999px;background:#f3f4f6;color:#111827;font-weight:700} table{width:100%;border-collapse:collapse;margin-top:12px} td{padding:6px;border-bottom:1px solid #e6e6e6}</style></head><body><h1>Assessment Summary</h1><p class="kv"><strong>Patient:</strong> ${patientName}</p><p class="kv"><strong>Date:</strong> ${date}</p><p class="kv"><strong>Risk Score:</strong> ${riskScore}</p><p class="kv"><strong>Category:</strong> <span class="pill">${category}</span></p><h2 style="margin-top:18px;font-size:16px">Vitals & Inputs</h2><table><tbody><tr><td>Age</td><td>${age}</td></tr><tr><td>BMI</td><td>${bmi}</td></tr><tr><td>HbA1c</td><td>${hba1cLevel}${hba1cLevel !== "N/A" ? "%" : ""}</td></tr><tr><td>Blood Glucose</td><td>${bloodGlucoseLevel}</td></tr><tr><td>Hypertension</td><td>${hypertension}</td></tr><tr><td>Heart Disease</td><td>${heartDisease}</td></tr><tr><td>Smoking</td><td>${smokingHistory}</td></tr></tbody></table><h2 style="margin-top:18px;font-size:16px">Top Factors</h2><ul>${(
       assessment.factors || []
     )
       .slice(0, 5)
-      .map((f: any) => `<li>${f.name} — ${f.description} (${f.impact})</li>`)
+      .map((f: any) => `<li>${f.name || 'Unknown'} — ${f.description || ''} (${f.impact || 'N/A'})</li>`)
       .join("")}</ul></body></html>`;
 
-    const w = window.open("", "_blank", "noopener,noreferrer");
+    const w = window.open("", "_blank");
     if (!w) {
       alert("Please allow popups to enable PDF export.");
       return;
@@ -578,7 +595,7 @@ export default function History() {
                             Reload
                           </button>
                           <button
-                            onClick={() => exportAsPdf(assessment)}
+                            onClick={() => handleExportPDF(assessment)}
                             className="inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-semibold bg-white dark:bg-slate-800 border border-slate-100 dark:border-slate-700 text-slate-900 dark:text-slate-100 hover:shadow-sm focus:outline-none focus:ring-4 focus:ring-blue-100 dark:focus:ring-blue-900"
                           >
                             <FileText className="w-4 h-4" />


### PR DESCRIPTION
## Description

This PR fixes an application crash that occurs when a user clicks the "Export" button from a patient row in the History page. The PDF generator was crashing and leaving a blank screen because it was attempting to access undefined properties when optional assessment data (like HbA1c or risk score) was missing, and the browser was blocking the window injection due to overly strict popup flags.

## Related Issue

Closes #630

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- Replaced the vulnerable `exportAsPdf` function with a robust `handleExportPDF` function.
- Added safe data fallbacks (e.g. `?? "N/A"`) for all clinical fields so that missing optional metrics do not break the PDF renderer.
- Removed the `noopener,noreferrer` flags from `window.open` which were causing modern browsers to block the script from injecting the PDF HTML into the new tab.
- Ensured the `onClick` handler explicitly passes the correct row context.

## Screenshots (if applicable)

**Before:**
<img width="2880" height="1734" alt="patient-histor(before)" src="https://github.com/user-attachments/assets/7ded1994-9fdc-4694-aeb3-ae5a6a96764f" />


<img width="2880" height="1652" alt="export-page(before)" src="https://github.com/user-attachments/assets/d709f6ea-c558-4f74-9639-ec8dca70eacd" />


**After:**
<img width="2880" height="1734" alt="patient-histor(after)" src="https://github.com/user-attachments/assets/40556b55-dc8a-4507-9a8b-7bda3e9f3365" />

<img width="2880" height="1556" alt="export-(after fix)" src="https://github.com/user-attachments/assets/26031950-2474-4be3-a94a-326656133353" />


## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors