### PR TITLE
fix: use single quote instead of tab to neutralize CSV injection

### DIFF
--- a/app/utils/csv_sanitizer.py
+++ b/app/utils/csv_sanitizer.py
@@ -33,8 +33,8 @@ def sanitize_csv_value(value: Any) -> str:
     s = str(value).strip()
 
     if s and s[0] in DANGEROUS_PREFIXES:
-        # Prepend tab to neutralize the formula
-        return "	" + s
+        # Prepend single quote to neutralize the formula (OWASP recommended)
+        return "'" + s
 
     return s
 


### PR DESCRIPTION
Closes #853 

## Description

Fixes a self-defeating CSV injection sanitizer in app/utils/csv_sanitizer.py, where the neutralizing prefix used to escape dangerous formula characters was \t (tab) — a character that is itself listed as dangerous in DANGEROUS_PREFIXES.
This caused any cell value starting with a real tab character to be double-escaped (\t\t<value>), corrupting the data. It also meant the OWASP mitigation was incomplete, since a crafted value beginning with \t followed by =, +, etc. could still be interpreted as a formula by spreadsheet applications. The fix replaces the tab prefix with a single quote ', which is the mitigation
explicitly recommended by OWASP and already described in the function's own docstring.

## Root Cause

In app/utils/csv_sanitizer.py, sanitize_csv_value prepends \t to neutralize dangerous formula characters. However \t is included in DANGEROUS_PREFIXES itself, creating two problems:

Data corruption — any legitimate cell value starting with a tab is double-escaped to \t\t<value>. Broken mitigation — the function's own docstring says it should prepend a single quote (OWASP recommendation) but the implementation uses tab instead, indicating a hasty edit that was never reconciled.