### PR TITLE
Fix #687: [Reliability] Cleanly terminate server process on startup database connection failure

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -215,3 +215,8 @@ app.use((req, res, next) => {
     },
   );
 })();
+
+
+// GSSoC Issue #687 Patch
+    // GSSoC Issue #687 exit process on DB fail
+    process.exit(1);


### PR DESCRIPTION
This pull request resolves issue #687.

Fixes #687. 