### PR TITLE
fix: remove maximum-scale=1 from viewport meta tag to enable pinch-zoom (fixes #753)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Clinical Insight Engine</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" href="/favicon.png" sizes="32x32" />


### PR DESCRIPTION
## Description

Remove `maximum-scale=1` from the viewport meta tag in index.html to allow pinch-zoom on mobile devices. This fixes a WCAG 2.1 Success Criterion 1.4.4 (Resize Text) violation that made the application inaccessible to low-vision users.

## Related Issue

Fixes #753

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Removed `maximum-scale=1` from the viewport meta tag in client/index.html

## Screenshots (if applicable)

N/A — HTML meta tag change

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors