### PR TITLE
fix: prevent same-day assessments from collapsing to identical X-axis labels in RiskTrendChart

### DIFF
--- a/client/src/components/RiskTrendChart.tsx
+++ b/client/src/components/RiskTrendChart.tsx
@@ -47,14 +47,17 @@ export default function RiskTrendChart({ assessments }: Props) {
   const chartData = useMemo(() => {
     return [...assessments]
       .sort((a, b) => new Date(a.createdAt || 0).getTime() - new Date(b.createdAt || 0).getTime())
-      .map(a => ({
-        date: isValid(new Date(a.createdAt)) ? format(new Date(a.createdAt), "MMM d") : "?",
+      .map(a => {
+        const dateObj = a.createdAt ? new Date(a.createdAt) : null;
+        return {
+        date: dateObj && isValid(dateObj) ? dateObj.toISOString() : "?",
         riskScore: Number(Number(a.riskScore).toFixed(1)),
         bmi: Number(Number(a.bmi).toFixed(1)),
         hba1cLevel: Number(Number(a.hba1cLevel).toFixed(1)),
         bloodGlucoseLevel: Number(Number(a.bloodGlucoseLevel).toFixed(1)),
         riskCategory: a.riskCategory,
-      }));
+      };
+      });
   }, [assessments]);
 
   function toggleMetric(key: string) {
@@ -98,7 +101,15 @@ export default function RiskTrendChart({ assessments }: Props) {
       <ResponsiveContainer width="100%" height={280}>
         <LineChart data={chartData} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-          <XAxis dataKey="date" tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} />
+          <XAxis
+            dataKey="date"
+            tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+            tickFormatter={(iso: string) => {
+              if (iso === "?") return "?";
+              const d = new Date(iso);
+              return isValid(d) ? format(d, "MMM d, HH:mm") : "?";
+            }}
+          />
           <YAxis tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} />
           <Tooltip
             contentStyle={{


### PR DESCRIPTION
## Description

`RiskTrendChart` used `format(date, "MMM d")` as the recharts `dataKey` for the X-axis. When two assessments were recorded on the same calendar day (e.g. both labeled `"Jun 5"`), recharts treated them as the same data point and silently dropped the earlier one from the chart. Any provider running two assessments in a single day would see missing data in their trend view.
 
The fix stores full ISO timestamps as the chart data key so every assessment gets a structurally unique X-axis position, and delegates human-readable formatting purely to the `XAxis tickFormatter`.

## Related Issue

Closes #929

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Change `chartData` `date` field from `format(dateObj, "MMM d")` to `dateObj.toISOString()` — guarantees uniqueness per assessment, not just per calendar day
- Add `tickFormatter` to `XAxis` that formats the ISO string as `"MMM d, HH:mm"` for display — readable and still distinguishes same-day entries
- Add null guard for `createdAt` (`Date | null`) using a local `dateObj` variable before calling `.toISOString()`

## Screenshots (if applicable)

No visual regression for single-day usage. Same-day assessments now appear as distinct points on the chart instead of being silently collapsed.

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors