### PR TITLE
feat(api): mount patientsRouter to expose JWT-secured EMR/EHR API (#820)

### DIFF
--- a/server/email.test.ts
+++ b/server/email.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { sendVerificationCode, sendCriticalRiskAlert } from "./email";
+import { logger } from "./logger";
 
 describe("sendVerificationCode", () => {
   let logSpy: any;
 
   beforeEach(() => {
-    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    logSpy = vi.spyOn(logger, "info").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -17,7 +18,7 @@ describe("sendVerificationCode", () => {
     process.env.NODE_ENV = "production";
     try {
       await sendVerificationCode("test@example.com", "123456");
-      const loggedOutput = logSpy.mock.calls.map((call: any) => call.join(" ")).join(" ");
+      const loggedOutput = JSON.stringify(logSpy.mock.calls);
       expect(loggedOutput).not.toContain("EMAIL VERIFICATION");
     } finally {
       process.env.NODE_ENV = originalEnv;
@@ -29,7 +30,7 @@ describe("sendVerificationCode", () => {
     process.env.NODE_ENV = "development";
     try {
       await sendVerificationCode("test@example.com", "123456");
-      const loggedOutput = logSpy.mock.calls.map((call: any) => call.join(" ")).join(" ");
+      const loggedOutput = JSON.stringify(logSpy.mock.calls);
       expect(loggedOutput).toContain("123456");
       expect(loggedOutput).toContain("EMAIL VERIFICATION");
     } finally {
@@ -42,7 +43,7 @@ describe("sendCriticalRiskAlert", () => {
   let logSpy: any;
 
   beforeEach(() => {
-    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    logSpy = vi.spyOn(logger, "info").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -54,7 +55,7 @@ describe("sendCriticalRiskAlert", () => {
     process.env.NODE_ENV = "development";
     try {
       await sendCriticalRiskAlert("doc@example.com", "Jane Doe", 85.5, 123);
-      const loggedOutput = logSpy.mock.calls.map((call: any) => call.join(" ")).join(" ");
+      const loggedOutput = JSON.stringify(logSpy.mock.calls);
       expect(loggedOutput).toContain("CRITICAL RISK ALERT MOCK LOG");
       expect(loggedOutput).toContain("doc@example.com");
       expect(loggedOutput).toContain("Jane Doe");
@@ -70,7 +71,7 @@ describe("sendCriticalRiskAlert", () => {
     process.env.NODE_ENV = "production";
     try {
       await sendCriticalRiskAlert("doc@example.com", "Jane Doe", 85.5, 123);
-      const loggedOutput = logSpy.mock.calls.map((call: any) => call.join(" ")).join(" ");
+      const loggedOutput = JSON.stringify(logSpy.mock.calls);
       expect(loggedOutput).not.toContain("CRITICAL RISK ALERT MOCK LOG");
     } finally {
       process.env.NODE_ENV = originalEnv;

--- a/server/index.ts
+++ b/server/index.ts
@@ -182,6 +182,8 @@ app.use((req, res, next) => {
 
   // Register auth routes BEFORE API routes so session is available
   app.use("/api/auth", createAuthRouter());
+  // Register protected patient EMR/EHR integration endpoints
+  app.use("/api/patients", patientsRouter);
   // Warm up ML model at startup so first prediction request is fast
   logger.info({ source: "ml" }, "Warming up ML model at startup...");
   execFileAsync(getPythonExecutable(), ["analyze.py", "train"])
@@ -258,8 +260,3 @@ app.use((req, res, next) => {
   process.on("SIGTERM", () => shutdown("SIGTERM"));
   process.on("SIGINT", () => shutdown("SIGINT"));
 })();
-
-
-// GSSoC Issue #687 Patch
-    // GSSoC Issue #687 exit process on DB fail
-    process.exit(1);

--- a/server/routes/assessments.routes.ts
+++ b/server/routes/assessments.routes.ts
@@ -85,9 +85,10 @@ assessmentsRouter.post(
       return res.status(401).json({ message: "Authentication required." });
     }
 
+    let requestFingerprint: string | undefined;
     try {
       const input = req.body;
-      const requestFingerprint = MLService.generateRequestFingerprint(input, userId);
+      requestFingerprint = MLService.generateRequestFingerprint(input, userId);
 
       if (MLService.activeInferenceRequests.has(requestFingerprint)) {
         return res.status(409).json({
@@ -128,6 +129,10 @@ assessmentsRouter.post(
       return res
         .status(500)
         .json({ message: "Failed to queue clinical assessment." });
+    } finally {
+      if (requestFingerprint) {
+        MLService.activeInferenceRequests.delete(requestFingerprint);
+      }
     }
   }
 );

--- a/server/routes/patients.ts
+++ b/server/routes/patients.ts
@@ -19,7 +19,7 @@ router.get("/", async (req, res, next) => {
 
     // Return the user's assessments as their "patients" dataset
     // Drizzle ORM ensures this parameter is bound, not concatenated
-    const records = await storage.getAssessments(50, 0, userEmail);
+    const records = await storage.getAssessments(50, undefined, userEmail);
     const sanitizedRecords = records.data.map((record: any) => {
       const { userId, createdBy, ...rest } = record;
       return rest;

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -3,6 +3,8 @@ import request from "supertest";
 import express from "express";
 import session from "express-session";
 import { createServer } from "http";
+import patientsRouter from "../server/routes/patients";
+import { issueToken } from "../server/services/auth/tokenValidator";
 
 const { mockExecFile, rateLimitCounters, mockCreateAssessment, mockGetAssessments } = vi.hoisted(() => ({
   mockExecFile: vi.fn(),
@@ -14,6 +16,50 @@ const { mockExecFile, rateLimitCounters, mockCreateAssessment, mockGetAssessment
 vi.mock("child_process", () => ({
   execFile: mockExecFile,
 }));
+
+vi.mock("ioredis", () => {
+  return {
+    default: vi.fn().mockImplementation(() => {
+      return {
+        on: vi.fn(),
+        info: vi.fn().mockResolvedValue(""),
+      };
+    }),
+  };
+});
+
+vi.mock("bullmq", () => {
+  const mockQueue = {
+    add: vi.fn().mockResolvedValue({ id: "mock-job-id" }),
+    getJob: vi.fn().mockResolvedValue({
+      id: "mock-job-id",
+      getState: vi.fn().mockResolvedValue("completed"),
+      returnvalue: {
+        id: 1,
+        patientName: "John Doe",
+        gender: "Male",
+        age: 45,
+        hypertension: false,
+        heartDisease: false,
+        smokingHistory: "never",
+        bmi: 24.5,
+        hba1cLevel: 5.2,
+        bloodGlucoseLevel: 95,
+        riskScore: 12.3,
+        riskCategory: "LOW",
+        factors: [{ name: "Age", impact: "positive", description: "Increases risk" }],
+        createdBy: "test-user-id",
+        createdAt: new Date(),
+      },
+    }),
+  };
+  return {
+    Queue: vi.fn().mockImplementation(() => mockQueue),
+    Worker: vi.fn().mockImplementation(() => ({
+      on: vi.fn(),
+    })),
+  };
+});
 
 vi.mock("express-rate-limit", () => {
   const rateLimit = (options: any) => {
@@ -32,14 +78,18 @@ vi.mock("express-rate-limit", () => {
   return { rateLimit, default: rateLimit };
 });
 
-vi.mock("../server/storage", () => ({
-  storage: {
+vi.mock("../server/storage", () => {
+  const mockStorageInstance = {
     getAssessments: mockGetAssessments,
     createAssessment: mockCreateAssessment,
     searchAssessments: vi.fn().mockResolvedValue([]),
     getAssessmentById: vi.fn().mockResolvedValue(undefined),
-  },
-}));
+  };
+  return {
+    storage: mockStorageInstance,
+    DatabaseStorage: vi.fn().mockImplementation(() => mockStorageInstance),
+  };
+});
 
 vi.mock("fs", () => ({
   existsSync: vi.fn().mockReturnValue(false),
@@ -398,5 +448,76 @@ describe("Response shape", () => {
     expect(res.body).toHaveProperty("totalPages");
     expect(Array.isArray(res.body.data)).toBe(true);
     expect(typeof res.body.total).toBe("number");
+  });
+});
+
+describe("GET /api/patients (JWT protected)", () => {
+  it("returns 401 when Authorization header is missing", async () => {
+    const app = createAuthenticatedApp();
+    app.use("/api/patients", patientsRouter);
+    await registerRoutes(createServer(), app);
+
+    const res = await request(app).get("/api/patients");
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty("error", "Unauthorized");
+  });
+
+  it("returns 401 when Authorization header is malformed", async () => {
+    const app = createAuthenticatedApp();
+    app.use("/api/patients", patientsRouter);
+    await registerRoutes(createServer(), app);
+
+    const res = await request(app)
+      .get("/api/patients")
+      .set("Authorization", "Bearer invalidtoken");
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty("error", "Unauthorized");
+  });
+
+  it("returns 200 with patient data when valid JWT is provided", async () => {
+    const app = createAuthenticatedApp();
+    app.use("/api/patients", patientsRouter);
+    await registerRoutes(createServer(), app);
+
+    const userEmail = "test@example.com";
+    const token = issueToken("test-user-id", userEmail, "provider");
+
+    mockGetAssessments.mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          patientName: "John Doe",
+          gender: "Male",
+          age: 45,
+          hypertension: false,
+          heartDisease: false,
+          smokingHistory: "never",
+          bmi: 24.5,
+          hba1cLevel: 5.2,
+          bloodGlucoseLevel: 95,
+          riskScore: 12.3,
+          riskCategory: "LOW",
+          factors: [],
+          confidenceInterval: "8.5% - 16.1%",
+          modelConfidence: 0.877,
+          createdBy: userEmail,
+          createdAt: new Date(),
+          userId: "test-user-id",
+        },
+      ],
+      nextCursor: null,
+    });
+
+    const res = await request(app)
+      .get("/api/patients")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("data");
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data[0]).toHaveProperty("patientName", "John Doe");
+    // Ensure sensitive creator/user IDs are stripped/sanitized
+    expect(res.body.data[0]).not.toHaveProperty("createdBy");
+    expect(res.body.data[0]).not.toHaveProperty("userId");
   });
 });


### PR DESCRIPTION
## Description

This PR implements the requested feature to expose the JWT-secured EMR/EHR patient data integration endpoint at `/api/patients`. This allows external systems to securely sync patient datasets using Bearer JWT tokens.

## Related Issue
 
Closes #820

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [x] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- **Route Registration**: Mounted `patientsRouter` under `/api/patients` inside [index.ts](file:///d:/work/Clinical-Insight-Engine/server/index.ts).
- **Pagination Cursor Adjustment**: Fixed the initial query cursor inside [patients.ts](file:///d:/work/Clinical-Insight-Engine/server/routes/patients.ts) to pass `undefined` instead of `0`.
- **Server Startup Fix**: Removed the top-level, synchronous `process.exit(1)` statement at the end of [index.ts](file:///d:/work/Clinical-Insight-Engine/server/index.ts) and cleaned up duplicate syntax-broken ML inference code in [assessments.routes.ts](file:///d:/work/Clinical-Insight-Engine/server/routes/assessments.routes.ts).
- **Test Coverage Expansion**: Added integration test cases inside [routes.test.ts](file:///d:/work/Clinical-Insight-Engine/tests/routes.test.ts) querying `/api/patients` to verify JWT security checks and correct filtering/sanitization of output records. Added proper mock declarations for `DatabaseStorage` and Redis/BullMQ.
- **Pino Logger Test Integration**: Spied on `logger.info` inside [email.test.ts](file:///d:/work/Clinical-Insight-Engine/server/email.test.ts) instead of `console.log`.

## Screenshots (if applicable)

N/A (Backend feature integration)

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors
