### PR TITLE
fix(assessments): fix pino logger error signatures, use named rateLim…

### DIFF
--- a/server/routes/assessments.routes.ts
+++ b/server/routes/assessments.routes.ts
@@ -1,7 +1,7 @@
 import { logger } from "../logger";
 import { Router } from "express";
 import { z } from "zod";
-import rateLimit from "express-rate-limit";
+import { rateLimit } from "express-rate-limit";
 import { requireAuth, requireVerified } from "../auth";
 import { api } from "@shared/routes";
 import { storage } from "../storage";
@@ -228,7 +228,7 @@ assessmentsRouter.get(
 
       return res.json(results);
     } catch (err) {
-      logger.error("Assessment search error:", err);
+      logger.error({ err }, "Assessment search error:");
       const { statusCode, message } = sanitizeDatabaseError(err);
       return res.status(statusCode).json({ message });
     }
@@ -272,7 +272,7 @@ assessmentsRouter.get(
       logAccessAttempt((user as any).id, "Assessment", id, true, "Authorized access");
       return res.json(assessment);
     } catch (err) {
-      logger.error("Assessment fetch error:", err);
+      logger.error({ err }, "Assessment fetch error:");
       const { statusCode, message } = sanitizeDatabaseError(err);
       return res.status(statusCode).json({ message });
     }

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -88,6 +88,7 @@ function createAuthenticatedApp() {
       id: "test-user-id",
       email: "test@example.com",
       name: "Test User",
+      emailVerified: true,
     };
     next();
   });


### PR DESCRIPTION

## Description
Refactors catch-block logging in assessments search and fetch routes to use logger.error({ err }, "msg").
Fixes default import of rateLimit to named import { rateLimit } to align with the rest of the application.
Adds emailVerified: true to the mocked test user session in the routes unit tests to prevent failing tests with a 403 status.

## Related Issue

Closes #770 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

<!-- List the key changes made in this PR -->

- 
- 
- 

## Screenshots (if applicable)

<!-- Add before/after screenshots for UI changes -->

## Testing

- [ ] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [ ] All existing tests pass

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [ ] My changes generate no new warnings or errors