### PR TITLE
fix(cleanup): replace Replit debug stub in main.py with real entry point

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,19 @@
-def main():
-    print("Hello from repl-nix-workspace!")
+"""
+Entry point for the Clinical Insight Engine Python ML pipeline.
+
+For training and prediction, use analyze.py directly:
+  python analyze.py train
+  python analyze.py predict_file <path_to_input.json>
+"""
+
+import sys
+from analyze import save_pretrained_model
+
+
+def main() -> None:
+    print("Training and saving ML model...")
+    success = save_pretrained_model()
+    sys.exit(0 if success else 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

`main.py` contained a leftover Replit scaffolding stub whose only action was printing `"Hello from repl-nix-workspace!"`. Running `python main.py` produced confusing output and performed no useful work, and the platform-specific string suggested the file was never properly initialized for this project.

**Before:** 
```python
def main():
    print("Hello from repl-nix-workspace!")
```

**After:** Replaced with a real entry point that trains and serializes the ML model, matching how the Node.js server warms up the pipeline on startup:
```python
def main() -> None:
    print("Training and saving ML model...")
    success = save_pretrained_model()
    sys.exit(0 if success else 1)
```

Also added a module docstring pointing contributors to `analyze.py` for the full CLI.

## Related Issue

Closes #727

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ♻️ Refactor (no functional changes to the rest of the system)

## Changes Made

- Replaced the no-op `print("Hello from repl-nix-workspace!")` stub with a call to `save_pretrained_model()` from `analyze.py`
- Added proper `sys.exit()` based on success/failure
- Added a module-level docstring explaining the CLI usage

## Testing

- [x] I have tested these changes locally
- [x] Python syntax validated: `python3 -m py_compile main.py`
- [x] Confirmed `analyze.py` exports `save_pretrained_model` (no import errors)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors