### PR TITLE
fix: disclose fallback model usage in assessment preview response

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -535,6 +535,15 @@ export default function Dashboard() {
 
                 {preview && (
                   <>
+                    {preview.isFallback && (
+                      <div className="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+                        <span className="mt-0.5 shrink-0">⚠️</span>
+                        <span>
+                          <strong>Rule-based estimate</strong> — ML model unavailable. Results are from a simplified heuristic and may be less accurate.
+                        </span>
+                      </div>
+                    )}
+
                     <div className="rounded-2xl border border-slate-200 bg-slate-50 p-5 text-center">
                       <p className="text-xs font-bold uppercase tracking-[0.12em] text-slate-500">Risk Score</p>
                       <p className="mt-2 text-5xl font-black text-[#1E293B]">{preview.riskScore.toFixed(1)}%</p>

--- a/server/routes/assessments.routes.ts
+++ b/server/routes/assessments.routes.ts
@@ -50,7 +50,7 @@ assessmentsRouter.post(
   async (req, res) => {
     try {
       const input = req.body;
-      const { prediction } = await MLService.runAssessmentInference(input);
+      const { prediction, isFallback } = await MLService.runAssessmentInference(input);
 
       return res.json({
         riskScore: prediction.riskScore,
@@ -58,6 +58,7 @@ assessmentsRouter.post(
         factors: prediction.factors ?? [],
         confidenceInterval: prediction.confidenceInterval ?? null,
         modelConfidence: prediction.modelConfidence ?? null,
+        isFallback,
       });
     } catch (err: any) {
       if (err instanceof z.ZodError) {

--- a/shared/routes.ts
+++ b/shared/routes.ts
@@ -83,6 +83,7 @@ export const api = {
           ),
           confidenceInterval: z.string().nullable().optional(),
           modelConfidence: z.number().nullable().optional(),
+          isFallback: z.boolean().optional(),
         }),
         400: errorSchemas.validation,
         500: errorSchemas.internal,


### PR DESCRIPTION
## Description

When the Python ML model is unavailable (subprocess timeout, missing venv, or an unhandled error), `MLService.runAssessmentInference` silently falls back to a rule-based heuristic (`calculateClinicalFallback`). The full assessment creation flow already appends a disclaimer in this case. However, the **preview endpoint** was destructuring only `{ prediction }` and discarding `isFallback` entirely — meaning providers watching the live risk preview panel had no indication that the score came from a simplified 5-rule model rather than the trained ML model.

This fix propagates the fallback flag through the full preview pipeline so providers are always aware of the provenance of a risk estimate.

## Related Issue

Closes #921

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `shared/routes.ts` — added `isFallback: z.boolean().optional()` to the preview response schema
- `server/routes/assessments.routes.ts` — destructure `isFallback` from `runAssessmentInference` and include it in the preview JSON response
- `client/src/pages/Dashboard.tsx` — render an amber warning banner in the live preview panel when `isFallback` is `true`, clearly labelling the result as a rule-based estimate

## Screenshots (if applicable)

When the ML model is unavailable the preview panel now shows:

> ⚠️ **Rule-based estimate** — ML model unavailable. Results are from a simplified heuristic and may be less accurate.

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors