### PR TITLE
fix(security): replace hardcoded OAuth2 identity stub with explicit error

### DIFF
--- a/server/auth/oauth2.ts
+++ b/server/auth/oauth2.ts
@@ -23,8 +23,12 @@ if (
         clientSecret: OAUTH2_CLIENT_SECRET,
         callbackURL: OAUTH2_CALLBACK_URL,
       },
-      (accessToken: string, refreshToken: string, profile: any, cb: any) => {
-        return cb(null, { id: "clinician-id", profile });
+      (_accessToken: string, _refreshToken: string, _profile: any, cb: any) => {
+        // OAuth2 user lookup is not yet implemented.
+        // Do NOT replace this with a hardcoded identity — every OAuth2 user would
+        // share the same account and see all other users' patient records.
+        // Implement a real DB lookup (e.g. by profile.emails[0].value) before enabling.
+        return cb(new Error("OAuth2 authentication is not yet configured for this application."));
       }
     )
   );


### PR DESCRIPTION
## Description
 
The OAuth2 verification callback in `server/auth/oauth2.ts` returned `{ id: "clinician-id" }` for every authenticated user — a hardcoded stub that was never replaced with a real user lookup.

**The security risk:** If anyone set the `OAUTH2_*` environment variables and imported this module, every OAuth2 login would be mapped to the same hardcoded identity. All users would share one account and see each other's patient records.

**Fix:** Replace the stub `cb(null, { id: "clinician-id" })` with `cb(new Error(...))` so the strategy fails loudly and safely. Added a comment explicitly warning against re-introducing a hardcoded identity and describing what a correct implementation must do.

**Before:**
```ts
(accessToken, refreshToken, profile, cb) => {
  return cb(null, { id: "clinician-id", profile }); // ← all users get the same account
}
```

**After:**
```ts
(_accessToken, _refreshToken, _profile, cb) => {
  // OAuth2 user lookup is not yet implemented.
  // Do NOT replace this with a hardcoded identity...
  return cb(new Error("OAuth2 authentication is not yet configured for this application."));
}
```

## Related Issue

Closes #722

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Replaced the hardcoded `{ id: "clinician-id" }` callback with an explicit error
- Added an explanatory comment describing the required implementation and the specific danger of hardcoding identity

## Testing

- [x] TypeScript compilation passes (`npm run check`)
- [x] The module is currently not imported anywhere, so no runtime behavior changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors