### PR TITLE
fix(server): remove rogue process.exit(1) placed outside async IIFE that crashed server on startup

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -262,8 +262,3 @@ app.use((req, res, next) => {
   process.on("SIGTERM", () => shutdown("SIGTERM"));
   process.on("SIGINT", () => shutdown("SIGINT"));
 })();
-
-
-// GSSoC Issue #687 Patch
-    // GSSoC Issue #687 exit process on DB fail
-    process.exit(1);


### PR DESCRIPTION

## Description

A `process.exit(1)` call was placed **outside** the async IIFE that contains all server startup logic (DB connection, ML warmup, route registration, `app.listen()`). When Node.js evaluates the module, it invokes the IIFE (returns a Promise), then immediately executes `process.exit(1)` — killing the process before the async startup completes. The server never binds to its port and never serves requests.

The comment references "GSSoC Issue #687 Patch" but the IIFE already handles:
- Database startup failures (line ~191: `process.exit(1)`)
- Graceful shutdown on SIGTERM/SIGINT (shutdown() with `process.exit(0)`)

This rogue line was a duplicate accidentally placed outside the closure.

## Fix

Removed the rogue `process.exit(1)` and its surrounding GSSoC #687 comments at the module top level (after the IIFE).

## Changes

- `server/index.ts:266-269` — removed rogue `process.exit(1)` outside async IIFE

Closes #748