### PR TITLE
fix: reuse nodemailer SMTP transport via module-level singleton

### DIFF
--- a/server/email.ts
+++ b/server/email.ts
@@ -43,6 +43,29 @@ function isSmtpConfigured(): boolean {
 }
 
 /**
+ * Module-level SMTP transport singleton.
+ * Created once on first use so every sendEmail call reuses the same
+ * connection pool instead of opening a new TCP connection each time.
+ */
+let _transporter: import("nodemailer").Transporter | null = null;
+
+async function getTransporter(): Promise<import("nodemailer").Transporter> {
+  if (!_transporter) {
+    const { createTransport } = await import("nodemailer") as typeof import("nodemailer");
+    _transporter = createTransport({
+      host: process.env.SMTP_HOST,
+      port: parseInt(process.env.SMTP_PORT!, 10),
+      secure: process.env.SMTP_SECURE === "true",
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+  }
+  return _transporter;
+}
+
+/**
  * Logs a visible OTP block to the console in development.
  */
 function logDevOtp(email: string, code: string): void {
@@ -70,17 +93,7 @@ async function sendEmail(options: EmailOptions): Promise<boolean> {
   }
 
   try {
-    const { createTransport } = await import("nodemailer") as typeof import("nodemailer");
-
-    const transporter = createTransport({
-      host: process.env.SMTP_HOST,
-      port: parseInt(process.env.SMTP_PORT!, 10),
-      secure: process.env.SMTP_SECURE === "true",
-      auth: {
-        user: process.env.SMTP_USER,
-        pass: process.env.SMTP_PASS,
-      },
-    });
+    const transporter = await getTransporter();
 
     await transporter.sendMail({
       from: FROM_ADDRESS,


### PR DESCRIPTION
## Description

`sendEmail()` was calling `createTransport()` on every invocation, creating a new SMTP connection pool for each email sent (OTP verifications, password resets, critical risk alerts). The nodemailer documentation explicitly recommends reusing a single transport instance. Under burst load — e.g., 10 users registering simultaneously — this opens 10 separate TCP connections to the SMTP server and may trigger provider rate limits or connection caps.

## Related Issue

Closes #925

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ⚡ Performance improvement

## Changes Made

- `server/email.ts`
  - Introduced a `_transporter` module-level variable (initially `null`)
  - Added a `getTransporter()` async function that lazily creates the transport on first use and returns the cached instance on all subsequent calls
  - `sendEmail()` now calls `getTransporter()` instead of `createTransport()` directly
  - No changes to public API — all exported functions (`sendVerificationCode`, `sendPasswordResetEmail`, `sendCriticalRiskAlert`) are unaffected

## Screenshots (if applicable)

N/A — server-side change with no UI impact.

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors