### PR TITLE
fix: log temp file cleanup failures instead of silently swallowing

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -462,8 +462,8 @@ export async function registerRoutes(
       } finally {
         try {
           await unlink(tempFilePath);
-        } catch {
-          // ignore
+        } catch (e) {
+          console.warn("Failed to clean up temp file (preview):", tempFilePath, e);
         }
       }
     }
@@ -560,8 +560,8 @@ export async function registerRoutes(
         if (tempFilePath) {
           try {
             await unlink(tempFilePath);
-          } catch {
-            // ignore
+          } catch (e) {
+            console.warn("Failed to clean up temp file (create):", tempFilePath, e);
           }
         }
         if (requestFingerprint) {


### PR DESCRIPTION
## Description

Fixes temp files containing patient PII (age, BMI, HbA1c, blood glucose, smoking history, etc.) being silently left on disk when `unlink` fails in both the preview and create assessment endpoints.

## Related Issue

Closes #575

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Preview endpoint (`server/routes.ts`): replaced silent `catch { // ignore }` with `catch (e) { console.warn("Failed to clean up temp file (preview):", tempFile, e); }`
- Create endpoint (`server/routes.ts`): replaced silent `catch { // ignore }` with `catch (e) { console.warn("Failed to clean up temp file (create):", tempFile, e); }`

Temp file deletion failures are now logged so operators can detect, investigate, and remediate PII data leakage on disk.

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors