### PR TITLE
fix: remove misleading fake stats from calculateClinicalFallback (#574)

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -229,8 +229,6 @@ interface PredictionResult {
   }>;
   clinicianAdvice: string[];
   patientAdvice: string[];
-  confidenceInterval?: string;
-  modelConfidence?: number;
 }
 
 function calculateClinicalFallback(input: unknown): PredictionResult {
@@ -378,8 +376,6 @@ function calculateClinicalFallback(input: unknown): PredictionResult {
           : [
             "Continue maintaining a healthy, balanced lifestyle and regular physical activity.",
           ],
-    confidenceInterval: `${Math.max(1, riskScore - 5)}% - ${Math.min(99, riskScore + 5)}%`,
-    modelConfidence: 0.95,
   };
 }
 
@@ -530,6 +526,7 @@ export async function registerRoutes(
           (isFallback
             ? " (Generated via fallback rule-based clinical support model due to system unavailability)"
             : "");
+        prediction.isFallback = isFallback;
 
         const assessment = await storage.createAssessment({
           ...input,

--- a/shared/routes.ts
+++ b/shared/routes.ts
@@ -114,6 +114,7 @@ export type AssessmentResponse = z.infer<typeof api.assessments.create.responses
     confidenceInterval?: string | null;
     modelConfidence?: number | null;
     disclaimer?: string;
+    isFallback?: boolean;
   };
 };
 export type AssessmentsListResponse = z.infer<typeof api.assessments.list.responses[200]>;


### PR DESCRIPTION
## Description

Fixes `calculateClinicalFallback` returning statistically meaningless `confidenceInterval: riskScore ± 5` and hardcoded `modelConfidence: 0.95` that appear identical to real covariance-matrix-based ML statistics, misleading clinicians viewing the report.

## Related Issue

Closes #574

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Removed `confidenceInterval` and `modelConfidence` from the `PredictionResult` interface in `server/routes.ts`
- Removed `confidenceInterval: riskScore ± 5` and hardcoded `modelConfidence: 0.95` from `calculateClinicalFallback` return value — these fields are now absent and correctly serialized as `null` in the JSON response
- Added `prediction.isFallback = isFallback` boolean to the prediction object so the frontend can conditionally surface the disclaimer prominently in the UI rather than hiding it in a JSON field
- Added `isFallback?: boolean` to the `AssessmentResponse` type in `shared/routes.ts`

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors