### PR TITLE
fix(security): resolve CSV formula injection and correct row newline …

### DIFF
--- a/server/utils/csvExport.test.ts
+++ b/server/utils/csvExport.test.ts
@@ -13,6 +13,14 @@ describe("csvSanitizer", () => {
     );
     expect(sanitizeCsvCell("  +SUM(A1:A2)")).toBe("'  +SUM(A1:A2)");
   });
+
+  it("does not prefix valid numbers or numeric strings", () => {
+    expect(sanitizeCsvCell(-12.5)).toBe("-12.5");
+    expect(sanitizeCsvCell("-12.5")).toBe("-12.5");
+    expect(sanitizeCsvCell(123)).toBe("123");
+    expect(sanitizeCsvCell("123")).toBe("123");
+    expect(sanitizeCsvCell("+123")).toBe("+123");
+  });
 });
 
 describe("assessmentsToCsv", () => {
@@ -26,7 +34,7 @@ describe("assessmentsToCsv", () => {
     ]);
 
     expect(csv).toBe(
-      'patientName,riskCategory,notes\\n"Jane, Doe",\'=HIGH,"Needs ""follow-up"""'
+      "patientName,riskCategory,notes\n\"Jane, Doe\",'=HIGH,\"Needs \"\"follow-up\"\"\""
     );
   });
 });

--- a/server/utils/csvExport.ts
+++ b/server/utils/csvExport.ts
@@ -6,5 +6,5 @@ export function assessmentsToCsv(data: Record<string, unknown>[]): string {
   const rows = data.map((row) =>
     headers.map((h) => escapeCsvCell(row[h])).join(",")
   );
-  return [headers.map(escapeCsvCell).join(","), ...rows].join("\\n");
+  return [headers.map(escapeCsvCell).join(","), ...rows].join("\n");
 }

--- a/server/utils/csvSanitizer.ts
+++ b/server/utils/csvSanitizer.ts
@@ -5,7 +5,18 @@ export function sanitizeCsvCell(value: unknown): string {
     return "";
   }
 
+  if (typeof value === "number") {
+    return String(value);
+  }
+
   let text = value instanceof Date ? value.toISOString() : String(value);
+
+  // If the text can be parsed as a valid number, do not prepend a quote
+  // This avoids converting negative numbers (e.g. -12.5) or standard integer fields to strings.
+  const trimmed = text.trim();
+  if (trimmed !== "" && !isNaN(Number(trimmed))) {
+    return text;
+  }
 
   if (FORMULA_PREFIX_PATTERN.test(text.trimStart())) {
     text = `'${text}`;


### PR DESCRIPTION
## Description

Resolved the CSV Formula Injection vulnerability in the clinical assessment export feature and corrected a formatting bug that caused exported rows to join on literal `\n` characters instead of real newlines.

## Related Issue 

Closes #918

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- Updated `sanitizeCsvCell` in `server/utils/csvSanitizer.ts` to ignore valid numbers and numeric strings, preventing them from being wrapped with single quotes while maintaining formula injection blockings.
- Changed the row joining separator from a double-escaped `\\n` text to a real newline `\n` in `server/utils/csvExport.ts`.
- Added unit tests in `server/utils/csvExport.test.ts` to assert that negative numbers/floats are not quoted and updated the CSV format expectations.

## Screenshots (if applicable)

N/A

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the code style of this project
- [x] My changes generate no new warnings or type errors
- [x] I have performed a self-review of my own code
