### PR TITLE
fix: use actual newline in assessmentsToCsv row join

### DIFF
--- a/server/utils/csvExport.ts
+++ b/server/utils/csvExport.ts
@@ -2,5 +2,5 @@ export function assessmentsToCsv(data: Record<string, unknown>[]): string {
   if (data.length === 0) return "";
   const headers = Object.keys(data[0]);
   const rows = data.map(row => headers.map(h => JSON.stringify(row[h] ?? "")).join(","));
-  return [headers.join(","), ...rows].join("\\n");
+  return [headers.join(","), ...rows].join("\n");
 }


### PR DESCRIPTION
Closes #848 

## Description

Fixes a broken CSV export in assessmentsToCsv where rows were joined with a literal two-character string \n (escaped backslash + n) instead of an actual newline character. This caused the entire export to be rendered as a single unbroken line, making the CSV completely unreadable in Excel, Google Sheets, or any standard CSV parser.

## Root Cause

In server/utils/csvExport.ts, the assessmentsToCsv function joins rows using "\\n" — a JavaScript string literal that produces the two characters \ and n, not a newline. Every CSV row was separated by the visible text \n rather than an actual line break.

// ❌ Before — literal backslash-n, not a newline
return [headers.join(","), ...rows].join("\\\n");

// ✅ After — real newline character
return [headers.join(","), ...rows].join("\n");