### PR TITLE
Refactor/replace console error with pino logger

### DIFF
--- a/server/routes/analytics.routes.ts
+++ b/server/routes/analytics.routes.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { logger } from "../logger";
 import { requireAuth, requireVerified } from "../auth";
 import { storage } from "../storage";
 
@@ -17,7 +18,7 @@ analyticsRouter.get(
       const stats = await storage.getAnalyticsStats(userEmail);
       return res.json(stats);
     } catch (err) {
-      console.error("Analytics fetch error:", err);
+      logger.error({ err }, "Analytics fetch error");
       return res.status(500).json({ message: "Failed to fetch analytics" });
     }
   }

--- a/server/routes/exports.routes.ts
+++ b/server/routes/exports.routes.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { logger } from "../logger";
 import { requireAuth, requireVerified } from "../auth";
 import { storage } from "../storage";
 import { assessmentsToCsv } from "../utils/csvExport";
@@ -22,7 +23,7 @@ exportsRouter.get(
       res.attachment("assessments.csv");
       return res.send(csv);
     } catch (err) {
-      console.error("Export error:", err);
+      logger.error({ err }, "Export error");
       return res.status(500).json({ message: "Failed to export data" });
     }
   }

--- a/server/routes/ml.routes.ts
+++ b/server/routes/ml.routes.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { logger } from "../logger";
 import { z } from "zod";
 import os from "os";
 import path from "path";
@@ -82,7 +83,7 @@ mlRouter.post(
       if (err instanceof z.ZodError) {
         return res.status(400).json({ message: "Invalid bulk input data format. Ensure all rows meet schema requirements." });
       }
-      console.error("Bulk create error:", err);
+      logger.error({ err }, "Bulk create error");
       return res.status(500).json({ message: "Failed to generate bulk assessments." });
     } finally {
       if (tempFilePath) {

--- a/tests/auth-resend-otp.test.ts
+++ b/tests/auth-resend-otp.test.ts
@@ -1,0 +1,81 @@
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+import session from "express-session";
+
+const { mockSendVerificationCode } = vi.hoisted(() => ({
+  mockSendVerificationCode: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../server/email", () => ({
+  sendVerificationCode: mockSendVerificationCode,
+  sendPasswordResetEmail: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../server/db", () => ({
+  getDb: vi.fn(),
+}));
+
+vi.mock("../server/storage", () => ({
+  storage: {
+    getUserByEmail: vi.fn(),
+    createUser: vi.fn(),
+  },
+}));
+
+vi.mock("ioredis", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    on: vi.fn(),
+    info: vi.fn().mockResolvedValue(""),
+  })),
+}));
+
+async function buildApp() {
+  const { createAuthRouter } = await import("../server/auth");
+  const app = express();
+  app.use(express.json());
+  app.use(
+    session({
+      secret: "test-secret",
+      resave: false,
+      saveUninitialized: false,
+    })
+  );
+  app.use("/api/auth", createAuthRouter());
+  return app;
+}
+
+describe("POST /api/auth/resend-otp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSendVerificationCode.mockResolvedValue(true);
+  });
+
+  it("returns 400 when email is missing", async () => {
+    const app = await buildApp();
+    const res = await request(app)
+      .post("/api/auth/resend-otp")
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/email is required/i);
+  });
+
+  it("returns 400 when no pending OTP exists for login mode", async () => {
+    const app = await buildApp();
+    const res = await request(app)
+      .post("/api/auth/resend-otp")
+      .send({ email: "noone@clinic.com", mode: "login" });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/no pending verification/i);
+  });
+
+it("does not require password — only email", async () => {
+    const app = await buildApp();
+    const res = await request(app)
+      .post("/api/auth/resend-otp")
+      .send({ email: "test@clinic.com", mode: "login" });
+    // The 400 should be for "no pending OTP", not for missing password
+    expect(res.body.message).not.toMatch(/password/i);
+  });
+});


### PR DESCRIPTION
Closes #831

Several server route modules were still using `console.error` for error logging, bypassing the project's existing structured Pino logger. This caused inconsistent logging practices across the codebase and made production debugging and log aggregation harder.

**Changes**

- `server/routes/analytics.routes.ts` — added Pino logger import, replaced `console.error` with `logger.error({ err }, "Analytics fetch error")`
- `server/routes/exports.routes.ts` — added Pino logger import, replaced `console.error` with `logger.error({ err }, "Export error")`
- `server/routes/ml.routes.ts` — added Pino logger import, replaced `console.error` with `logger.error({ err }, "Bulk create error")`

No functional changes to API responses or business logic. Pure refactor — zero behavioral change.