### PR TITLE
fix: make date range filter buttons keyboard-accessible

### DIFF
--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -355,9 +355,11 @@ export default function History() {
             <div className="flex items-center gap-2 bg-card border border-border rounded-xl px-3 py-2 shadow-sm select-none">
               <Calendar className="w-4 h-4 text-muted-foreground shrink-0" />
 
-              <div
+              <button
+                type="button"
                 onClick={triggerStartPicker}
-                className="cursor-pointer hover:bg-muted/50 px-2 py-0.5 rounded transition-colors min-w-[85px] text-center"
+                className="cursor-pointer hover:bg-muted/50 px-2 py-0.5 rounded transition-colors min-w-[85px] text-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-600"
+                aria-label={startDate ? `Start date: ${format(new Date(startDate), "MMM d, yyyy")}` : "Choose start date"}
               >
                 <span
                   className={`text-sm font-medium ${startDate ? "text-foreground font-semibold" : "text-muted-foreground"}`}
@@ -372,17 +374,20 @@ export default function History() {
                   value={startDate}
                   onChange={(e) => setStartDate(e.target.value)}
                   className="sr-only"
-                  aria-label="Start date"
+                  tabIndex={-1}
+                  aria-hidden="true"
                 />
-              </div>
+              </button>
 
-              <span className="text-muted-foreground text-xs font-bold px-0.5">
+              <span className="text-muted-foreground text-xs font-bold px-0.5" aria-hidden="true">
                 to
               </span>
 
-              <div
+              <button
+                type="button"
                 onClick={triggerEndPicker}
-                className="cursor-pointer hover:bg-muted/50 px-2 py-0.5 rounded transition-colors min-w-[85px] text-center"
+                className="cursor-pointer hover:bg-muted/50 px-2 py-0.5 rounded transition-colors min-w-[85px] text-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-600"
+                aria-label={endDate ? `End date: ${format(new Date(endDate), "MMM d, yyyy")}` : "Choose end date"}
               >
                 <span
                   className={`text-sm font-medium ${endDate ? "text-foreground font-semibold" : "text-muted-foreground"}`}
@@ -397,9 +402,10 @@ export default function History() {
                   value={endDate}
                   onChange={(e) => setEndDate(e.target.value)}
                   className="sr-only"
-                  aria-label="End date"
+                  tabIndex={-1}
+                  aria-hidden="true"
                 />
-              </div>
+              </button>
 
               {(startDate || endDate) && (
                 <button


### PR DESCRIPTION
## Description

The date range filter in the History page used plain `<div>` elements as interactive controls. These are not reachable by keyboard Tab and are not announced by screen readers, making the date filters completely inaccessible to keyboard-only and assistive-technology users.

## Related Issue

Closes #793

## Type of Change 

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🎨 Style / UI improvement

## Changes Made

- Replaced both date-trigger `<div>` elements with `<button type="button">` so they participate in the natural tab order and respond to Enter/Space
- Added `aria-label` to each button that reflects the currently selected date (or a prompt when unset), giving screen-reader users meaningful context
- Added `focus-visible:ring-2 focus-visible:ring-blue-600` for a visible keyboard focus indicator
- Marked the underlying hidden `<input type="date">` as `aria-hidden="true"` and `tabIndex={-1}` so assistive technology interacts only with the button, not the raw input

## Testing

- [x] Verified Tab focus moves through Start Date → End Date → Clear buttons in order
- [x] Enter/Space on each button opens the native date picker
- [x] `aria-label` updates correctly when a date is selected
- [x] No TypeScript errors in `History.tsx`
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors