### PR TITLE
fix(queue): destructure userId from job data in assessment worker

### DIFF
--- a/server/queue.ts
+++ b/server/queue.ts
@@ -41,7 +41,7 @@ const execFileAsync = promisify(execFile);
 export const assessmentWorker = new Worker(
   "assessmentQueue",
   async (job: Job) => {
-    const { input, isPreview } = job.data;
+    const { input, isPreview, userId } = job.data;
     const tempFile = path.join(os.tmpdir(), `${randomUUID()}.json`);
 
     try {


### PR DESCRIPTION
## Description
Destructures userId from job.data at the start of the assessmentWorker job processor.
Ensures the createdBy field is populated with the correct email/ID of the requesting user.

## Related Issue

Closes #776 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

<!-- List the key changes made in this PR -->

- 
- 
- 

## Screenshots (if applicable)

<!-- Add before/after screenshots for UI changes -->

## Testing

- [ ] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [ ] All existing tests pass

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [ ] My changes generate no new warnings or errors