### PR TITLE
fix: prevent Patient View recommendation text from overlapping footer

### DIFF
--- a/client/src/components/AssessmentResult.tsx
+++ b/client/src/components/AssessmentResult.tsx
@@ -167,7 +167,7 @@ export function AssessmentResult({ assessment }: AssessmentResultProps) {
       id="assessment-result-wrapper"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      className="bg-card rounded-2xl shadow-xl shadow-black/5 border border-border/60 overflow-hidden flex flex-col"
+      className="bg-card rounded-2xl shadow-xl shadow-black/5 border border-border/60 flex flex-col"
     >
       {/* Header/Tabs */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 border-b border-border/60 bg-muted/30 p-2.5">

--- a/client/src/components/PatientPresentationMode.tsx
+++ b/client/src/components/PatientPresentationMode.tsx
@@ -66,7 +66,7 @@ export function PatientPresentationMode({ assessment, onClose }: Props) {
       exit={{ opacity: 0 }}
       className="fixed inset-0 z-50 flex flex-col bg-slate-50/95 backdrop-blur-md overflow-y-auto"
     >
-      <div className="flex-1 w-full max-w-5xl mx-auto p-6 md:p-12 relative">
+      <div className="w-full max-w-5xl mx-auto p-4 sm:p-6 md:p-12 relative">
         <button
           onClick={onClose}
           className="absolute top-6 right-6 md:top-8 md:right-8 p-3 bg-white border border-slate-200 rounded-full text-slate-500 hover:text-slate-800 hover:bg-slate-100 shadow-sm transition-all duration-200 active:scale-[0.92]"
@@ -75,7 +75,7 @@ export function PatientPresentationMode({ assessment, onClose }: Props) {
           <X className="w-6 h-6" />
         </button>
 
-        <div className="text-center space-y-6 max-w-3xl mx-auto pt-10 md:pt-16">
+        <div className="text-center space-y-4 sm:space-y-6 max-w-3xl mx-auto pt-6 sm:pt-10 md:pt-16">
           <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-5 py-2.5 text-sm font-bold uppercase tracking-wide text-primary">
             <UserCircle className="h-5 w-5" />
             Patient Presentation Mode
@@ -85,16 +85,16 @@ export function PatientPresentationMode({ assessment, onClose }: Props) {
             Your Health Assessment
           </h1>
 
-          <div className="py-8 md:py-12">
+          <div className="py-6 sm:py-8 md:py-12">
             <div
-              className={`mx-auto flex flex-col items-center justify-center w-56 h-56 md:w-72 md:h-72 rounded-full border-[12px] ring-4 ring-offset-4 ${getRiskColor(
+              className={`mx-auto flex flex-col items-center justify-center w-40 h-40 sm:w-56 sm:h-56 md:w-72 md:h-72 rounded-full border-[8px] sm:border-[12px] ring-4 ring-offset-4 ${getRiskColor(
                 assessment.riskCategory
               )}`}
             >
-              <span className="text-base md:text-lg font-bold uppercase tracking-widest opacity-80 mb-2">
+              <span className="text-xs sm:text-base md:text-lg font-bold uppercase tracking-widest opacity-80 mb-1 sm:mb-2">
                 Risk Level
               </span>
-              <span className="text-5xl md:text-6xl font-display font-black tracking-tight">
+              <span className="text-3xl sm:text-5xl md:text-6xl font-display font-black tracking-tight">
                 {assessment.riskCategory}
               </span>
             </div>
@@ -106,7 +106,7 @@ export function PatientPresentationMode({ assessment, onClose }: Props) {
           </p>
         </div>
 
-        <div className="mt-16 md:mt-24 space-y-8 max-w-4xl mx-auto">
+        <div className="mt-8 sm:mt-16 md:mt-24 space-y-6 sm:space-y-8 max-w-4xl mx-auto">
           <h3 className="font-bold text-2xl flex items-center gap-3 border-b pb-4">
             <Target className="w-7 h-7 text-primary" /> Clinical Smart Goals
           </h3>
@@ -129,7 +129,7 @@ export function PatientPresentationMode({ assessment, onClose }: Props) {
           </div>
         </div>
 
-        <div className="mt-16 text-center pb-12">
+        <div className="mt-8 sm:mt-16 text-center pb-8 sm:pb-12">
           <button
             onClick={onClose}
             className="inline-flex items-center gap-2 px-8 py-4 bg-slate-900 text-white font-bold rounded-xl hover:bg-slate-800 shadow-md transition-all duration-200 active:scale-[0.98]"


### PR DESCRIPTION
## Description

On mobile screens, the Patient View recommendation/guidance cards overflow their container and visually overlap the application footer, making bottom links unclickable. This PR fixes the overflow by removing a clipping `overflow-hidden` class and making the `PatientPresentationMode` layout responsive for small screens.

**Root Cause:**
1. `overflow-hidden` on the `AssessmentResult` wrapper clipped vertically-expanding content instead of letting the page grow.
2. The risk circle in `PatientPresentationMode` had fixed large dimensions (`w-56 h-56` = 224×224px) and `flex-1` on the inner container, pushing content below the viewport fold on mobile.

## Related Issue

Closes #837

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🎨 Style / UI improvement

## Changes Made

- **`AssessmentResult.tsx`**: Removed `overflow-hidden` from the card wrapper so content expands the page height dynamically instead of being clipped on mobile.
- **`PatientPresentationMode.tsx`**: Made the risk circle responsive (`w-40 h-40 sm:w-56 sm:h-56 md:w-72 md:h-72`) with scaled border width (`border-[8px] sm:border-[12px]`).
- **`PatientPresentationMode.tsx`**: Replaced `flex-1` with natural content flow so the scrollable overlay sizes to its content rather than stretching to fill the viewport.
- **`PatientPresentationMode.tsx`**: Tightened vertical margins, padding, and typography on mobile breakpoints (`mt-8 sm:mt-16`, `pb-8 sm:pb-12`, `pt-6 sm:pt-10 md:pt-16`, smaller text sizes).

## Screenshots (if applicable)

N/A — Tested via Chrome DevTools mobile simulation (iPhone 13 Pro, Galaxy S21). Patient guidance cards and Smart Goals now push page height down; footer links remain clickable on all screen sizes. Desktop layout is unchanged.

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors