### PR TITLE
test: add regression tests for resend-otp endpoint (fixes #824)

### DIFF
--- a/tests/auth-resend-otp.test.ts
+++ b/tests/auth-resend-otp.test.ts
@@ -1,0 +1,81 @@
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+import session from "express-session";
+
+const { mockSendVerificationCode } = vi.hoisted(() => ({
+  mockSendVerificationCode: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../server/email", () => ({
+  sendVerificationCode: mockSendVerificationCode,
+  sendPasswordResetEmail: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../server/db", () => ({
+  getDb: vi.fn(),
+}));
+
+vi.mock("../server/storage", () => ({
+  storage: {
+    getUserByEmail: vi.fn(),
+    createUser: vi.fn(),
+  },
+}));
+
+vi.mock("ioredis", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    on: vi.fn(),
+    info: vi.fn().mockResolvedValue(""),
+  })),
+}));
+
+async function buildApp() {
+  const { createAuthRouter } = await import("../server/auth");
+  const app = express();
+  app.use(express.json());
+  app.use(
+    session({
+      secret: "test-secret",
+      resave: false,
+      saveUninitialized: false,
+    })
+  );
+  app.use("/api/auth", createAuthRouter());
+  return app;
+}
+
+describe("POST /api/auth/resend-otp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSendVerificationCode.mockResolvedValue(true);
+  });
+
+  it("returns 400 when email is missing", async () => {
+    const app = await buildApp();
+    const res = await request(app)
+      .post("/api/auth/resend-otp")
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/email is required/i);
+  });
+
+  it("returns 400 when no pending OTP exists for login mode", async () => {
+    const app = await buildApp();
+    const res = await request(app)
+      .post("/api/auth/resend-otp")
+      .send({ email: "noone@clinic.com", mode: "login" });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/no pending verification/i);
+  });
+
+it("does not require password — only email", async () => {
+    const app = await buildApp();
+    const res = await request(app)
+      .post("/api/auth/resend-otp")
+      .send({ email: "test@clinic.com", mode: "login" });
+    // The 400 should be for "no pending OTP", not for missing password
+    expect(res.body.message).not.toMatch(/password/i);
+  });
+});


### PR DESCRIPTION
## Summary

Adds regression tests for the `POST /api/auth/resend-otp` endpoint to prevent reintroduction of the bug described in #824.

## What was the bug 

The client's `handleResend` function was previously calling `/api/auth/login` without a password, hitting the strict `if (!email || !password)` guard and returning `400 Bad Request`. This was fixed in #797 by adding a dedicated `/api/auth/resend-otp` endpoint that only requires `email`.

## What this PR adds

Three regression tests in `tests/auth-resend-otp.test.ts`:

- Returns 400 when email is missing
- Returns 400 with correct message when no pending OTP exists (not a password error)
- Confirms the endpoint does not require a password — error messages never mention password

## Test results

All 3 tests pass.

Closes #824