### PR TITLE
fix(server): fix ReferenceError in temp file cleanup from variable name mismatch

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -416,19 +416,19 @@ export async function registerRoutes(
     previewLimiter,
     async (req, res) => {
       const input = api.assessments.preview.input.parse(req.body);
-      const tempFile = path.join(
+      const tempFilePath = path.join(
         os.tmpdir(),
         `${randomUUID()}.json`
       );
 
       try {
-        await writeFile(tempFile, JSON.stringify(input));
+        await writeFile(tempFilePath, JSON.stringify(input));
 
         let prediction;
         try {
           const { stdout, stderr } = await execFileAsync(
             getPythonExecutable(),
-            [analyzePyPath, "predict_file", tempFile],
+            [analyzePyPath, "predict_file", tempFilePath],
             {
               timeout: 30000
             }


### PR DESCRIPTION

## Description

The assessment preview handler declares a variable `tempFile` but the `finally` cleanup block references `tempFilePath` (never declared in this scope). Every successful assessment preview throws a `ReferenceError` after the response is already sent to the client. The temp file containing patient data is never deleted, leaving PII on disk.

## Root Cause

The variable is declared as `const tempFile = path.join(...)` but the `finally` block uses `await unlink(tempFilePath)` — a different identifier that is never declared in this scope.

## Fix

Renamed the declaration from `tempFile` to `tempFilePath` to match the cleanup code.

## Changes

- `server/routes.ts:419,425,431` — renamed `tempFile` → `tempFilePath` in the preview handler

Closes #749