### PR TITLE
fix(auth): invalidate user sessions upon password reset

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -2,7 +2,7 @@ import { Router, type Request, type Response, type NextFunction } from "express"
 import { randomInt, randomBytes } from "crypto";
 import bcrypt from "bcrypt";
 import { rateLimit } from "express-rate-limit";
-import { eq, and, gte } from "drizzle-orm";
+import { eq, and, gte, sql } from "drizzle-orm";
 import { storage } from "./storage";
 import { getDb } from "./db";
 import { users, emailVerificationTokens, passwordResetTokens } from "@shared/schema";
@@ -745,6 +745,13 @@ export function createAuthRouter(): Router {
 
       await db.update(users).set({ passwordHash }).where(eq(users.id, resetToken.userId));
       await db.update(passwordResetTokens).set({ used: true }).where(eq(passwordResetTokens.id, resetToken.id));
+
+      // Invalidate all active sessions for the user to prevent session hijacking
+      try {
+        await db.execute(sql`DELETE FROM "session" WHERE (sess->'user'->>'id') = ${resetToken.userId}`);
+      } catch (sessErr) {
+        logger.error({ err: sessErr, userId: resetToken.userId }, "Failed to clear user sessions upon password reset");
+      }
 
       return res.json({ success: true, message: "Password has been reset successfully." });
     } catch (err) {


### PR DESCRIPTION
## Description

This PR resolves a critical security vulnerability where active user sessions were not invalidated or revoked after a password reset. By querying the database-backed session table and deleting any active sessions matching the resetting user's ID, we guarantee that all devices are immediately forced to re-authenticate following a credential change, preventing session hijacking.

## Related Issue
 
Closes #915

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- **`server/auth.ts`** — Imported `sql` from `drizzle-orm` to enable raw SQL execution.
- **Session Revocation** — Added logic inside `POST /api/auth/reset-password` to execute a raw delete statement targeting matching user IDs inside session store payloads: `DELETE FROM "session" WHERE (sess->'user'->>'id') = ${userId}`.
- **Outage Resiliency** — Wrapped the database execution in a try-catch block to log any database-level exceptions (e.g. during specific testing setups where the session table might not be generated) while ensuring the password reset operation completes successfully.

## Screenshots (if applicable)

N/A

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
