### PR TITLE
fix(#494): replace import.meta.dirname with fileURLToPath for Node 20 compat

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,12 +1,14 @@
 import { type Express } from "express";
 import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
+import { fileURLToPath } from "url";
 import viteConfig from "../vite.config";
 import fs from "fs";
 import path from "path";
 import { nanoid } from "nanoid";
 
 const viteLogger = createLogger();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export async function setupVite(server: Server, app: Express) {
   const serverOptions = {
@@ -35,7 +37,7 @@ export async function setupVite(server: Server, app: Express) {
 
     try {
       const clientTemplate = path.resolve(
-        import.meta.dirname,
+        __dirname,
         "..",
         "client",
         "index.html",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,10 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
+import { fileURLToPath } from "url";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [
@@ -23,14 +26,14 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(import.meta.dirname, "client", "src"),
-      "@shared": path.resolve(import.meta.dirname, "shared"),
-      "@assets": path.resolve(import.meta.dirname, "attached_assets"),
+      "@": path.resolve(__dirname, "client", "src"),
+      "@shared": path.resolve(__dirname, "shared"),
+      "@assets": path.resolve(__dirname, "attached_assets"),
     },
   },
-  root: path.resolve(import.meta.dirname, "client"),
+  root: path.resolve(__dirname, "client"),
   build: {
-    outDir: path.resolve(import.meta.dirname, "dist/public"),
+    outDir: path.resolve(__dirname, "dist/public"),
     emptyOutDir: true,
   },
   server: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from "vitest/config";
 import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   test: {
@@ -9,8 +12,8 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@": path.resolve(import.meta.dirname, "client", "src"),
-      "@shared": path.resolve(import.meta.dirname, "shared"),
+      "@": path.resolve(__dirname, "client", "src"),
+      "@shared": path.resolve(__dirname, "shared"),
     },
   },
 });


### PR DESCRIPTION
## Description

`import.meta.dirname` requires Node.js ≥21.2, but `.nvmrc` specifies v20 and all CI workflows use `node-version-file: .nvmrc`. Three files used it, causing `TypeError: import.meta.dirname is undefined` on Node 20.

Replaced all 8 occurrences with the cross-version compatible pattern:
`const __dirname = path.dirname(fileURLToPath(import.meta.url))` — works on Node 16+.

## Related Issue

Closes #494

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`vitest.config.ts`** (2 occurrences): Added `fileURLToPath` import + `__dirname` — replaced both `import.meta.dirname` references.
- **`vite.config.ts`** (5 occurrences): Added `fileURLToPath` import + `__dirname` — replaced all 5 references (aliases, root, outDir).
- **`server/vite.ts`** (1 occurrence): Added `fileURLToPath` import + `__dirname` — replaced the `client/index.html` path resolution.

## Screenshots (if applicable)

N/A — config-only change

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass (87/88 pass; 1 pre-existing upstream failure)
- [x] TypeScript compilation succeeds (same 4 pre-existing `tokenValidator.ts` errors only)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors