### PR TITLE
fix: replace hardcoded admin credentials with ADMIN_EMAIL/ADMIN_PASSWORD env vars (fixes #751)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Server
+﻿# Server
 PORT=5000
 
 # API
@@ -10,7 +10,7 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/clinical_insight_engi
 # Authentication
 SESSION_SECRET=replace-with-a-long-random-session-secret
 
-# Email (SMTP) — optional, falls back to console logging if unset
+# Email (SMTP) â€” optional, falls back to console logging if unset
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587
 EMAIL_FROM=noreply@clinicalinsight.dev
@@ -21,3 +21,6 @@ ELASTICSEARCH_API_KEY=your-elasticsearch-api-key
 
 # Other
 NODE_ENV=development
+# Admin seed credentials — MUST be set in production
+# ADMIN_EMAIL=admin@example.com
+# ADMIN_PASSWORD=replace-with-a-strong-admin-password

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -208,19 +208,38 @@ export function getPythonExecutable() {
 }
 
 async function seedDatabase() {
-  const existingAdmin = await storage.getUserByEmail("admin@clinical-insight-engine.dev");
+  const adminEmail = process.env.ADMIN_EMAIL;
+  const adminPassword = process.env.ADMIN_PASSWORD;
+
+  if (process.env.NODE_ENV === "production") {
+    if (!adminEmail) {
+      throw new Error("ADMIN_EMAIL environment variable is required in production.");
+    }
+    if (!adminPassword) {
+      throw new Error("ADMIN_PASSWORD environment variable is required in production.");
+    }
+  }
+
+  const email = adminEmail || "admin@clinical-insight-engine.dev";
+  const password = adminPassword || "admin123";
+
+  if (!adminEmail || !adminPassword) {
+    logger.warn("[DEV] Using default admin credentials. Set ADMIN_EMAIL and ADMIN_PASSWORD env vars for production.");
+  }
+
+  const existingAdmin = await storage.getUserByEmail(email);
   if (!existingAdmin) {
-    const adminPasswordHash = bcrypt.hashSync("admin123", 10);
+    const adminPasswordHash = bcrypt.hashSync(password, 10);
     await storage.createUser({
       fullName: "System Admin",
-      email: "admin@clinical-insight-engine.dev",
+      email,
       medicalLicenseNumber: "ADMIN-000001",
       passwordHash: adminPasswordHash,
       role: "ADMIN",
       isActive: true,
       emailVerified: true,
     });
-    logger.info("Seeded admin user: admin@clinical-insight-engine.dev / admin123");
+    logger.info("Admin user seeded successfully.");
   }
 
   const existing = await storage.getAssessments();


### PR DESCRIPTION
## Description

Replace hardcoded admin credentials (`admin@clinical-insight-engine.dev` / `admin123`) in the seed database function with `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables. In production, the server crashes on startup if these are not set — no fallback to hardcoded defaults. In development, defaults with a warning are allowed for convenience. The credential leak in the log output is also removed.

## Related Issue

Fixes #751

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **server/routes.ts**: Rewrote `seedDatabase()` to read `ADMIN_EMAIL` / `ADMIN_PASSWORD` from env vars; throws in production if unset; dev fallback with logger.warn (no credential leak); removed `console.log` that printed credentials
- **.env.example**: Added documented entries for `ADMIN_EMAIL` and `ADMIN_PASSWORD` with placeholder values

## Screenshots (if applicable)

N/A — server-side change

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors