### PR TITLE
fix: add rate limiting to forgot-password and reset-password endpoints (fixes #754)

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -134,6 +134,18 @@ const resendLimiter = rateLimit({
   message: { error: "Too many resend requests. Please try again later." },
 });
 
+/**
+ * Stricter rate limiter for password-reset endpoint.
+ * Guards against token brute-force on the only credential-changing unauthenticated route.
+ */
+const passwordLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  limit: 3,
+  standardHeaders: "draft-8",
+  legacyHeaders: false,
+  message: { error: "Too many password reset attempts. Please try again later." },
+});
+
 function generateOtp(): string {
   return randomInt(100000, 999999).toString();
 }
@@ -558,7 +570,7 @@ export function createAuthRouter(): Router {
    * POST /api/auth/forgot-password
    * Accepts email, creates a password reset token, and logs the reset link.
    */
-  router.post("/forgot-password", validateDTO(forgotPasswordDTOSchema), async (req: Request, res: Response) => {
+  router.post("/forgot-password", authLimiter, validateDTO(forgotPasswordDTOSchema), async (req: Request, res: Response) => {
     const { email } = req.body;
 
     try {
@@ -605,7 +617,7 @@ export function createAuthRouter(): Router {
    * POST /api/auth/reset-password
    * Accepts token and new password, validates token, updates password.
    */
-  router.post("/reset-password", validateDTO(resetPasswordDTOSchema), async (req: Request, res: Response) => {
+  router.post("/reset-password", passwordLimiter, validateDTO(resetPasswordDTOSchema), async (req: Request, res: Response) => {
     const { token, newPassword } = req.body;
 
     try {


### PR DESCRIPTION
## Description

Apply rate limiting to the forgot-password and reset-password endpoints which were previously unprotected. forgot-password gets the same authLimiter (5 requests per 15 minutes) as login/register to prevent email enumeration. reset-password gets a stricter passwordLimiter (3 requests per 15 minutes) to prevent token brute-force since it directly changes credentials.

## Related Issue

Fixes #754

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added passwordLimiter rate limiter (limit: 3 per 15 min) for the reset-password endpoint
- Applied authLimiter middleware to POST /api/auth/forgot-password
- Applied passwordLimiter middleware to POST /api/auth/reset-password

## Screenshots (if applicable)

N/A — server-side middleware change

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors