### PR TITLE
fix: populate updatedAt when marking user email as verified

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -528,7 +528,7 @@ export function createAuthRouter(): Router {
 
       await db
         .update(users)
-        .set({ emailVerified: true, emailVerifiedAt: new Date() })
+        .set({ emailVerified: true, emailVerifiedAt: new Date(), updatedAt: new Date() })
         .where(eq(users.id, user.id));
 
       await establishAuthenticatedSession(req, { id: user.id, email: user.email, name: user.fullName, role: user.role ?? "provider" });


### PR DESCRIPTION
## Description

The `users` table has an `updated_at` column, but PostgreSQL does not automatically update it on `UPDATE` — it only receives a value at `INSERT` time via `defaultNow()`. The email verification query updated `emailVerified` and `emailVerifiedAt` but never touched `updatedAt`, leaving it frozen at the original account creation timestamp for the lifetime of the record.

**Before:**
```ts
await db.update(users) 
  .set({ emailVerified: true, emailVerifiedAt: new Date() })
  .where(eq(users.id, user.id));
```

**After:**
```ts
await db.update(users)
  .set({ emailVerified: true, emailVerifiedAt: new Date(), updatedAt: new Date() })
  .where(eq(users.id, user.id));
```

## Related Issue

Closes #726

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added `updatedAt: new Date()` to the email verification `UPDATE` in `server/auth.ts`

## Testing

- [x] I have tested these changes locally
- [x] TypeScript compilation passes (`npm run check`)
- [x] Verified that after email verification, `SELECT updated_at FROM users` returns the verification timestamp rather than the creation timestamp

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors