### PR TITLE
fix: eliminate global regex lastIndex drift in HighlightText

### DIFF
--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -28,16 +28,13 @@ import { advancedFilter } from "@/utils/search_filters";
 function HighlightText({ text, search }: { text: string; search: string }) {
   if (!search.trim()) return <>{text}</>;
 
-  const regex = new RegExp(
-    `(${search.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&")})`,
-    "gi"
-  );
-  const parts = text.split(regex);
+  const escaped = search.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&");
+  const parts = text.split(new RegExp(`(${escaped})`, "gi"));
 
   return (
     <>
       {parts.map((part, i) =>
-        regex.test(part) ? (
+        i % 2 === 1 ? (
           <mark
             key={i}
             className="bg-yellow-100 text-[#1E293B] rounded px-0.5 font-bold"


### PR DESCRIPTION
## Description

Fixes a subtle bug in the `HighlightText` component in `History.tsx` where search term highlighting would silently miss every other match.

## Related Issue

Closes #792

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Removed the `regex.test(part)` call inside `Array.map()` that was consuming the stateful `lastIndex` of the global regex
- Now uses index-parity of `String.split()` with a capturing group: captured matches always land at **odd** indices (1, 3, 5, …), non-matching text at even indices — no regex state involved

**Root cause:** `String.prototype.split` with a capturing-group regex produces an array where matched substrings sit at odd positions. The previous code re-used the same `g`-flagged regex object and called `.test()` on each part inside `.map()`. `RegExp.prototype.test` advances `lastIndex` on each call when the `g` flag is set, so every second call started searching from the wrong position and returned `false`, causing half the highlights to be dropped.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] TypeScript reports no new errors in `History.tsx` (`npx tsc --noEmit`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors