### PR TITLE
fix: correct boolean operator in advancedFilter 'no' comorbidity search

### DIFF
--- a/client/src/utils/search_filters.test.ts
+++ b/client/src/utils/search_filters.test.ts
@@ -82,3 +82,31 @@ describe("advancedFilter metric triage", () => {
     ).toBe(false);
   });
 });
+
+describe("advancedFilter — hypertension/heartDisease yes/no search", () => {
+  const noConditions = assessment({ id: 1, hypertension: false, heartDisease: false });
+  const hypertensionOnly = assessment({ id: 2, hypertension: true, heartDisease: false });
+  const heartDiseaseOnly = assessment({ id: 3, hypertension: false, heartDisease: true });
+  const bothConditions = assessment({ id: 4, hypertension: true, heartDisease: true });
+  const records = [noConditions, hypertensionOnly, heartDiseaseOnly, bothConditions];
+
+  it("'yes' matches patients with at least one comorbidity", () => {
+    const matches = advancedFilter(records, "yes");
+    expect(matches.map((a) => a.id)).toEqual([2, 3, 4]);
+  });
+
+  it("'no' matches only patients with NEITHER hypertension NOR heart disease", () => {
+    const matches = advancedFilter(records, "no");
+    expect(matches.map((a) => a.id)).toEqual([1]);
+  });
+
+  it("'no' does NOT match a patient with hypertension but no heart disease", () => {
+    const matches = advancedFilter([hypertensionOnly], "no");
+    expect(matches).toHaveLength(0);
+  });
+
+  it("'no' does NOT match a patient with heart disease but no hypertension", () => {
+    const matches = advancedFilter([heartDiseaseOnly], "no");
+    expect(matches).toHaveLength(0);
+  });
+});

--- a/client/src/utils/search_filters.ts
+++ b/client/src/utils/search_filters.ts
@@ -58,7 +58,7 @@ export function advancedFilter(
       String(a.bloodGlucoseLevel).includes(term) ||
       String(a.riskScore).includes(term) ||
       (term === "yes" && (a.hypertension || a.heartDisease)) ||
-      (term === "no" && (!a.hypertension || !a.heartDisease))
+      (term === "no" && (!a.hypertension && !a.heartDisease))
     )
   );
 }


### PR DESCRIPTION
## Description

Fixes a logic error in `advancedFilter()` where the `"no"` search term used `||` (OR) instead of `&&` (AND) when checking whether a patient has neither hypertension nor heart disease.
 
**Before (broken):**
```ts
(term === "no" && (!a.hypertension || !a.heartDisease))
```
A patient with `hypertension=true` and `heartDisease=false` would pass this filter because `!false = true`, so the `||` evaluates to `true`. This means hypertensive patients were incorrectly shown when searching for `"no"`.

**After (correct):**
```ts
(term === "no" && (!a.hypertension && !a.heartDisease))
```
Only patients with **neither** condition now match.

## Related Issue

Closes #719

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Test addition or update

## Changes Made

- Fixed `||` → `&&` on line 61 of `client/src/utils/search_filters.ts`
- Added 4 regression tests in `search_filters.test.ts` covering:
  - `"yes"` matches patients with at least one comorbidity
  - `"no"` matches **only** patients with neither condition
  - `"no"` does **not** match hypertension-only patients
  - `"no"` does **not** match heart-disease-only patients

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

```
✓ client/src/utils/search_filters.test.ts (9 tests) 2ms
Test Files  1 passed (1)
     Tests  9 passed (9)
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors