### PR TITLE
fix: replace stale standalone login page with AuthFlowModal wrapper

### DIFF
--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,222 +1,24 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect } from "react";
 import { useLocation } from "wouter";
-import { queryClient } from "@/lib/queryClient";
-import { ApiClient } from "@/lib/apiClient";
+import { AuthFlowModal } from "@/components/AuthFlowModal";
 
+/**
+ * /login is kept as a navigable route so that direct links and bookmarks
+ * continue to work. It renders the canonical AuthFlowModal rather than
+ * duplicating the auth logic inline.
+ */
 export default function LoginPage() {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
-  const [rememberMe, setRememberMe] = useState(false);
+  const [, setLocation] = useLocation();
 
   useEffect(() => {
     document.title = "Clinical Insight Engine - Sign In";
   }, []);
-  const [, setLocation] = useLocation();
-  const [errors, setErrors] = useState<{ email?: string; password?: string; otp?: string }>({});
-  const [isLoading, setIsLoading] = useState(false);
-  const [step, setStep] = useState<"form" | "otp">("form");
-  const [pendingEmail, setPendingEmail] = useState("");
-  const [devOtp, setDevOtp] = useState<string | undefined>(undefined);
-  const [otp, setOtp] = useState(["", "", "", "", "", ""]);
-  const inputRefs = useRef<Array<HTMLInputElement | null>>([]);
-
-  const validate = () => {
-    const newErrors: { email?: string; password?: string } = {};
-    if (!email) {
-      newErrors.email = "Email is required";
-    } else if (!/\S+@\S+\.\S+/.test(email)) {
-      newErrors.email = "Enter a valid email address";
-    }
-    if (!password) {
-      newErrors.password = "Password is required";
-    } else if (password.length < 8) {
-      newErrors.password = "Password must be at least 8 characters";
-    }
-    return newErrors;
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const validationErrors = validate();
-    if (Object.keys(validationErrors).length > 0) {
-      setErrors(validationErrors);
-      return;
-    }
-    setErrors({});
-    if (rememberMe) {
-      localStorage.setItem("rememberedEmail", email);
-    } else {
-      localStorage.removeItem("rememberedEmail");
-    }
-    setIsLoading(true);
-    try {
-      const data = await ApiClient.post("/api/auth/login", { email, password });
-      setPendingEmail(email);
-      if (data.devOtp) setDevOtp(data.devOtp);
-      setStep("otp");
-    } catch {
-      setErrors({ email: "Unable to connect to server. Please try again." });
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const handleOtpSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const otpValue = otp.join("");
-    if (otpValue.length !== 6) return;
-    setIsLoading(true);
-    setErrors({});
-    try {
-      await ApiClient.post("/api/auth/verify-otp", { email: pendingEmail, otp: otpValue });
-      queryClient.invalidateQueries({ queryKey: ["/api/auth/me"] });
-      setLocation("/dashboard");
-    } catch (err: any) {
-      setErrors({ otp: err.message || "Unable to connect to server. Please try again." });
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const updateDigit = (index: number, value: string) => {
-    const digit = value.replace(/\D/g, "").slice(-1);
-    const next = [...otp];
-    next[index] = digit;
-    setOtp(next);
-    if (digit && index < 5) inputRefs.current[index + 1]?.focus();
-  };
-
-  if (step === "otp") {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-teal-50 flex items-center justify-center px-4 py-8">
-        <div className="w-full max-w-md">
-          <div className="text-center mb-8">
-            <div className="inline-flex items-center justify-center w-16 h-16 bg-blue-600 rounded-2xl mb-4 shadow-lg">
-              <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-              </svg>
-            </div>
-            <h1 className="text-2xl font-bold text-gray-800">Verify your identity</h1>
-            <p className="text-gray-500 text-sm mt-1">Enter the 6-digit code sent to {pendingEmail}</p>
-          </div>
-          <div className="bg-white rounded-2xl shadow-xl p-8 border border-gray-100">
-            {devOtp && (
-              <div className="mb-4 rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm font-semibold text-amber-700">
-                🔧 Dev mode: OTP auto-filled — <span className="font-mono">{devOtp}</span>
-              </div>
-            )}
-            {errors.otp && (
-              <div className="mb-4 rounded-xl border border-red-200 bg-red-50 p-3 text-sm font-semibold text-red-700">
-                {errors.otp}
-              </div>
-            )}
-            <form onSubmit={handleOtpSubmit}>
-              <div className="flex justify-center gap-2 mb-6">
-                {otp.map((digit, index) => (
-                  <input
-                    key={index}
-                    ref={(el) => { inputRefs.current[index] = el; }}
-                    type="text"
-                    inputMode="numeric"
-                    maxLength={1}
-                    value={digit}
-                    onChange={(e) => updateDigit(index, e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Backspace" && !otp[index] && index > 0) {
-                        inputRefs.current[index - 1]?.focus();
-                      }
-                    }}
-                    className="w-12 h-12 text-center text-lg font-bold border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:ring-2 focus:ring-blue-100 outline-none transition-all"
-                  />
-                ))}
-              </div>
-              <button
-                type="submit"
-                disabled={isLoading || otp.join("").length !== 6}
-                className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white font-semibold py-3 px-4 rounded-xl transition-all duration-200 flex items-center justify-center gap-2 shadow-md"
-              >
-                {isLoading ? "Verifying..." : "Verify & Sign In"}
-              </button>
-              <button
-                type="button"
-                onClick={() => { setStep("form"); setOtp(["", "", "", "", "", ""]); }}
-                className="w-full mt-3 text-sm text-gray-500 hover:text-gray-700 transition-colors"
-              >
-                Back to sign in
-              </button>
-            </form>
-          </div>
-        </div>
-      </div>
-    );
-  }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-teal-50 flex items-center justify-center px-4 py-8">
-      <div className="w-full max-w-md">
-        <div className="text-center mb-8">
-          <div className="inline-flex items-center justify-center w-16 h-16 bg-blue-600 rounded-2xl mb-4 shadow-lg">
-            <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-            </svg>
-          </div>
-          <h1 className="text-2xl font-bold text-gray-800">Clinical Insight Engine</h1>
-          <p className="text-gray-500 text-sm mt-1">Sign in to your account</p>
-        </div>
-        <div className="bg-white rounded-2xl shadow-xl p-8 border border-gray-100">
-          <form onSubmit={handleSubmit} noValidate>
-            <div className="mb-5">
-              <label className="block text-sm font-medium text-gray-700 mb-1.5">Email Address</label>
-              <input
-                type="email"
-                value={email}
-                onChange={(e) => { setEmail(e.target.value); setErrors((prev) => ({ ...prev, email: undefined })); }}
-                placeholder="you@example.com"
-                className={`w-full px-4 py-3 rounded-xl border text-sm outline-none transition-all duration-200 ${errors.email ? "border-red-400 bg-red-50 focus:ring-2 focus:ring-red-200" : "border-gray-200 bg-gray-50 focus:border-blue-500 focus:ring-2 focus:ring-blue-100 focus:bg-white"}`}
-              />
-              {errors.email && <p className="mt-1.5 text-xs text-red-500">{errors.email}</p>}
-            </div>
-            <div className="mb-5">
-              <label className="block text-sm font-medium text-gray-700 mb-1.5">Password</label>
-              <div className="relative">
-                <input
-                  type={showPassword ? "text" : "password"}
-                  value={password}
-                  onChange={(e) => { setPassword(e.target.value); setErrors((prev) => ({ ...prev, password: undefined })); }}
-                  placeholder="Enter your password"
-                  className={`w-full px-4 py-3 pr-12 rounded-xl border text-sm outline-none transition-all duration-200 ${errors.password ? "border-red-400 bg-red-50 focus:ring-2 focus:ring-red-200" : "border-gray-200 bg-gray-50 focus:border-blue-500 focus:ring-2 focus:ring-blue-100 focus:bg-white"}`}
-                />
-                <button type="button" onClick={() => setShowPassword(!showPassword)} className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    {showPassword
-                      ? <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
-                      : <><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" /></>
-                    }
-                  </svg>
-                </button>
-              </div>
-              {errors.password && <p className="mt-1.5 text-xs text-red-500">{errors.password}</p>}
-            </div>
-            <div className="flex items-center justify-between mb-6">
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input type="checkbox" checked={rememberMe} onChange={(e) => setRememberMe(e.target.checked)} className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 cursor-pointer" />
-                <span className="text-sm text-gray-600">Remember me</span>
-              </label>
-              <a href="/forgot-password" className="text-sm text-blue-600 hover:text-blue-700 hover:underline font-medium transition-colors">Forgot password?</a>
-            </div>
-            <button type="submit" disabled={isLoading} className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white font-semibold py-3 px-4 rounded-xl transition-all duration-200 flex items-center justify-center gap-2 shadow-md hover:shadow-lg">
-              {isLoading ? "Signing in..." : "Sign In"}
-            </button>
-          </form>
-        </div>
-        <p className="text-center text-xs text-gray-400 mt-6">Clinical Insight Engine © 2026 · Frontend UI only</p>
-
-        {/* Footer */}
-        <p className="text-center text-xs text-gray-400 mt-6">
-          Clinical Insight Engine © {new Date().getFullYear()} · Frontend UI only
-        </p>
-      </div>
-    </div>
+    <AuthFlowModal
+      initialMode="login"
+      isOpen={true}
+      onClose={() => setLocation("/")}
+    />
   );
 }


