### PR TITLE
fix: remove vulnerable exportAsPdf and wire safe escapeHtml version (fixes #752)

### DIFF
--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -161,29 +161,6 @@ export default function History() {
 
   const [, setLocation] = useLocation();
 
-  function exportAsPdf(assessment: any) {
-    const patientName = assessment.patientName || "Unknown Patient";
-    const html = `<!doctype html><html><head><meta charset="utf-8"><title>Assessment ${assessment.id}</title><meta name="viewport" content="width=device-width,initial-scale=1"><style>body{font-family:system-ui, -apple-system, Segoe UI, Roboto, Arial; padding:24px; color:#0f172a} h1{font-size:20px} .kv{margin:6px 0} .pill{display:inline-block;padding:6px 10px;border-radius:999px;background:#f3f4f6;color:#111827;font-weight:700} table{width:100%;border-collapse:collapse;margin-top:12px} td{padding:6px;border-bottom:1px solid #e6e6e6}</style></head><body><h1>Assessment Summary</h1><p class="kv"><strong>Patient:</strong> ${patientName}</p><p class="kv"><strong>Date:</strong> ${new Date(assessment.createdAt).toLocaleString()}</p><p class="kv"><strong>Risk Score:</strong> ${Number(assessment.riskScore).toFixed(1)}%</p><p class="kv"><strong>Category:</strong> <span class="pill">${assessment.riskCategory}</span></p><h2 style="margin-top:18px;font-size:16px">Vitals & Inputs</h2><table><tbody><tr><td>Age</td><td>${assessment.age}</td></tr><tr><td>BMI</td><td>${assessment.bmi}</td></tr><tr><td>HbA1c</td><td>${assessment.hba1cLevel}%</td></tr><tr><td>Blood Glucose</td><td>${assessment.bloodGlucoseLevel}</td></tr><tr><td>Hypertension</td><td>${assessment.hypertension ? "Yes" : "No"}</td></tr><tr><td>Heart Disease</td><td>${assessment.heartDisease ? "Yes" : "No"}</td></tr><tr><td>Smoking</td><td>${assessment.smokingHistory}</td></tr></tbody></table><h2 style="margin-top:18px;font-size:16px">Top Factors</h2><ul>${(
-      assessment.factors || []
-    )
-      .slice(0, 5)
-      .map((f: any) => `<li>${f.name} — ${f.description} (${f.impact})</li>`)
-      .join("")}</ul></body></html>`;
-
-    const w = window.open("", "_blank", "noopener,noreferrer");
-    if (!w) {
-      alert("Please allow popups to enable PDF export.");
-      return;
-    }
-
-    w.document.write(html);
-    w.document.close();
-    w.focus();
-    setTimeout(() => {
-      w.print();
-    }, 250);
-  }
-
   function reloadToForm(assessment: any) {
     const draft = {
       patientName: assessment.patientName ?? "",
@@ -217,7 +194,7 @@ export default function History() {
       .replace(/'/g, "&#039;");
   }
 
-  function handleExportPDF(assessment: any) {
+  function exportAsPdf(assessment: any) {
     if (!assessment) return;
 
     const patientName = escapeHtml(assessment.patientName || "Unknown Patient");


### PR DESCRIPTION
## Description

PR #730 added a safe `handleExportPDF` function using `escapeHtml()` to prevent stored XSS in PDF export, but the old vulnerable `exportAsPdf` function was never removed and the button onClick still called it — leaving the XSS vulnerability unpatched. This fix removes the vulnerable function and renames the safe one so the UI actually uses it.

## Related Issue

Fixes #752

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Deleted the old `exportAsPdf` function (lines 164-185) which used unescaped template literal interpolation with `document.write()`
- Renamed `handleExportPDF` → `exportAsPdf` so the existing `onClick={() => exportAsPdf(assessment)}` calls the safe version that escapes all values with `escapeHtml()`

## Screenshots (if applicable)

N/A — code-only change, no visual difference

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors