### PR TITLE
fix(auth): implement brute-force lockout on 2FA OTP verification

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -50,6 +50,7 @@ function verifyPassword(password: string, storedHash: string): boolean {
 interface PendingOtp {
   otp: string;
   expiresAt: number;
+  attempts: number;
 }
 
 /**
@@ -346,7 +347,7 @@ export function createAuthRouter(): Router {
     }
 
     const otp = generateOtp();
-    pendingOtps.set(email, { otp, expiresAt: Date.now() + 10 * 60 * 1000 });
+    pendingOtps.set(email, { otp, expiresAt: Date.now() + 10 * 60 * 1000, attempts: 0 });
 
     // Send verification email
     const emailSent = await sendVerificationCode(email, otp);
@@ -388,7 +389,7 @@ export function createAuthRouter(): Router {
           return res.status(400).json({ message: "OTP has expired. Please sign in again." });
         }
 
-        pendingOtps.set(email, { otp, expiresAt: expiresAt.getTime() });
+        pendingOtps.set(email, { otp, expiresAt: expiresAt.getTime(), attempts: 0 });
         const emailSent = await sendVerificationCode(email, otp);
         if (!emailSent) {
           return res.status(503).json({ message: "Failed to send verification email. Please try again." });
@@ -473,12 +474,29 @@ export function createAuthRouter(): Router {
     }
 
     if (pending.otp !== otp) {
+      pending.attempts = (pending.attempts ?? 0) + 1;
+
+      if (pending.attempts >= 3) {
+        pendingOtps.delete(email);
+        await storage.recordLoginAudit({
+          ipAddress: req.ip,
+          userAgent: req.headers["user-agent"],
+          loginStatus: "otp_failed_lockout",
+        });
+        return res.status(429).json({
+          message: "Too many failed attempts. Please sign in again.",
+        });
+      }
+
       await storage.recordLoginAudit({
         ipAddress: req.ip,
         userAgent: req.headers["user-agent"],
         loginStatus: "otp_failed",
       });
-      return res.status(401).json({ message: "Invalid OTP. Please try again." });
+      const remaining = 3 - pending.attempts;
+      return res.status(401).json({
+        message: `Invalid OTP. ${remaining} attempt(s) remaining.`,
+      });
     }
 
     pendingOtps.delete(email);

--- a/tests/otp-lockout.test.ts
+++ b/tests/otp-lockout.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+import session from "express-session";
+import { createAuthRouter } from "../server/auth";
+
+// Mock the db module to return our mock user on query
+vi.mock("../server/db", async (importOriginal) => {
+  const original = (await importOriginal()) as any;
+  return {
+    ...original,
+    getDb: () => ({
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => [
+              {
+                id: "test-user-id",
+                fullName: "Test Doctor",
+                email: "doc@example.com",
+                medicalLicenseNumber: "DOC123",
+                passwordHash: "$2b$10$UnqO1D.K2i8e.3yY4/pZkO/rQhZz7xI7TfX6f4r4uYgG0p0p0p0p.",
+                role: "provider",
+                isActive: true,
+                emailVerified: true,
+              }
+            ]
+          })
+        })
+      })
+    })
+  };
+});
+
+// Mock the storage module
+vi.mock("../server/storage", () => {
+  const mockStorageInstance = {
+    getUserByEmail: vi.fn(),
+    createUser: vi.fn(),
+    recordLoginAudit: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return {
+    storage: mockStorageInstance,
+    DatabaseStorage: vi.fn().mockImplementation(() => mockStorageInstance),
+  };
+});
+
+// Mock bcrypt compareSync because we want login to succeed
+vi.mock("bcrypt", () => ({
+  default: {
+    compareSync: () => true,
+    hashSync: () => "hashed",
+  },
+  compareSync: () => true,
+  hashSync: () => "hashed",
+}));
+
+// Mock email service
+vi.mock("../server/email", () => ({
+  sendVerificationCode: vi.fn().mockResolvedValue(true),
+  validateSmtpConfig: vi.fn(),
+}));
+
+describe("OTP Brute-Force Lockout Integration", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    app.use(
+      session({
+        secret: "test-session-secret",
+        resave: false,
+        saveUninitialized: false,
+      })
+    );
+    app.use("/api/auth", createAuthRouter());
+  });
+
+  it("locks out user after 3 failed OTP verification attempts", async () => {
+    // 1. Post to login to trigger OTP creation
+    const loginRes = await request(app)
+      .post("/api/auth/login")
+      .send({ email: "doc@example.com", password: "password" });
+
+    expect(loginRes.status).toBe(200);
+    expect(loginRes.body.success).toBe(true);
+    expect(loginRes.body.pendingEmail).toBe("doc@example.com");
+    
+    // In development/test mode, the devOtp is returned in the body
+    const correctOtp = loginRes.body.devOtp;
+    expect(correctOtp).toBeDefined();
+
+    // 2. First failed attempt: should return 401 with 2 attempts remaining
+    const fail1 = await request(app)
+      .post("/api/auth/verify-otp")
+      .send({ email: "doc@example.com", otp: "000000" });
+    
+    expect(fail1.status).toBe(401);
+    expect(fail1.body.message).toContain("2 attempt(s) remaining");
+
+    // 3. Second failed attempt: should return 401 with 1 attempt remaining
+    const fail2 = await request(app)
+      .post("/api/auth/verify-otp")
+      .send({ email: "doc@example.com", otp: "000000" });
+
+    expect(fail2.status).toBe(401);
+    expect(fail2.body.message).toContain("1 attempt(s) remaining");
+
+    // 4. Third failed attempt: should trigger lockout and return 429
+    const fail3 = await request(app)
+      .post("/api/auth/verify-otp")
+      .send({ email: "doc@example.com", otp: "000000" });
+
+    expect(fail3.status).toBe(429);
+    expect(fail3.body.message).toContain("Too many failed attempts");
+
+    // 5. Subsequent attempts: OTP should be deleted, returning 400
+    const fail4 = await request(app)
+      .post("/api/auth/verify-otp")
+      .send({ email: "doc@example.com", otp: "000000" });
+
+    expect(fail4.status).toBe(400);
+    expect(fail4.body.message).toContain("No pending verification found");
+  });
+});


### PR DESCRIPTION
## Description

Implemented a brute-force verification lockout for the two-factor authentication (2FA) OTP flow. Failed OTP entries are now tracked and immediately invalidated after 3 incorrect attempts to mitigate automated guessing attacks.

## Related Issue

Closes #919 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- Added `attempts: number` to the `PendingOtp` interface in `server/auth.ts`.
- Initialized `attempts: 0` in both `/login` and `/resend-otp` generation blocks.
- Added logic inside `/verify-otp` to increment failed attempts and delete the cached OTP on the 3rd failure (returning `429`).
- Created integration tests in `tests/otp-lockout.test.ts` to assert OTP lockout and token deletion logic.

## Screenshots (if applicable)

N/A

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the code style of this project
- [x] My changes generate no new warnings or type errors
- [x] I have performed a self-review of my own code
