### PR TITLE
fix: restore assessment request fingerprint lifecycle (#870)

### DIFF
--- a/server/routes/assessments.routes.ts
+++ b/server/routes/assessments.routes.ts
@@ -89,6 +89,15 @@ assessmentsRouter.post(
     let requestFingerprint: string | undefined;
     try {
       const input = req.body;
+
+      requestFingerprint = MLService.generateRequestFingerprint(input, userId);
+      if (MLService.activeInferenceRequests.has(requestFingerprint)) {
+        return res.status(409).json({
+          message: "An identical assessment request is already being processed.",
+        });
+      }
+      MLService.activeInferenceRequests.add(requestFingerprint);
+
       const job = await assessmentQueue.add("predict", {
         input,
         userId,

--- a/tests/assessment-fingerprint.test.ts
+++ b/tests/assessment-fingerprint.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import request from "supertest";
+import express from "express";
+import session from "express-session";
+import { createServer } from "http";
+
+const { mockExecFile, rateLimitCounters, mockCreateAssessment, mockGetAssessments } = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+  rateLimitCounters: new Map<string, number>(),
+  mockCreateAssessment: vi.fn(),
+  mockGetAssessments: vi.fn(),
+}));
+
+vi.mock("child_process", () => ({
+  execFile: mockExecFile,
+}));
+
+vi.mock("ioredis", () => {
+  return {
+    default: vi.fn().mockImplementation(() => {
+      return {
+        on: vi.fn(),
+        info: vi.fn().mockResolvedValue(""),
+      };
+    }),
+  };
+});
+
+vi.mock("bullmq", () => {
+  const mockQueue = {
+    add: vi.fn().mockResolvedValue({ id: "mock-job-id" }),
+    getJob: vi.fn().mockResolvedValue(null),
+  };
+  return {
+    Queue: vi.fn().mockImplementation(() => mockQueue),
+    Worker: vi.fn().mockImplementation(() => ({
+      on: vi.fn(),
+    })),
+  };
+});
+
+vi.mock("express-rate-limit", () => {
+  const rateLimit = (options: any) => {
+    return (req: any, res: any, next: any) => {
+      const key = req.ip || "test";
+      const count = (rateLimitCounters.get(key) || 0) + 1;
+      rateLimitCounters.set(key, count);
+      if (count > (options.limit || 5)) {
+        return res.status(429).json({
+          error: options.message?.error || "Too many requests",
+        });
+      }
+      next();
+    };
+  };
+  return { rateLimit, default: rateLimit };
+});
+
+vi.mock("../server/storage", () => {
+  const mockStorageInstance = {
+    getAssessments: mockGetAssessments,
+    createAssessment: mockCreateAssessment,
+    searchAssessments: vi.fn().mockResolvedValue([]),
+    getAssessmentById: vi.fn().mockResolvedValue(undefined),
+    getUserByEmail: vi.fn().mockResolvedValue({ id: "admin-id" }),
+    createUser: vi.fn().mockResolvedValue({ id: "admin-id" }),
+  };
+  return {
+    storage: mockStorageInstance,
+    DatabaseStorage: vi.fn().mockImplementation(() => mockStorageInstance),
+  };
+});
+
+vi.mock("fs", () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("fs/promises", () => ({
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  unlink: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { registerRoutes } from "../server/routes";
+import { MLService } from "../server/services/mlService";
+
+const validPayload = {
+  patientName: "John Doe",
+  gender: "Male",
+  age: 45,
+  hypertension: false,
+  heartDisease: false,
+  smokingHistory: "never",
+  bmi: 24.5,
+  hba1cLevel: 5.2,
+  bloodGlucoseLevel: 95,
+};
+
+const pythonSuccessOutput = JSON.stringify({
+  riskScore: 12.3,
+  riskCategory: "LOW",
+  factors: [{ name: "Age", impact: "positive", description: "Increases risk" }],
+  clinicianAdvice: ["Monitor annually."],
+  patientAdvice: ["Keep it up!"],
+  confidenceInterval: "8.5% - 16.1%",
+  modelConfidence: 0.877,
+});
+
+function createAuthenticatedApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    session({
+      secret: "test-secret",
+      resave: false,
+      saveUninitialized: false,
+    })
+  );
+  app.use((req, res, next) => {
+    req.session.user = {
+      id: "test-user-id",
+      email: "test@example.com",
+      name: "Test User",
+      emailVerified: true,
+    };
+    next();
+  });
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  rateLimitCounters.clear();
+  // Clear any leftover fingerprints between tests
+  MLService.activeInferenceRequests.clear();
+
+  mockCreateAssessment.mockImplementation((input) =>
+    Promise.resolve({ id: 1, ...input, createdAt: new Date() })
+  );
+  mockGetAssessments.mockResolvedValue({
+    data: [],
+    total: 0,
+    page: 1,
+    totalPages: 0,
+  });
+  mockExecFile.mockImplementation((cmd: any, args: any, opts: any, cb: any) => {
+    if (typeof opts === "function") {
+      cb = opts;
+      cb(null, pythonSuccessOutput, "");
+      return;
+    }
+    cb(null, pythonSuccessOutput, "");
+  });
+});
+
+afterEach(() => {
+  MLService.activeInferenceRequests.clear();
+});
+
+describe("Assessment request fingerprint lifecycle", () => {
+  it("fingerprint is removed from activeInferenceRequests after a successful request", async () => {
+    const app = createAuthenticatedApp();
+    await registerRoutes(createServer(), app);
+
+    expect(MLService.activeInferenceRequests.size).toBe(0);
+
+    const res = await request(app)
+      .post("/api/assessments")
+      .send(validPayload);
+
+    expect(res.status).toBe(202);
+    // After request completes, the fingerprint must be cleaned up
+    expect(MLService.activeInferenceRequests.size).toBe(0);
+  });
+
+  it("fingerprint is removed from activeInferenceRequests after a queue failure", async () => {
+    const app = createAuthenticatedApp();
+    await registerRoutes(createServer(), app);
+
+    // Make the queue.add() call reject by importing the mocked queue
+    const { assessmentQueue } = await import("../server/queue");
+    (assessmentQueue.add as any).mockRejectedValueOnce(new Error("Redis connection failed"));
+
+    const res = await request(app)
+      .post("/api/assessments")
+      .send(validPayload);
+
+    expect(res.status).toBe(500);
+    // Fingerprint must still be cleaned up even after error
+    expect(MLService.activeInferenceRequests.size).toBe(0);
+  });
+
+  it("duplicate concurrent requests return 409 Conflict", async () => {
+    const app = createAuthenticatedApp();
+    await registerRoutes(createServer(), app);
+
+    // Pre-populate the fingerprint to simulate an in-flight request
+    const fingerprint = MLService.generateRequestFingerprint(validPayload, "test-user-id");
+    MLService.activeInferenceRequests.add(fingerprint);
+
+    const res = await request(app)
+      .post("/api/assessments")
+      .send(validPayload);
+
+    expect(res.status).toBe(409);
+    expect(res.body.message).toMatch(/already being processed/i);
+  });
+
+  it("identical request succeeds after a previous identical request has completed", async () => {
+    const app = createAuthenticatedApp();
+    await registerRoutes(createServer(), app);
+
+    // First request
+    const res1 = await request(app)
+      .post("/api/assessments")
+      .send(validPayload);
+
+    expect(res1.status).toBe(202);
+    expect(MLService.activeInferenceRequests.size).toBe(0);
+
+    // Second identical request should succeed, not 409
+    const res2 = await request(app)
+      .post("/api/assessments")
+      .send(validPayload);
+
+    expect(res2.status).toBe(202);
+    expect(MLService.activeInferenceRequests.size).toBe(0);
+  });
+});


### PR DESCRIPTION
During a previous refactor to queue-based assessment processing, the request fingerprint variable remained declared and cleanup logic remained in a `finally` block, but fingerprint generation, duplicate-request checking, and registration in `activeInferenceRequests` were no longer performed.

This PR restores the complete lifecycle: generate, check, add, and delete in `finally`. This matches the behavior already implemented in the bulk assessment route.

Fixes #870

## Description

Restores request fingerprint lifecycle management for the single assessment route.

The route now generates a fingerprint for incoming assessment requests, checks for duplicate in-flight requests, registers active requests before queue dispatch, and ensures cleanup occurs through the existing `finally` block regardless of success or failure.

## Related Issue

Closes #870

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- Restored request fingerprint generation in `POST /api/assessments`
- Added duplicate in-flight request detection using `activeInferenceRequests`
- Registered fingerprints before queue dispatch and ensured cleanup through the existing `finally` block
- Added tests covering fingerprint lifecycle behavior, duplicate request protection, and cleanup on success/failure

## Screenshots (if applicable)

Not applicable (backend/API change).

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors