### PR TITLE
fix(queue): cast redisConnection as any for Queue and Worker initiali…

### DIFF
--- a/server/queue.ts
+++ b/server/queue.ts
@@ -33,7 +33,7 @@ export const redisConnection = new IORedis(process.env.REDIS_URL || "redis://loc
 });
 
 export const assessmentQueue = new Queue("assessmentQueue", {
-  connection: redisConnection,
+  connection: redisConnection as any,
 });
 
 const execFileAsync = promisify(execFile);
@@ -89,7 +89,7 @@ export const assessmentWorker = new Worker(
     }
   },
   {
-    connection: redisConnection,
+    connection: redisConnection as any,
     concurrency: 4,
   }
 );


### PR DESCRIPTION

## Description
Casts redisConnection as any in Queue and Worker constructors.
Solves compile errors due to incompatible connector class typing structures in ioredis.

## Related Issue

Closes #774 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

<!-- List the key changes made in this PR -->

- 
- 
- 

## Screenshots (if applicable)

<!-- Add before/after screenshots for UI changes -->

## Testing

- [ ] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [ ] All existing tests pass

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [ ] My changes generate no new warnings or errors