### PR DESCRIPTION
## Description

`LoginPage.tsx` contained a ~200-line hand-rolled reimplementation of the entire auth flow (credentials form, OTP step, fetch calls, validation, state management) that `AuthFlowModal` already implements as the canonical path used by the landing page. The two copies had diverged — `LoginPage` was missing the registration flow, did not wire into the `useAuth` hook, and had a bug where the copyright footer was rendered twice (once hardcoded as "2026" and once with a dynamic year).

## Related Issue

Closes #796

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ♻️ Refactor (no functional changes)

## Changes Made

- Replaced the ~200-line custom `LoginPage` implementation with a 22-line wrapper that renders `<AuthFlowModal initialMode="login" isOpen={true} />`
- The `/login` route is preserved so existing bookmarks and direct links continue to work
- Closing the modal (e.g. pressing Escape or the close button) redirects to `/`
- On successful login `AuthFlowModal` navigates to `/dashboard` as it does from the landing page — no change in user journey

**What was removed:**
- Duplicate `fetch("/api/auth/login")` and `fetch("/api/auth/verify-otp")` calls
- Duplicate OTP digit-input component and focus-management logic  
- Duplicate client-side validation  
- Stale `queryClient` import that was used only to invalidate auth state (now handled inside `AuthFlowModal`)
- Doubled copyright footer

## Testing

- [x] Navigating to `/login` opens the sign-in modal immediately
- [x] Successful login redirects to `/dashboard`
- [x] Closing the modal (Escape / close button) redirects to `/`
- [x] No TypeScript errors in `LoginPage.tsx`
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] No new dependencies introduced