### PR TITLE
fix: form submission crash when Age field is left empty (#841)

### DIFF
--- a/shared/schema.test.ts
+++ b/shared/schema.test.ts
@@ -72,4 +72,64 @@ describe("insertAssessmentSchema", () => {
 
     expect(result.success).toBe(true);
   });
+
+  it("rejects empty age string with 'required' error", () => {
+    const result = insertAssessmentSchema.safeParse({
+      ...validAssessment,
+      age: "",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe("Age is required");
+    }
+  });
+
+  it("rejects empty BMI string with 'required' error", () => {
+    const result = insertAssessmentSchema.safeParse({
+      ...validAssessment,
+      bmi: "",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe("BMI is required");
+    }
+  });
+
+  it("rejects empty HbA1c string with 'required' error", () => {
+    const result = insertAssessmentSchema.safeParse({
+      ...validAssessment,
+      hba1cLevel: "",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe("HbA1c level is required");
+    }
+  });
+
+  it("rejects empty blood glucose string with 'required' error", () => {
+    const result = insertAssessmentSchema.safeParse({
+      ...validAssessment,
+      bloodGlucoseLevel: "",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe("Blood glucose level is required");
+    }
+  });
+
+  it("still accepts numeric age 0 as out-of-range (not 'required')", () => {
+    const result = insertAssessmentSchema.safeParse({
+      ...validAssessment,
+      age: 0,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe("Age must be at least 1");
+    }
+  });
 });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -46,29 +46,57 @@ export const insertAssessmentSchema = createInsertSchema(assessments, {
     required_error: "Gender is required",
     invalid_type_error: "Gender must be 'Male' or 'Female'",
   }),
-  age: z.coerce
-    .number({ invalid_type_error: "Age must be a number" })
-    .int("Age must be a whole number")
-    .min(1, "Age must be at least 1")
-    .max(120, "Age must be 120 or below"),
+  age: z.preprocess(
+    (v) => {
+      if (v === "" || v === undefined || v === null) return undefined;
+      const n = Number(v);
+      return Number.isNaN(n) ? v : n;
+    },
+    z
+      .number({ required_error: "Age is required", invalid_type_error: "Age must be a number" })
+      .int("Age must be a whole number")
+      .min(1, "Age must be at least 1")
+      .max(120, "Age must be 120 or below"),
+  ),
   hypertension: z.boolean({ invalid_type_error: "Hypertension must be true or false" }).default(false),
   heartDisease: z.boolean({ invalid_type_error: "Heart disease must be true or false" }).default(false),
   smokingHistory: z.enum(["never", "No Info", "current", "former"], {
     required_error: "Smoking history is required",
     invalid_type_error: "Invalid smoking history value",
   }),
-  bmi: z.coerce
-    .number({ invalid_type_error: "BMI must be a number" })
-    .min(10, "BMI must be at least 10")
-    .max(60, "BMI must be 60 or below"),
-  hba1cLevel: z.coerce
-    .number({ invalid_type_error: "HbA1c level must be a number" })
-    .min(3, "HbA1c must be at least 3")
-    .max(15, "HbA1c must be 15 or below"),
-  bloodGlucoseLevel: z.coerce
-    .number({ invalid_type_error: "Blood glucose must be a number" })
-    .min(50, "Blood glucose must be at least 50")
-    .max(400, "Blood glucose must be 400 or below"),
+  bmi: z.preprocess(
+    (v) => {
+      if (v === "" || v === undefined || v === null) return undefined;
+      const n = Number(v);
+      return Number.isNaN(n) ? v : n;
+    },
+    z
+      .number({ required_error: "BMI is required", invalid_type_error: "BMI must be a number" })
+      .min(10, "BMI must be at least 10")
+      .max(60, "BMI must be 60 or below"),
+  ),
+  hba1cLevel: z.preprocess(
+    (v) => {
+      if (v === "" || v === undefined || v === null) return undefined;
+      const n = Number(v);
+      return Number.isNaN(n) ? v : n;
+    },
+    z
+      .number({ required_error: "HbA1c level is required", invalid_type_error: "HbA1c level must be a number" })
+      .min(3, "HbA1c must be at least 3")
+      .max(15, "HbA1c must be 15 or below"),
+  ),
+  bloodGlucoseLevel: z.preprocess(
+    (v) => {
+      if (v === "" || v === undefined || v === null) return undefined;
+      const n = Number(v);
+      return Number.isNaN(n) ? v : n;
+    },
+    z
+      .number({ required_error: "Blood glucose level is required", invalid_type_error: "Blood glucose must be a number" })
+      .min(50, "Blood glucose must be at least 50")
+      .max(400, "Blood glucose must be 400 or below"),
+  ),
   createdBy: z.string().email("createdBy must be a valid email").optional(),
 }).omit({
   id: true,


### PR DESCRIPTION
## Description

Fixed the Risk Assessment Form crash when the "Age" field is left empty. The root cause was that `z.coerce.number()` converts an empty string `""` to `0`, which bypasses the required-field check and either shows a misleading "Age must be at least 1" error or submits `age: 0` to the backend, causing a TypeError and UI freeze.

## Related Issue

Closes #841

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **Added `z.preprocess()`** to all 4 numeric schema fields (`age`, `bmi`, `hba1cLevel`, `bloodGlucoseLevel`) in `shared/schema.ts` — empty strings are converted to `undefined` before validation so `required_error` properly fires with a clear message
- **Replaced `z.coerce.number()`** with manual coercion inside the preprocessor + `z.number()` — this ensures `required_error: "Age is required"` appears when the field is empty, while valid numeric strings (e.g. `"25"`) still coerce correctly to numbers
- **Added 5 test cases** in `shared/schema.test.ts` verifying empty strings produce `"required"` errors and `age: 0` still produces the range error

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors