### PR TITLE
fix: disambiguate duplicate authLimiter declarations into strictAuthLimiter and authLimiter (fixes #755)

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -97,14 +97,27 @@ if (otpCleanupTimer.unref) {
 }
 
 /**
- * Rate limiters for verification endpoints.
+ * Strict rate limiter for sensitive endpoints (e.g., registration).
+ * Prevents mass account creation and brute-force attacks.
  */
-const authLimiter = rateLimit({
+const strictAuthLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  limit: 5, // Stricter limit to prevent brute force (Fixes #624)
+  limit: 5, // Stricter limit (Fixes #624)
   standardHeaders: "draft-8",
   legacyHeaders: false,
   message: { error: "Too many authentication attempts. Please try again later." },
+});
+
+/**
+ * General rate limiter for standard auth endpoints (e.g., login).
+ * More lenient than strictAuthLimiter to avoid frustrating legitimate users.
+ */
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  limit: 15,
+  standardHeaders: "draft-8",
+  legacyHeaders: false,
+  message: { error: "Too many login/registration attempts. Please try again in 15 minutes." },
 });
 
 const otpLimiter = rateLimit({
@@ -193,7 +206,7 @@ export function createAuthRouter(): Router {
    * POST /api/auth/register
    * Validates registration fields, creates a new user account, and establishes a session.
    */
-  router.post("/register", authLimiter, validateDTO(registerDTOSchema), async (req: Request, res: Response) => {
+  router.post("/register", strictAuthLimiter, validateDTO(registerDTOSchema), async (req: Request, res: Response) => {
     const { fullName, email, password, licenseNumber } = req.body;
 
 


### PR DESCRIPTION
## Description

The original code had two `const authLimiter` declarations in `server/auth.ts` — one with `limit: 5` (line 99) and another with `limit: 15` (line 124) — causing the second to shadow the first. Upstream PR #764 removed the duplicate but left `limit: 5` as the effective limit for both `/register` and `/login`, which is too restrictive: legitimate users lock out after 5 mistyped password attempts in 15 minutes.

This fix properly disambiguates the two limiters with distinct names following the exact pattern prescribed in the issue.

## Related Issue

Fixes #755

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **server/auth.ts**: Renamed the existing stricter `authLimiter` (limit: 5) → `strictAuthLimiter`, created a new general `authLimiter` (limit: 15), and applied them to the appropriate routes:
  - `/register` → `strictAuthLimiter` (limit: 5 per 15 min) — prevents mass account creation and brute force on registration
  - `/login` → `authLimiter` (limit: 15 per 15 min) — forgives legitimate users who mistype their password without removing brute-force protection

## Screenshots (if applicable)

N/A — server-side change

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors