### PR TITLE
fix: patch SQL injection vulnerability in patient name search (Issue …

### DIFF
--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -1,5 +1,5 @@
 import { AppLayout } from "@/components/layout/AppLayout";
-import { useAssessments } from "@/hooks/use-assessments";
+import { useAssessments, usePatientAssessments, useClearPatientCache } from "@/hooks/use-assessments";
 import {
   format,
   isValid,
@@ -17,6 +17,7 @@ import {
   X,
   ChevronLeft,
   ChevronRight,
+  ShieldAlert,
 } from "lucide-react";
 import { useState, useEffect, useRef, useMemo } from "react";
 import StatusPill from "@/components/ui/StatusPill";
@@ -24,6 +25,7 @@ import ConfidenceRange from "@/components/ui/ConfidenceRange";
 import { FileText, RotateCw } from "lucide-react";
 import { useLocation } from "wouter";
 import { advancedFilter } from "@/utils/search_filters";
+import { validateSearchInput } from "@/validation/filterValidation";
 
 function HighlightText({ text, search }: { text: string; search: string }) {
   if (!search.trim()) return <>{text}</>;
@@ -60,6 +62,8 @@ export default function History() {
   const { data: infiniteData, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } = useAssessments();
   const assessments = infiniteData ? infiniteData.pages.flatMap((page) => page.data) : [];
   const [searchTerm, setSearchTerm] = useState("");
+  // Security (Issue #743): track if the last input was rejected so we can show a warning.
+  const [searchRejected, setSearchRejected] = useState(false);
   const [sortBy, setSortBy] = useState<string>("date-desc");
 
   // Date filter state
@@ -336,9 +340,37 @@ export default function History() {
                 type="text"
                 placeholder="Search history..."
                 value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                className="pl-10 pr-10 py-2.5 rounded-xl border border-border bg-card focus:outline-none focus:border-blue-600 focus:ring-4 focus:ring-blue-600/20 transition-all w-full sm:w-64"
+                onChange={(e) => {
+                  const raw = e.target.value;
+                  // FIX for Issue #743: validate and sanitize input before storing in
+                  // state. SQL injection patterns (e.g. `' OR 1=1 --`) are rejected
+                  // here at the client layer. The server independently validates via
+                  // Drizzle ORM parameterized queries + Zod schema (defence in depth).
+                  const safe = validateSearchInput(raw, () => {
+                    setSearchRejected(true);
+                    // Auto-clear the warning after 3 seconds
+                    setTimeout(() => setSearchRejected(false), 3000);
+                  });
+                  setSearchTerm(safe);
+                }}
+                className={`pl-10 pr-10 py-2.5 rounded-xl border bg-card focus:outline-none focus:ring-4 transition-all w-full sm:w-64 ${
+                  searchRejected
+                    ? "border-red-400 focus:border-red-500 focus:ring-red-100 dark:focus:ring-red-900/30"
+                    : "border-border focus:border-blue-600 focus:ring-blue-600/20"
+                }`}
+                aria-invalid={searchRejected}
+                aria-describedby={searchRejected ? "search-security-warning" : undefined}
               />
+              {searchRejected && (
+                <div
+                  id="search-security-warning"
+                  role="alert"
+                  className="absolute top-full mt-1.5 left-0 z-10 flex items-center gap-1.5 rounded-lg border border-red-200 bg-red-50 dark:bg-red-950/40 dark:border-red-800 px-3 py-1.5 text-xs font-semibold text-red-600 dark:text-red-400 shadow-sm"
+                >
+                  <ShieldAlert className="w-3.5 h-3.5 shrink-0" />
+                  Invalid search pattern detected and blocked.
+                </div>
+              )}
               {searchTerm && (
                 <button
                   type="button"

--- a/client/src/validation/filterValidation.test.ts
+++ b/client/src/validation/filterValidation.test.ts
@@ -1,0 +1,157 @@
+/**
+ * filterValidation.test.ts
+ *
+ * Unit tests for the client-side SQL injection and XSS validation utilities.
+ * These tests verify the fix for Issue #743 (SQL Injection Vulnerability in Patient Name Search).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  validateFilterInput,
+  validateSearchInput,
+  detectClientSqlInjection,
+} from "./filterValidation";
+
+// ---------------------------------------------------------------------------
+// detectClientSqlInjection
+// ---------------------------------------------------------------------------
+describe("detectClientSqlInjection", () => {
+  it("returns null for a clean patient name", () => {
+    expect(detectClientSqlInjection("John Doe")).toBeNull();
+    expect(detectClientSqlInjection("O'Brien")).toBeNull(); // apostrophe in name is fine
+    expect(detectClientSqlInjection("Mary-Jane")).toBeNull();
+  });
+
+  it("detects OR 1=1 (the exact payload from Issue #743)", () => {
+    expect(detectClientSqlInjection("' OR 1=1 --")).not.toBeNull();
+    expect(detectClientSqlInjection("OR 1=1")).not.toBeNull();
+    expect(detectClientSqlInjection("1 OR 1=1")).not.toBeNull();
+  });
+
+  it("detects SQL line comment (--)", () => {
+    // Fix for Issue #743: the old pattern /--\\s*$/m missed trailing spaces
+    expect(detectClientSqlInjection("admin'--")).not.toBeNull();
+    expect(detectClientSqlInjection("' OR 1=1 -- ")).not.toBeNull(); // trailing space after --
+    expect(detectClientSqlInjection("test--")).not.toBeNull();
+  });
+
+  it("detects UNION SELECT", () => {
+    expect(detectClientSqlInjection("UNION SELECT * FROM users")).not.toBeNull();
+    expect(detectClientSqlInjection("UNION ALL SELECT password FROM users")).not.toBeNull();
+  });
+
+  it("detects DROP TABLE", () => {
+    expect(detectClientSqlInjection("; DROP TABLE assessments")).not.toBeNull();
+    expect(detectClientSqlInjection("x; DELETE FROM users")).not.toBeNull();
+  });
+
+  it("detects block comment injection", () => {
+    expect(detectClientSqlInjection("admin'/*comment*/OR'1'='1")).not.toBeNull();
+  });
+
+  it("detects SELECT FROM", () => {
+    expect(detectClientSqlInjection("SELECT * FROM patients")).not.toBeNull();
+  });
+
+  it("detects time-based blind injection", () => {
+    expect(detectClientSqlInjection("'; SLEEP(5)--")).not.toBeNull();
+    expect(detectClientSqlInjection("1; WAITFOR DELAY '0:0:5'--")).not.toBeNull();
+  });
+
+  it("detects schema enumeration", () => {
+    expect(detectClientSqlInjection("INFORMATION_SCHEMA.tables")).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateSearchInput
+// ---------------------------------------------------------------------------
+describe("validateSearchInput", () => {
+  it("returns the trimmed input for safe patient names", () => {
+    expect(validateSearchInput("Jane Smith")).toBe("Jane Smith");
+    expect(validateSearchInput("  John Doe  ")).toBe("John Doe");
+    expect(validateSearchInput("O'Brien")).toBe("O'Brien");
+  });
+
+  it("returns empty string for null or undefined", () => {
+    expect(validateSearchInput(null)).toBe("");
+    expect(validateSearchInput(undefined)).toBe("");
+    expect(validateSearchInput("")).toBe("");
+  });
+
+  it("blocks the exact payload from Issue #743: ' OR 1=1 --", () => {
+    const rejected: string[] = [];
+    const result = validateSearchInput("' OR 1=1 --", (reason) => rejected.push(reason));
+    expect(result).toBe("");
+    expect(rejected.length).toBeGreaterThan(0);
+  });
+
+  it("blocks OR 1=1 variants", () => {
+    expect(validateSearchInput("OR 1=1")).toBe("");
+    expect(validateSearchInput("' OR '1'='1")).toBe("");
+  });
+
+  it("blocks UNION SELECT", () => {
+    expect(validateSearchInput("UNION SELECT password FROM users")).toBe("");
+  });
+
+  it("blocks SQL line comments", () => {
+    expect(validateSearchInput("admin'--")).toBe("");
+    expect(validateSearchInput("test -- ")).toBe("");
+  });
+
+  it("blocks DROP TABLE", () => {
+    expect(validateSearchInput("; DROP TABLE patients")).toBe("");
+  });
+
+  it("blocks XSS payloads", () => {
+    expect(validateSearchInput("<script>alert(1)</script>")).toBe("");
+    expect(validateSearchInput("javascript:alert(1)")).toBe("");
+  });
+
+  it("calls onRejected callback when input is rejected", () => {
+    let called = false;
+    let reason = "";
+    validateSearchInput("' OR 1=1 --", (r) => {
+      called = true;
+      reason = r;
+    });
+    expect(called).toBe(true);
+    expect(reason).toBeTruthy();
+  });
+
+  it("truncates input exceeding 200 characters", () => {
+    const longInput = "a".repeat(300);
+    const result = validateSearchInput(longInput);
+    expect(result.length).toBeLessThanOrEqual(200);
+  });
+
+  it("rejects input with disallowed special characters", () => {
+    // Characters like | < > { } are not in the allowlist
+    expect(validateSearchInput("test|injection")).toBe("");
+    expect(validateSearchInput("test<injection>")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateFilterInput (existing behaviour, no regression)
+// ---------------------------------------------------------------------------
+describe("validateFilterInput (backwards compatibility)", () => {
+  it("returns the input for safe strings", () => {
+    expect(validateFilterInput("some filter")).toBe("some filter");
+  });
+
+  it("blocks XSS patterns", () => {
+    expect(validateFilterInput("<script>alert(1)</script>")).toBe("");
+    expect(validateFilterInput("<iframe src='evil'></iframe>")).toBe("");
+  });
+
+  it("returns empty string for null/undefined", () => {
+    expect(validateFilterInput(null)).toBe("");
+    expect(validateFilterInput(undefined)).toBe("");
+  });
+
+  it("truncates to 200 characters", () => {
+    expect(validateFilterInput("x".repeat(300)).length).toBeLessThanOrEqual(200);
+  });
+});

--- a/client/src/validation/filterValidation.ts
+++ b/client/src/validation/filterValidation.ts
@@ -1,8 +1,26 @@
 /**
- * Validates search and filter parameters to prevent malicious inputs.
+ * filterValidation.ts
+ *
+ * Client-side input validation for search and filter fields.
+ *
+ * Security layering:
+ * - PRIMARY defence: Drizzle ORM parameterized queries on the backend.
+ * - SECONDARY defence: Zod schema + SQL pattern detection on the backend (searchValidation.ts).
+ * - TERTIARY defence (this file): early client-side rejection of obviously malicious
+ *   inputs BEFORE they are sent to the server, providing a faster feedback loop
+ *   and reducing the attack surface exposed to the backend.
+ *
+ * Note: client-side validation is NOT a substitute for server-side validation.
+ * A determined attacker can bypass the browser. The server MUST validate independently.
  */
 
-const MALICIOUS_PATTERNS = [
+/** Maximum characters allowed in a patient/assessment search query. */
+const MAX_SEARCH_LENGTH = 200;
+
+/**
+ * XSS (Cross-Site Scripting) patterns — reject HTML/JS injection attempts.
+ */
+const XSS_PATTERNS: RegExp[] = [
   /<script/gi,
   /javascript:/gi,
   /onerror\s*=/gi,
@@ -15,21 +33,134 @@ const MALICIOUS_PATTERNS = [
   /<img/gi,
 ];
 
+/**
+ * SQL injection signature patterns — mirrors the patterns in the backend
+ * searchValidation.ts so that payloads like `' OR 1=1 --` are rejected
+ * at the client layer BEFORE being sent to the server.
+ *
+ * Fix for Issue #743: the client previously had NO SQL injection detection,
+ * allowing these payloads to pass through filterValidation unchecked.
+ */
+const SQL_INJECTION_PATTERNS: RegExp[] = [
+  /(\bOR\b|\bAND\b)\s+['"]?\d+['"]?\s*=\s*['"]?\d+['"]?/i, // OR 1=1, AND '1'='1'
+  /'\s*(OR|AND)\s*'/i,                                        // ' OR '
+  /\bOR\b\s+['"]?[^\s]+['"]?\s*=\s*['"]?[^\s]+['"]?/i,     // OR 'x'='x'
+  /UNION\s+(ALL\s+)?SELECT/i,                                 // UNION SELECT
+  /;\s*(DROP|DELETE|INSERT|UPDATE|ALTER|CREATE|TRUNCATE)\b/i, // ; DROP TABLE
+  /--+/,                                                      // SQL line comment (-- or ---)
+  /\/\*.*\*\//s,                                              // /* block comment */
+  /\bEXEC\s*\(/i,                                             // EXEC(
+  /\bxp_\w+/i,                                               // xp_ stored procedures
+  /\bINFORMATION_SCHEMA\b/i,                                  // schema enumeration
+  /\bSYS\.(TABLES|COLUMNS|OBJECTS)\b/i,                      // sys tables
+  /SLEEP\s*\(\s*\d+\s*\)/i,                                  // time-based: SLEEP(n)
+  /WAITFOR\s+DELAY/i,                                         // MSSQL time-based
+  /BENCHMARK\s*\(/i,                                          // MySQL time-based
+  /LOAD_FILE\s*\(/i,                                          // MySQL file read
+  /INTO\s+OUTFILE/i,                                          // MySQL file write
+  /\bSELECT\b.*\bFROM\b/i,                                   // SELECT ... FROM
+  /\bINSERT\b.*\bINTO\b/i,                                   // INSERT INTO
+  /\bDELETE\b.*\bFROM\b/i,                                   // DELETE FROM
+  /\bDROP\b.*\bTABLE\b/i,                                    // DROP TABLE
+];
+
+/**
+ * Characters allowed in a patient/assessment search query.
+ * Covers: letters, numbers, spaces, hyphens, apostrophes (O'Brien), periods, commas.
+ * NOTE: apostrophe (') is allowed for names like "O'Brien" but SQL injection
+ * patterns above will still catch `' OR 1=1` style payloads.
+ */
+const ALLOWED_SEARCH_CHARS = /^[a-zA-Z0-9 \-'.,]+$/;
+
+/**
+ * Checks whether an input string contains SQL injection patterns.
+ * Returns the matched pattern description, or null if none found.
+ */
+export function detectClientSqlInjection(input: string): string | null {
+  for (const pattern of SQL_INJECTION_PATTERNS) {
+    if (pattern.test(input)) {
+      return pattern.toString();
+    }
+  }
+  return null;
+}
+
+/**
+ * Validates a generic filter input string (XSS focus).
+ * Sanitizes length and rejects HTML/JS injection patterns.
+ *
+ * For search fields that may reach the database, prefer `validateSearchInput`.
+ */
 export function validateFilterInput(input: string | null | undefined): string {
   if (!input) return "";
 
   // 1. Max length constraint
   let safeInput = input.trim();
-  if (safeInput.length > 200) {
-    safeInput = safeInput.substring(0, 200);
+  if (safeInput.length > MAX_SEARCH_LENGTH) {
+    safeInput = safeInput.substring(0, MAX_SEARCH_LENGTH);
   }
 
-  // 2. Reject clearly malicious payloads
-  for (const pattern of MALICIOUS_PATTERNS) {
+  // 2. Reject XSS payloads
+  for (const pattern of XSS_PATTERNS) {
     if (pattern.test(safeInput)) {
-      console.warn("Rejected suspicious input payload");
+      console.warn("[Security] Rejected XSS payload in filter input");
       return "";
     }
+  }
+
+  return safeInput;
+}
+
+/**
+ * Validates a patient/assessment search term.
+ *
+ * Applies all checks from `validateFilterInput` PLUS:
+ * - SQL injection pattern detection (Fix for Issue #743)
+ * - Strict character allowlist
+ *
+ * Returns the trimmed, safe input string, or an empty string if the input
+ * contains any dangerous pattern.
+ *
+ * @param input - The raw string from the search field.
+ * @param onRejected - Optional callback called when the input is rejected,
+ *   useful for showing a UI warning to the user.
+ */
+export function validateSearchInput(
+  input: string | null | undefined,
+  onRejected?: (reason: string) => void
+): string {
+  if (!input) return "";
+
+  let safeInput = input.trim();
+
+  // 1. Length constraint
+  if (safeInput.length > MAX_SEARCH_LENGTH) {
+    safeInput = safeInput.substring(0, MAX_SEARCH_LENGTH);
+  }
+
+  // 2. Reject XSS payloads
+  for (const pattern of XSS_PATTERNS) {
+    if (pattern.test(safeInput)) {
+      console.warn("[Security] Rejected XSS payload in search input");
+      onRejected?.("Invalid characters detected in search query.");
+      return "";
+    }
+  }
+
+  // 3. Reject SQL injection patterns (Fix for Issue #743)
+  const sqlMatch = detectClientSqlInjection(safeInput);
+  if (sqlMatch !== null) {
+    console.warn("[Security] Rejected SQL injection pattern in search input");
+    onRejected?.("Search query contains a disallowed pattern.");
+    return "";
+  }
+
+  // 4. Strict character allowlist — only permit characters valid in patient names
+  //    and clinical terms. This catches any novel injection vector not covered above.
+  if (safeInput !== "" && !ALLOWED_SEARCH_CHARS.test(safeInput)) {
+    console.warn("[Security] Rejected disallowed characters in search input");
+    onRejected?.("Search query contains invalid characters.");
+    return "";
   }
 
   return safeInput;

--- a/server/validation/searchValidation.ts
+++ b/server/validation/searchValidation.ts
@@ -22,7 +22,7 @@ const SQL_INJECTION_PATTERNS: RegExp[] = [
   /'\s*(OR|AND)\s*'/i,                                           // ' OR '
   /UNION\s+(ALL\s+)?SELECT/i,                                    // UNION SELECT
   /;\s*(DROP|DELETE|INSERT|UPDATE|ALTER|CREATE|TRUNCATE)\b/i,    // ; DROP TABLE ...
-  /--\s*$/m,                                                     // -- comment
+  /--+/,                                                         // SQL line comment: -- or trailing -- space
   /\/\*.*\*\//s,                                                 // /* block comment */
   /\bEXEC\s*\(/i,                                               // EXEC(
   /\bxp_\w+/i,                                                  // xp_ stored procs


### PR DESCRIPTION
## Description

Patches a critical SQL injection vulnerability in the patient name search bar. The search field was passing raw, unsanitized user input through the client layer with no SQL injection detection — only XSS patterns were being checked. This meant a payload like `' OR 1=1 --` was never caught at the client layer before being sent to the server.

Additionally, a gap in the backend's `--` SQL comment pattern allowed inputs ending with a trailing space after `--` (e.g. `' OR 1=1 -- `) to bypass the pattern check.

The fix applies a **defence-in-depth** approach across three layers: client-side input validation, backend Zod schema validation, and the existing Drizzle ORM parameterized queries (primary protection, unchanged).

## Related Issue

Closes #743

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- **`client/src/validation/filterValidation.ts`** — Added comprehensive `SQL_INJECTION_PATTERNS` array (OR 1=1, UNION SELECT, DROP TABLE, block comments, time-based blind injection, schema enumeration, file read/write, etc.); added `detectClientSqlInjection()` export and a new `validateSearchInput()` function with full SQL + XSS + strict character allowlist validation and an optional `onRejected` callback for UI feedback; existing `validateFilterInput()` preserved for backwards compatibility
- **`client/src/pages/History.tsx`** — Search input `onChange` now calls `validateSearchInput()` instead of setting state with the raw value; added `searchRejected` state that turns the input border red and shows a `ShieldAlert` warning tooltip for 3 seconds when a SQL injection pattern is detected and blocked; added `aria-invalid` and `aria-describedby` for accessibility
- **`server/validation/searchValidation.ts`** — Fixed the `--` SQL comment detection pattern from `/--\s*$/m` (end-of-line only, missed trailing spaces) to `/--+/` (catches `--` anywhere in the string, closing the bypass gap)
- **`client/src/validation/filterValidation.test.ts`** *(new file)* — 20+ unit tests covering: `detectClientSqlInjection` (clean names, OR 1=1, `--` comment, UNION SELECT, DROP TABLE, block comments, time-based injection), `validateSearchInput` (exact Issue #743 payload, XSS, onRejected callback, allowlist enforcement, length truncation), and `validateFilterInput` backwards-compatibility regression tests

## Screenshots (if applicable)

N/A — security fix; no UI screenshots applicable.

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors