### PR TITLE
fix(ml): fix ValueError from wrong tuple count in CSV error path

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -106,7 +106,7 @@ def train_model_pipeline():
         df = read_csv_safely(DATA_FILE)
     except SafeCSVError as e:
         print(f"Error loading dataset: {e}", file=sys.stderr)
-        return None, None, None
+        return None, None, None, None
     
     # Check for missing values and unrealistic zeros
     clinical_cols = ['bmi', 'HbA1c_level', 'blood_glucose_level']


### PR DESCRIPTION
## Description

When `read_csv_safely()` raises a `SafeCSVError` (malformed CSV, encoding issue, etc.), the handler returns a 3-tuple `(None, None, None)` instead of the expected 4-tuple `(None, None, None, None)`. The caller's tuple unpacking `model, scaler, features, cov_beta = train_model_pipeline()` then throws a cryptic `ValueError: not enough values to unpack` — completely masking the original descriptive error about the CSV format issue.

## Fix

Changed the `SafeCSVError` error path to return 4 values, consistent with the missing-file path and the successful return path.

## Changes

- `analyze.py:109` — changed `return None, None, None` → `return None, None, None, None`

Closes #750