### PR TITLE
fix(security): remove raw error.message from ErrorBoundary UI

### DIFF
--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -41,9 +41,6 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
             <p className="mb-6 text-muted-foreground">
               An unexpected error occurred. Please try refreshing the page.
             </p>
-            <pre className="mb-6 max-h-32 overflow-auto rounded-md bg-muted p-4 text-left text-sm text-muted-foreground">
-              {this.state.error?.message}
-            </pre>
             <button
               onClick={() => {
                 this.setState({ hasError: false, error: null });


### PR DESCRIPTION
## Description

The `ErrorBoundary` component was rendering `this.state.error?.message` inside a visible `<pre>` tag. Depending on what caused the render crash, this message can contain internal file paths, module names, database connection details, or stack fragments — all useful information for attackers.

The `componentDidCatch` method already logs the full error (including stack trace) to the browser console for developers. The user-visible surface only needs a generic message.

**Before:**
```tsx
<pre className="..."> 
  {this.state.error?.message}
</pre>
```

**After:** The `<pre>` block is removed entirely. The generic message above it is sufficient for users.

## Related Issue

Closes #723

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Removed the `<pre>{this.state.error?.message}</pre>` block from the error boundary fallback UI
- The `componentDidCatch` logging is unchanged — full error details remain available in the browser console

## Testing

- [x] I have tested these changes locally
- [x] TypeScript compilation passes (`npm run check`)
- [x] Verified that triggering a render error shows the generic message without any raw error text

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors