### PR TITLE
fix: type criticalAlerts as CriticalAlert[] instead of any[] in use-analytics

### DIFF
--- a/client/src/hooks/use-analytics.ts
+++ b/client/src/hooks/use-analytics.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import type { Assessment } from "@shared/schema";
 
 export type AnalyticsDistribution = {
   category: "LOW" | "MODERATE" | "HIGH";
@@ -10,11 +11,16 @@ export type AnalyticsAverages = {
   hba1c: number;
 };
 
+export type CriticalAlert = Pick<
+  Assessment,
+  "id" | "patientName" | "gender" | "age" | "riskScore" | "riskCategory" | "createdAt"
+>;
+
 export type AnalyticsStats = {
   totalPatients: number;
   distribution: AnalyticsDistribution[];
   averages: AnalyticsAverages;
-  criticalAlerts: any[]; // The top 5 assessments
+  criticalAlerts: CriticalAlert[];
 };
 
 export function useAnalytics() {

--- a/client/src/pages/Analytics.tsx
+++ b/client/src/pages/Analytics.tsx
@@ -1,4 +1,4 @@
-import { useAnalytics } from "@/hooks/use-analytics";
+import { useAnalytics, type CriticalAlert } from "@/hooks/use-analytics";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from "recharts";
 import { Activity, Users, AlertTriangle } from "lucide-react";
@@ -122,7 +122,7 @@ export default function Analytics() {
           <CardContent>
             {stats.criticalAlerts.length > 0 ? (
               <div className="space-y-4">
-                {stats.criticalAlerts.map((alert: any) => (
+                {stats.criticalAlerts.map((alert: CriticalAlert) => (
                   <div key={alert.id} className="flex items-center justify-between rounded-xl border border-destructive/20 bg-destructive/10 p-4">
                     <div className="flex items-center gap-3">
                       <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-destructive/20 text-destructive">
@@ -131,7 +131,7 @@ export default function Analytics() {
                       <div>
                         <p className="font-bold text-foreground">{alert.patientName}</p>
                         <p className="text-xs font-semibold text-muted-foreground">
-                          {alert.gender}, {alert.age} yrs • Assessed: {new Date(alert.createdAt).toLocaleDateString()}
+                          {alert.gender}, {alert.age} yrs • Assessed: {alert.createdAt ? new Date(alert.createdAt).toLocaleDateString() : "Unknown"}
                         </p>
                       </div>
                     </div>


### PR DESCRIPTION
## Description

`criticalAlerts` in `useAnalytics` was typed as `any[]`, making TypeScript completely blind to the shape of the highest-risk patient data shown in the Critical Alerts Feed. Any field rename or schema change on `Assessment` would compile silently while breaking the UI at runtime.
 
This PR introduces a `CriticalAlert` type derived from the shared `Assessment` schema, replacing every `any` in the analytics data path with a precise, structural type.

## Related Issue

Closes #928

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ♻️ Refactor (no functional changes)

## Changes Made

- Define `CriticalAlert` as `Pick<Assessment, "id" | "patientName" | "gender" | "age" | "riskScore" | "riskCategory" | "createdAt">` in `use-analytics.ts`
- Export `CriticalAlert` so consuming components can import the type directly
- Change `criticalAlerts: any[]` → `criticalAlerts: CriticalAlert[]` in `AnalyticsStats`
- Update `Analytics.tsx` to import and use `CriticalAlert` on the map callback instead of `any`
- Fix null-unsafe `new Date(alert.createdAt)` by adding a ternary guard — `createdAt` is `Date | null` in the schema, and this was a latent compile error that the typing exposed

## Screenshots (if applicable)

No UI change — purely a type-safety fix.

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors