### PR TITLE
fix: sanitize European decimal comma separators in BMI and numeric fields

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -349,6 +349,9 @@ def interpret_prediction(model, scaler, features, input_data, cov_beta=None):
             if field_label:
                 imputed_fields.append(field_label)
             return default_val
+        # Sanitize European decimal comma separators (e.g. "25,4" -> "25.4")
+        if isinstance(val, str):
+            val = val.replace(",", ".")
         return val
 
     # Safe extraction mapping utilizing dynamic baseline statistics for optional metrics

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -49,7 +49,8 @@ export const insertAssessmentSchema = createInsertSchema(assessments, {
   age: z.preprocess(
     (v) => {
       if (v === "" || v === undefined || v === null) return undefined;
-      const n = Number(v);
+      const sanitized = typeof v === "string" ? v.replace(/,/g, ".") : v;
+      const n = Number(sanitized);
       return Number.isNaN(n) ? v : n;
     },
     z
@@ -67,7 +68,8 @@ export const insertAssessmentSchema = createInsertSchema(assessments, {
   bmi: z.preprocess(
     (v) => {
       if (v === "" || v === undefined || v === null) return undefined;
-      const n = Number(v);
+      const sanitized = typeof v === "string" ? v.replace(/,/g, ".") : v;
+      const n = Number(sanitized);
       return Number.isNaN(n) ? v : n;
     },
     z
@@ -78,7 +80,8 @@ export const insertAssessmentSchema = createInsertSchema(assessments, {
   hba1cLevel: z.preprocess(
     (v) => {
       if (v === "" || v === undefined || v === null) return undefined;
-      const n = Number(v);
+      const sanitized = typeof v === "string" ? v.replace(/,/g, ".") : v;
+      const n = Number(sanitized);
       return Number.isNaN(n) ? v : n;
     },
     z
@@ -89,7 +92,8 @@ export const insertAssessmentSchema = createInsertSchema(assessments, {
   bloodGlucoseLevel: z.preprocess(
     (v) => {
       if (v === "" || v === undefined || v === null) return undefined;
-      const n = Number(v);
+      const sanitized = typeof v === "string" ? v.replace(/,/g, ".") : v;
+      const n = Number(sanitized);
       return Number.isNaN(n) ? v : n;
     },
     z


### PR DESCRIPTION
## Description

Fixes the Python backend returning 500 Internal Server Error when users input BMI (or other numeric fields) using European decimal comma formatting (e.g. "25,4" instead of "25.4"). The comma was forwarded to Python's `float()` which cannot parse it, throwing `ValueError: could not convert string to float: '25,4'`.

Two-layer fix: Zod preprocessor catches it at validation time, and `analyze.py` sanitizes as defense-in-depth.

## Related Issue

Closes #838

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`shared/schema.ts` (Zod)** — Added `v.replace(/,/g, ".")` in the `z.preprocess` for all 4 numeric fields (`age`, `bmi`, `hba1cLevel`, `bloodGlucoseLevel`). When a user types "25,4", it becomes "25.4" before `Number()` conversion, so Zod validation succeeds and the correct float reaches the Python backend.
- **`analyze.py` (Python)** — Added `val.replace(",", ".")` in the `_safe_get` helper function inside `interpret_prediction`. This ensures that even if data bypasses Zod validation (e.g. direct API calls), the Python ML pipeline will sanitize commas to periods before `float()` casting.

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors