### PR TITLE
fix: add csv sanitizer module

### DIFF
--- a/server/utils/csvExport.test.ts
+++ b/server/utils/csvExport.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { assessmentsToCsv } from "./csvExport";
+import { escapeCsvCell, sanitizeCsvCell } from "./csvSanitizer";
+
+describe("csvSanitizer", () => {
+  it("escapes commas, quotes, and newlines", () => {
+    expect(escapeCsvCell('Doe, "Jane"\nPatient')).toBe('"Doe, ""Jane""\nPatient"');
+  });
+
+  it("prefixes spreadsheet formula values", () => {
+    expect(sanitizeCsvCell("=HYPERLINK(\"https://example.com\")")).toBe(
+      "'=HYPERLINK(\"https://example.com\")"
+    );
+    expect(sanitizeCsvCell("  +SUM(A1:A2)")).toBe("'  +SUM(A1:A2)");
+  });
+});
+
+describe("assessmentsToCsv", () => {
+  it("exports sanitized CSV rows", () => {
+    const csv = assessmentsToCsv([
+      {
+        patientName: "Jane, Doe",
+        riskCategory: "=HIGH",
+        notes: 'Needs "follow-up"',
+      },
+    ]);
+
+    expect(csv).toBe(
+      'patientName,riskCategory,notes\\n"Jane, Doe",\'=HIGH,"Needs ""follow-up"""'
+    );
+  });
+});

--- a/server/utils/csvExport.ts
+++ b/server/utils/csvExport.ts
@@ -1,6 +1,10 @@
+import { escapeCsvCell } from "./csvSanitizer";
+
 export function assessmentsToCsv(data: Record<string, unknown>[]): string {
   if (data.length === 0) return "";
   const headers = Object.keys(data[0]);
-  const rows = data.map(row => headers.map(h => JSON.stringify(row[h] ?? "")).join(","));
-  return [headers.join(","), ...rows].join("\\n");
+  const rows = data.map((row) =>
+    headers.map((h) => escapeCsvCell(row[h])).join(",")
+  );
+  return [headers.map(escapeCsvCell).join(","), ...rows].join("\\n");
 }

--- a/server/utils/csvSanitizer.ts
+++ b/server/utils/csvSanitizer.ts
@@ -1,0 +1,25 @@
+const FORMULA_PREFIX_PATTERN = /^[=+\-@]/;
+
+export function sanitizeCsvCell(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  let text = value instanceof Date ? value.toISOString() : String(value);
+
+  if (FORMULA_PREFIX_PATTERN.test(text.trimStart())) {
+    text = `'${text}`;
+  }
+
+  return text;
+}
+
+export function escapeCsvCell(value: unknown): string {
+  const sanitized = sanitizeCsvCell(value);
+
+  if (/[",\r\n]/.test(sanitized)) {
+    return `"${sanitized.replace(/"/g, '""')}"`;
+  }
+
+  return sanitized;
+}


### PR DESCRIPTION
## Description

Implements `server/utils/csvSanitizer.ts` so the empty utility file is now a real TypeScript module, then routes CSV export cell serialization through the sanitizer.

## Related Issue

Closes #789

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test addition or update

## Changes Made

- Added `sanitizeCsvCell` and `escapeCsvCell` exports for CSV-safe value handling.
- Updated `assessmentsToCsv` to use the sanitizer for headers and row values.
- Added Vitest coverage for CSV escaping and spreadsheet formula-prefix protection.

## Testing

- [x] `npm run test -- server/utils/csvExport.test.ts`
- [x] `git diff --check`
- [ ] `npm run check` currently fails on upstream `main` before this change is reached due syntax errors in `server/routes/assessments.routes.ts` around lines 118-141.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added/updated tests where applicable
