### PR TITLE
feat: add patientName support to assessment search functionality

### DIFF
--- a/server/repositories/assessment.repository.ts
+++ b/server/repositories/assessment.repository.ts
@@ -86,7 +86,8 @@ export class AssessmentRepository {
         or(
           ilike(assessments.gender, pattern),
           ilike(assessments.smokingHistory, pattern),
-          ilike(assessments.riskCategory, pattern)
+          ilike(assessments.riskCategory, pattern),
+          ilike(assessments.patientName, pattern)
         ) as ReturnType<typeof eq>
       );
     }


### PR DESCRIPTION
Closes #832

The assessment search functionality only supported filtering by `gender`, `smokingHistory`, and `riskCategory`. Users had no way to search by patient name, which is the most natural identifier when looking up records.

**Changes**

- `server/repositories/assessment.repository.ts` — added `ilike(assessments.patientName, pattern)` to the `or(...)` search conditions block

Full and partial patient name searches now return matching records. All existing search filters continue to work without any changes. No API response changes, no schema changes.