### PR TITLE
fix(auth): fix pino logger error signatures for forgot and reset pass…

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -640,7 +640,7 @@ export function createAuthRouter(): Router {
 
       return res.json({ success: true, message: "If an account exists, a reset link has been sent." });
     } catch (err) {
-      logger.error("Forgot password error:", err);
+      logger.error({ err }, "Forgot password error:");
       return res.status(500).json({ message: "Failed to process request." });
     }
   });
@@ -686,7 +686,7 @@ export function createAuthRouter(): Router {
 
       return res.json({ success: true, message: "Password has been reset successfully." });
     } catch (err) {
-      logger.error("Reset password error:", err);
+      logger.error({ err }, "Reset password error:");
       return res.status(500).json({ message: "Failed to reset password." });
     }
   });


### PR DESCRIPTION

## Description
Aligns logging calls in forgot and reset password endpoints to conform to pino's overload: logger.error({ err }, "msg").

## Related Issue

Closes #773

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

<!-- List the key changes made in this PR -->

- 
- 
- 

## Screenshots (if applicable)

<!-- Add before/after screenshots for UI changes -->

## Testing

- [ ] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [ ] All existing tests pass

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [ ] My changes generate no new warnings or errors