### PR TITLE
feat(perf): implement server-side filtering, sorting, and pagination …

### DIFF
--- a/client/src/hooks/use-assessments.ts
+++ b/client/src/hooks/use-assessments.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api, type AssessmentInput, type AssessmentResponse, type AssessmentsListResponse } from "@shared/routes";
 import { useToast } from "./use-toast";
 
@@ -15,22 +15,35 @@ function parseWithLogging<T>(schema: any, data: unknown, label: string): T {
 // The base query key for all assessments list queries.
 const ASSESSMENTS_LIST_QUERY_KEY = api.assessments.list.path;
 
-export function useAssessments() {
-  return useInfiniteQuery({
-    queryKey: [ASSESSMENTS_LIST_QUERY_KEY],
-    queryFn: async ({ pageParam }) => {
+export function useAssessments(params?: {
+  page?: number;
+  limit?: number;
+  sortBy?: string;
+  order?: string;
+  searchTerm?: string;
+  riskCategory?: string;
+  gender?: string;
+  minAge?: number;
+  maxAge?: number;
+  startDate?: string;
+  endDate?: string;
+}) {
+  return useQuery({
+    queryKey: [ASSESSMENTS_LIST_QUERY_KEY, params],
+    queryFn: async () => {
       const url = new URL(api.assessments.list.path, window.location.origin);
-      if (pageParam !== undefined) {
-        url.searchParams.set("cursor", String(pageParam));
+      if (params) {
+        Object.entries(params).forEach(([key, value]) => {
+          if (value !== undefined && value !== null && value !== "") {
+            url.searchParams.set(key, String(value));
+          }
+        });
       }
-      url.searchParams.set("limit", "50");
       const res = await fetch(url.toString(), { credentials: "include" });
       if (!res.ok) throw new Error("Failed to fetch assessments");
       const data = await res.json();
       return parseWithLogging<AssessmentsListResponse>(api.assessments.list.responses[200], data, "assessments.list");
     },
-    initialPageParam: undefined as number | undefined,
-    getNextPageParam: (lastPage) => lastPage.nextCursor,
   });
 }
 

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -62,8 +62,8 @@ export default function Dashboard() {
   const [previewError, setPreviewError] = useState<string | null>(null);
   const { mutate: createAssessment, isPending, error } = useCreateAssessment();
 
-  const { data: infiniteData } = useAssessments();
-  const assessments = infiniteData ? infiniteData.pages.flatMap((page) => page.data) : [];
+  const { data: assessmentsData } = useAssessments({ limit: 50 });
+  const assessments = assessmentsData?.data ?? [];
 
   const stats = useMemo(() => {
     const list = assessments ?? [];

--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -66,11 +66,21 @@ export default function History() {
   const { toast } = useToast();
 
 
-  const { data: infiniteData, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } = useAssessments();
-  const assessments = infiniteData ? infiniteData.pages.flatMap((page) => page.data) : [];
   const [searchTerm, setSearchTerm] = useState("");
   const [sortBy, setSortBy] = useState<string>("date-desc");
   const [currentPage, setCurrentPage] = useState(1);
+
+  // Parse sortBy into field and order for backend query
+  const [sortField, sortOrder] = useMemo(() => {
+    const parts = sortBy.split("-");
+    const fieldMap: Record<string, string> = {
+      date: "createdAt",
+      risk: "riskScore",
+      age: "age",
+      bmi: "bmi"
+    };
+    return [fieldMap[parts[0]] || "createdAt", parts[1] || "desc"];
+  }, [sortBy]);
 
   // New filter state
   const [riskCategory, setRiskCategory] = useState<RiskCategoryFilterValue>("All");
@@ -81,6 +91,22 @@ export default function History() {
   // Date filter state
   const [startDate, setStartDate] = useState<string>("");
   const [endDate, setEndDate] = useState<string>("");
+
+  const { data: assessmentsData, isLoading, error } = useAssessments({
+    page: currentPage,
+    limit: PAGE_SIZE,
+    sortBy: sortField,
+    order: sortOrder,
+    searchTerm: searchTerm || undefined,
+    riskCategory: riskCategory !== "All" ? riskCategory : undefined,
+    gender: gender !== "All" ? gender : undefined,
+    minAge,
+    maxAge,
+    startDate: startDate || undefined,
+    endDate: endDate || undefined
+  });
+
+  const assessments = assessmentsData?.data ?? [];
 
   // Refs to programmatically trigger the pop-up calendar on click
   const startInputRef = useRef<HTMLInputElement>(null);
@@ -329,65 +355,19 @@ export default function History() {
     }, 250);
   }
 
-  const filteredAssessments = useMemo(() => {
-    return filterAssessments(assessments, {
-      searchTerm,
-      riskCategory,
-      gender,
-      ageRange: {
-        min: minAge,
-        max: maxAge,
-      },
-      dateRange: {
-        startDate,
-        endDate,
-      },
-    });
-  }, [assessments, searchTerm, riskCategory, gender, minAge, maxAge, startDate, endDate]);
-
-  // 3. Sorting Records
-  const sortedAssessments = [...filteredAssessments].sort((a, b) => {
-    switch (sortBy) {
-      case "date-desc":
-        return (
-          new Date(b.createdAt || 0).getTime() -
-          new Date(a.createdAt || 0).getTime()
-        );
-      case "date-asc":
-        return (
-          new Date(a.createdAt || 0).getTime() -
-          new Date(b.createdAt || 0).getTime()
-        );
-      case "risk-desc":
-        return Number(b.riskScore) - Number(a.riskScore);
-      case "risk-asc":
-        return Number(a.riskScore) - Number(b.riskScore);
-      case "age-desc":
-        return b.age - a.age;
-      case "age-asc":
-        return a.age - b.age;
-      case "bmi-desc":
-        return Number(b.bmi) - Number(a.bmi);
-      case "bmi-asc":
-        return Number(a.bmi) - Number(b.bmi);
-      default:
-        return 0;
-    }
-  });
-
   const latestBadgeAssessment = useMemo(() => {
-    if (sortedAssessments.length === 0) return null;
+    if (assessments.length === 0) return null;
     return (
-      sortedAssessments.find((assessment) =>
-        calculateHealthBadges(assessment, sortedAssessments).length > 0
-      ) || sortedAssessments[0]
+      assessments.find((assessment) =>
+        calculateHealthBadges(assessment, assessments).length > 0
+      ) || assessments[0]
     );
-  }, [sortedAssessments]);
+  }, [assessments]);
 
   const latestBadges = useMemo(() => {
     if (!latestBadgeAssessment) return [];
-    return calculateHealthBadges(latestBadgeAssessment, sortedAssessments);
-  }, [latestBadgeAssessment, sortedAssessments]);
+    return calculateHealthBadges(latestBadgeAssessment, assessments);
+  }, [latestBadgeAssessment, assessments]);
 
   const selectedPatientBadges = useMemo(() => {
     const sortedHistory = [...selectedPatientHistory].sort(
@@ -405,15 +385,12 @@ export default function History() {
     setCurrentPage(1);
   }, [searchTerm, riskCategory, gender, minAge, maxAge, startDate, endDate, sortBy]);
 
-  // 4. Pagination
-  const totalRecords = assessments.length;
-  const filteredRecords = sortedAssessments.length;
-  const totalPages = Math.max(1, Math.ceil(filteredRecords / PAGE_SIZE));
-  const safePage = Math.min(currentPage, totalPages);
-  const paginatedAssessments = sortedAssessments.slice(
-    (safePage - 1) * PAGE_SIZE,
-    safePage * PAGE_SIZE
-  );
+  // 4. Pagination (Server-Side)
+  const totalRecords = assessmentsData?.total ?? 0;
+  const filteredRecords = assessmentsData?.total ?? 0;
+  const totalPages = assessmentsData?.totalPages ?? 1;
+  const safePage = currentPage;
+  const paginatedAssessments = assessments;
 
   const formatAssessmentDate = (dateVal: any) => {
     if (!dateVal) return "Unknown";
@@ -753,20 +730,7 @@ export default function History() {
                   <ChevronRight className="w-4 h-4 ml-1" />
                 </button>
 
-                {hasNextPage && (
-                  <button
-                    type="button"
-                    onClick={() => fetchNextPage()}
-                    disabled={isFetchingNextPage}
-                    className="inline-flex items-center justify-center p-2 px-4 rounded-xl border border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100 disabled:opacity-40 transition-colors shadow-sm cursor-pointer mr-4 font-bold text-sm"
-                  >
-                    {isFetchingNextPage ? (
-                      <><Loader2 className="w-4 h-4 mr-2 animate-spin" /> Loading...</>
-                    ) : (
-                      "Load More from Server"
-                    )}
-                  </button>
-                )}
+
               </div>
             </div>
           </div>

--- a/server/repositories/assessment.repository.ts
+++ b/server/repositories/assessment.repository.ts
@@ -1,24 +1,208 @@
 import { getDb } from "../db";
-import { and, desc, eq, ilike, or, lt } from "drizzle-orm";
+import { and, desc, eq, ilike, or, lt, asc, sql, gte, lte, ne, not } from "drizzle-orm";
 import { assessments, type Assessment } from "@shared/schema";
 import type { RiskCategory } from "../validation/searchValidation";
 import type { AssessmentCreateInput } from "../storage";
 
 export class AssessmentRepository {
   async getAssessments(
-    limit: number = 20,
+    limitOrParams?: number | {
+      limit?: number;
+      page?: number;
+      cursor?: number;
+      createdBy?: string;
+      sortBy?: string;
+      order?: "asc" | "desc";
+      searchTerm?: string;
+      riskCategory?: string;
+      gender?: string;
+      minAge?: number;
+      maxAge?: number;
+      startDate?: string;
+      endDate?: string;
+    },
     cursor?: number,
     createdBy?: string
-  ): Promise<{ data: Assessment[]; nextCursor: number | null }> {
+  ): Promise<{
+    data: Assessment[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+    nextCursor: number | null;
+  }> {
     const db = getDb();
-    const filters: ReturnType<typeof eq>[] = [];
+    
+    let limit = 20;
+    let page = 1;
+    let sortBy = "createdAt";
+    let order: "asc" | "desc" = "desc";
+    let searchTerm: string | undefined;
+    let riskCategory: string | undefined;
+    let gender: string | undefined;
+    let minAge: number | undefined;
+    let maxAge: number | undefined;
+    let startDate: string | undefined;
+    let endDate: string | undefined;
+
+    if (typeof limitOrParams === "object" && limitOrParams !== null) {
+      limit = limitOrParams.limit ?? 20;
+      page = limitOrParams.page ?? 1;
+      createdBy = limitOrParams.createdBy;
+      sortBy = limitOrParams.sortBy ?? "createdAt";
+      order = limitOrParams.order ?? "desc";
+      searchTerm = limitOrParams.searchTerm;
+      riskCategory = limitOrParams.riskCategory;
+      gender = limitOrParams.gender;
+      minAge = limitOrParams.minAge;
+      maxAge = limitOrParams.maxAge;
+      startDate = limitOrParams.startDate;
+      endDate = limitOrParams.endDate;
+      cursor = limitOrParams.cursor;
+    } else {
+      limit = limitOrParams ?? 20;
+    }
+
+    const filters: any[] = [];
 
     if (createdBy) {
       filters.push(eq(assessments.createdBy, createdBy));
     }
-    if (cursor !== undefined) {
-      filters.push(lt(assessments.id, cursor) as any);
+
+    if (gender && gender !== "All") {
+      if (gender === "Other") {
+        filters.push(not(or(eq(assessments.gender, "Male"), eq(assessments.gender, "Female"))));
+      } else {
+        filters.push(eq(assessments.gender, gender));
+      }
     }
+
+    if (riskCategory && riskCategory !== "All") {
+      filters.push(eq(assessments.riskCategory, riskCategory.toUpperCase()));
+    }
+
+    if (minAge !== undefined) {
+      filters.push(gte(assessments.age, minAge));
+    }
+
+    if (maxAge !== undefined) {
+      filters.push(lte(assessments.age, maxAge));
+    }
+
+    if (startDate && !isNaN(Date.parse(startDate))) {
+      filters.push(gte(assessments.createdAt, new Date(startDate)));
+    }
+
+    if (endDate && !isNaN(Date.parse(endDate))) {
+      const end = new Date(endDate);
+      end.setHours(23, 59, 59, 999);
+      filters.push(lte(assessments.createdAt, end));
+    }
+
+    if (searchTerm && searchTerm.trim() !== "") {
+      const pattern = `%${searchTerm.trim()}%`;
+      filters.push(
+        or(
+          ilike(assessments.patientName, pattern),
+          ilike(assessments.gender, pattern),
+          ilike(assessments.riskCategory, pattern),
+          ilike(assessments.smokingHistory, pattern)
+        )
+      );
+    }
+
+    // 1. Get total matching count
+    let countQuery = db
+      .select({ count: sql<number>`count(*)` })
+      .from(assessments);
+
+    if (filters.length > 0) {
+      countQuery = countQuery.where(and(...filters)) as any;
+    }
+
+    const countResult = await countQuery;
+    const total = Number(countResult[0]?.count ?? 0);
+
+    // 2. Fetch data page
+    let orderFn = order === "asc" ? asc : desc;
+    let orderByClause: any;
+
+    switch (sortBy) {
+      case "date":
+      case "createdAt":
+        orderByClause = orderFn(assessments.createdAt);
+        break;
+      case "risk":
+      case "riskScore":
+        orderByClause = orderFn(assessments.riskScore);
+        break;
+      case "age":
+        orderByClause = orderFn(assessments.age);
+        break;
+      case "bmi":
+        orderByClause = orderFn(assessments.bmi);
+        break;
+      case "patientName":
+        orderByClause = orderFn(assessments.patientName);
+        break;
+      case "gender":
+        orderByClause = orderFn(assessments.gender);
+        break;
+      default:
+        orderByClause = desc(assessments.id);
+        break;
+    }
+
+    const totalPages = Math.ceil(total / limit);
+
+    // Handle cursor pagination fallback if cursor is explicitly passed
+    if (cursor !== undefined) {
+      const cursorFilters = [...filters];
+      cursorFilters.push(lt(assessments.id, cursor) as any);
+
+      let query = db
+        .select({
+          id: assessments.id,
+          patientName: assessments.patientName,
+          gender: assessments.gender,
+          age: assessments.age,
+          hypertension: assessments.hypertension,
+          heartDisease: assessments.heartDisease,
+          smokingHistory: assessments.smokingHistory,
+          bmi: assessments.bmi,
+          hba1cLevel: assessments.hba1cLevel,
+          bloodGlucoseLevel: assessments.bloodGlucoseLevel,
+          riskScore: assessments.riskScore,
+          riskCategory: assessments.riskCategory,
+          factors: assessments.factors,
+          confidenceInterval: (assessments as any).confidenceInterval ?? (assessments as any).confidence_interval,
+          modelConfidence: (assessments as any).modelConfidence ?? (assessments as any).model_confidence,
+          createdAt: (assessments as any).createdAt ?? (assessments as any).created_at,
+          createdBy: (assessments as any).createdBy ?? (assessments as any).created_by,
+          userId: (assessments as any).userId ?? (assessments as any).user_id,
+        })
+        .from(assessments)
+        .orderBy(desc(assessments.id))
+        .$dynamic();
+
+      const selectQuery = query.limit(limit + 1);
+      const data = await selectQuery.where(and(...cursorFilters));
+
+      const hasNext = data.length > limit;
+      const pagedData = hasNext ? data.slice(0, limit) : data;
+      const nextCursor = hasNext && pagedData.length > 0 ? pagedData[pagedData.length - 1].id : null;
+
+      return {
+        data: pagedData,
+        total,
+        page: 1,
+        limit,
+        totalPages,
+        nextCursor
+      };
+    }
+
+    const offset = (page - 1) * limit;
 
     let query = db
       .select({
@@ -42,22 +226,25 @@ export class AssessmentRepository {
         userId: (assessments as any).userId ?? (assessments as any).user_id,
       })
       .from(assessments)
-      .orderBy(desc(assessments.id))
+      .orderBy(orderByClause, desc(assessments.id))
       .$dynamic();
 
-    let data: Assessment[];
-    const selectQuery = query.limit(limit + 1);
     if (filters.length > 0) {
-      data = await selectQuery.where(and(...filters));
-    } else {
-      data = await selectQuery;
+      query = query.where(and(...filters)) as any;
     }
 
-    const hasNext = data.length > limit;
-    const pagedData = hasNext ? data.slice(0, limit) : data;
-    const nextCursor = hasNext && pagedData.length > 0 ? pagedData[pagedData.length - 1].id : null;
+    const data = await query.limit(limit).offset(offset);
+    const hasNext = page < totalPages;
+    const nextCursor = hasNext && data.length > 0 ? data[data.length - 1].id : null;
 
-    return { data: pagedData, nextCursor };
+    return {
+      data,
+      total,
+      page,
+      limit,
+      totalPages,
+      nextCursor
+    };
   }
 
   async searchAssessments(

--- a/server/routes/assessments.routes.ts
+++ b/server/routes/assessments.routes.ts
@@ -12,7 +12,7 @@ import {
   analyzeSearchInput,
   logSecurityEvent,
 } from "../security/sqlProtection";
-import { searchQuerySchema } from "../validation/searchValidation";
+import { searchQuerySchema, assessmentsQuerySchema } from "../validation/searchValidation";
 import { canAccessPatientRecord } from "../services/authz/patient-access";
 import { logAccessAttempt } from "../security/access-audit";
 import { validateDTO } from "../middleware/validateDTO";
@@ -165,16 +165,22 @@ assessmentsRouter.get(
     try {
       const userEmail = req.session.user?.email;
       
-      const limit = Math.min(
-        100,
-        Math.max(1, parseInt(req.query.limit as string) || 20)
-      );
-      const cursor = req.query.cursor ? parseInt(req.query.cursor as string, 10) : undefined;
-      
-      const result = await storage.getAssessments(limit, cursor, userEmail);
+      const parseResult = assessmentsQuerySchema.safeParse(req.query);
+      if (!parseResult.success) {
+        return res.status(400).json({
+          message: parseResult.error.errors[0]?.message ?? "Invalid query parameters.",
+        });
+      }
+
+      const params = parseResult.data;
+      const result = await storage.getAssessments({
+        ...params,
+        createdBy: userEmail,
+      });
 
       res.json(result);
     } catch (err) {
+      logger.error({ err }, "Fetch assessments error:");
       return res.status(500).json({ message: "Failed to fetch assessments" });
     }
   }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -7,7 +7,32 @@ import { AuditRepository } from "./repositories/audit.repository";
 import { AnalyticsRepository } from "./repositories/analytics.repository";
 
 export interface IStorage {
-  getAssessments(limit?: number, cursor?: number, createdBy?: string): Promise<{ data: Assessment[]; nextCursor: number | null }>;
+  getAssessments(
+    limitOrParams?: number | {
+      limit?: number;
+      page?: number;
+      cursor?: number;
+      createdBy?: string;
+      sortBy?: string;
+      order?: "asc" | "desc";
+      searchTerm?: string;
+      riskCategory?: string;
+      gender?: string;
+      minAge?: number;
+      maxAge?: number;
+      startDate?: string;
+      endDate?: string;
+    },
+    cursor?: number,
+    createdBy?: string
+  ): Promise<{
+    data: Assessment[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+    nextCursor: number | null;
+  }>;
   /**
    * Searches assessments by patient name, risk category, and other fields.
    * Uses Drizzle ORM ilike()/eq() — user input is NEVER interpolated into SQL strings.
@@ -48,200 +73,13 @@ export type AssessmentCreateInput = InsertAssessment & {
 };
 
 export class DatabaseStorage implements IStorage {
-  async getAssessments(
-    limit: number = 50,
-    offset: number = 0,
-    createdBy?: string
-  ): Promise<Assessment[]> {
-    const db = getDb();
 
-    const filters: any[] = [];
-
-    // Filter by createdBy when provided to ensure users only see their own assessments
-    if (createdBy) {
-      const createdByCol = (assessments as any).createdBy ?? (assessments as any).created_by;
-      if (createdByCol) {
-        filters.push(eq(createdByCol, createdBy));
-      }
-    }
-
-
-
-
-    // Avoid selecting non-existent columns (e.g., created_by in older DB states)
-    // by explicitly selecting only columns known to exist in migrations.
-    const query = db
-      .select({
-        id: assessments.id,
-        patientName: assessments.patientName,
-        gender: assessments.gender,
-        age: assessments.age,
-        hypertension: assessments.hypertension,
-        heartDisease: (assessments as any).heartDisease ?? (assessments as any).heart_disease,
-        smokingHistory:
-          (assessments as any).smokingHistory ?? (assessments as any).smoking_history,
-        bmi: assessments.bmi,
-        hba1cLevel:
-          (assessments as any).hba1cLevel ?? (assessments as any).hba1c_level,
-        bloodGlucoseLevel:
-          (assessments as any).bloodGlucoseLevel ?? (assessments as any).blood_glucose_level,
-        riskScore:
-          (assessments as any).riskScore ?? (assessments as any).risk_score,
-        riskCategory:
-          (assessments as any).riskCategory ?? (assessments as any).risk_category,
-        factors: assessments.factors,
-        confidenceInterval:
-          (assessments as any).confidenceInterval ?? (assessments as any).confidence_interval,
-        modelConfidence:
-          (assessments as any).modelConfidence ?? (assessments as any).model_confidence,
-        createdBy:
-          (assessments as any).createdBy ?? (assessments as any).created_by,
-        createdAt:
-          (assessments as any).createdAt ?? (assessments as any).created_at,
-        userId:
-          (assessments as any).userId ?? (assessments as any).user_id,
-      })
-      .from(assessments)
-      .orderBy(desc((assessments as any).createdAt ?? (assessments as any).created_at))
-      .$dynamic();
-
-
-
-
-
-    if (filters.length > 0) {
-      return await query.where(and(...filters)).limit(limit).offset(offset);
-    }
-
-    return await query.limit(limit).offset(offset);
-  }
-
-  /**
-   * Searches assessments by risk category label.
-   *
-   * Security: all conditions use Drizzle ORM parameterized helpers (ilike / eq).
-   * User-supplied `searchTerm` is passed as a bound parameter — never concatenated
-   * into a raw SQL string.  This is the primary defence against SQL injection.
-   *
-   * @param searchTerm   Free-text search term (validated upstream by searchValidation.ts)
-   * @param createdBy    Restrict results to this user's own records
-   * @param riskCategory Optional filter: LOW | MODERATE | HIGH
-   * @param limit        Maximum rows to return (default 20)
-   * @param offset       Pagination offset (default 0)
-   */
-  async searchAssessments(
-    searchTerm: string,
-    createdBy?: string,
-    riskCategory?: RiskCategory,
-    limit: number = 20,
-    offset: number = 0
-  ): Promise<Assessment[]> {
-    const db = getDb();
-
-    // Build an array of WHERE conditions — all parameterized by Drizzle ORM.
-    // ilike() maps to: WHERE column ILIKE $1   (PostgreSQL bound parameter)
-    // eq()    maps to: WHERE column = $1
-    const conditions: ReturnType<typeof eq>[] = [];
-
-    // Always scope results to the requesting user when available
-    if (createdBy) {
-      conditions.push(eq(assessments.createdBy, createdBy));
-    }
-
-    // Risk category exact-match filter (parameterized)
-    if (riskCategory) {
-      conditions.push(eq(assessments.riskCategory, riskCategory));
-    }
-
-    // Free-text search across gender and smokingHistory fields
-    // ilike() uses PostgreSQL's case-insensitive LIKE with bound parameters:
-    //   WHERE (gender ILIKE $N OR smoking_history ILIKE $N)
-    // The `searchTerm` value is NEVER interpolated — Drizzle sends it as a placeholder.
-    if (searchTerm && searchTerm.trim() !== "") {
-      const pattern = `%${searchTerm.trim()}%`;
-        conditions.push(
-          or(
-            ilike(assessments.patientName, pattern),   // ← ADD THIS LINE
-            ilike(assessments.gender, pattern),
-            ilike(assessments.smokingHistory, pattern),
-            ilike(assessments.riskCategory, pattern)
-          ) as ReturnType<typeof eq>
-        );
-    }
-
-    let query = db
-      .select()
-      .from(assessments)
-      .orderBy(desc(assessments.createdAt))
-      .$dynamic();
-
-    if (conditions.length > 0) {
-      query = query.where(and(...conditions));
-    }
-
-    return await query.limit(limit).offset(offset);
-  }
-
-  /**
-   * Retrieves a single assessment by its numeric primary key.
-   * NOTE: This function no longer implicitly scopes by `createdBy`.
-   * Object-Level Authorization must be explicitly checked by the caller using `canAccessPatientRecord`.
-   *
-   * Security: uses Drizzle ORM eq() — parameterized, not string-concatenated.
-   */
-  async getAssessmentById(
-    id: number
-  ): Promise<Assessment | undefined> {
-    const db = getDb();
-
-    const conditions: ReturnType<typeof eq>[] = [eq(assessments.id, id)];
-
-    const [result] = await db
-      .select()
-      .from(assessments)
-      .where(and(...conditions))
-      .limit(1);
-
-    return result;
-  }
-
-  async createAssessment(
-    assessment: AssessmentCreateInput
-  ): Promise<Assessment> {
-
-    const db = getDb();
-
-    const [created] = await db
-      .insert(assessments)
-      .values(assessment as any)
-      .returning();
-
-    return created;
-  }
-
-  async createUser(data: InsertUser): Promise<User> {
-    const db = getDb();
-    const [user] = await db.insert(users).values(data).returning();
-    return user;
-  }
-
-  async getUserByEmail(email: string): Promise<User | undefined> {
-    const db = getDb();
-    const [user] = await db.select().from(users).where(eq(users.email, email));
-    return user;
-  }
-
-  async getUserById(id: string): Promise<User | undefined> {
-    const db = getDb();
-    const [user] = await db.select().from(users).where(eq(users.id, id));
-    return user;
-  }
   private assessmentRepository = new AssessmentRepository();
   private userRepository = new UserRepository();
   private auditRepository = new AuditRepository();
   private analyticsRepository = new AnalyticsRepository();
 
-  getAssessments(limit?: number, cursor?: number, createdBy?: string) { return this.assessmentRepository.getAssessments(limit, cursor, createdBy); }
+  getAssessments(limitOrParams?: number | Parameters<AssessmentRepository["getAssessments"]>[0], cursor?: number, createdBy?: string) { return this.assessmentRepository.getAssessments(limitOrParams, cursor, createdBy); }
   searchAssessments(searchTerm: string, createdBy?: string, riskCategory?: RiskCategory, limit?: number, cursor?: number) { return this.assessmentRepository.searchAssessments(searchTerm, createdBy, riskCategory, limit, cursor); }
   getAssessmentById(id: number) { return this.assessmentRepository.getAssessmentById(id); }
   createAssessment(assessment: any) { return this.assessmentRepository.createAssessment(assessment); }

--- a/server/validation/searchValidation.ts
+++ b/server/validation/searchValidation.ts
@@ -115,3 +115,109 @@ export const searchQuerySchema = z.object({
 });
 
 export type SearchQueryParams = z.infer<typeof searchQuerySchema>;
+
+export const assessmentsQuerySchema = z.object({
+  cursor: z.coerce
+    .number()
+    .int("Cursor must be an integer")
+    .optional(),
+
+  page: z.coerce
+    .number()
+    .int("Page must be an integer")
+    .min(1, "Page must be at least 1")
+    .default(1),
+
+  limit: z.coerce
+    .number()
+    .int("Limit must be an integer")
+    .min(1, "Limit must be at least 1")
+    .max(100, "Limit must not exceed 100")
+    .default(50),
+
+  sortBy: z
+    .enum(["createdAt", "date", "riskScore", "risk", "age", "bmi", "patientName", "gender"])
+    .optional()
+    .default("createdAt"),
+
+  order: z
+    .enum(["asc", "desc"])
+    .optional()
+    .default("desc"),
+
+  searchTerm: z
+    .string()
+    .max(MAX_SEARCH_LENGTH, `Search query must not exceed ${MAX_SEARCH_LENGTH} characters`)
+    .optional()
+    .transform((val) => (val === undefined ? "" : val.trim()))
+    .refine(
+      (val) => val === "" || ALLOWED_SEARCH_CHARS_PATTERN.test(val),
+      {
+        message:
+          "Search query contains invalid characters. Only letters, numbers, spaces, hyphens, apostrophes, and periods are allowed.",
+      }
+    )
+    .refine(
+      (val) => {
+        if (val === "") return true;
+        return detectSqlInjectionPattern(val) === null;
+      },
+      {
+        message: "Search query contains a disallowed pattern.",
+      }
+    ),
+
+  riskCategory: z
+    .string()
+    .optional()
+    .transform((val) => val ? val.trim().toUpperCase() : undefined)
+    .refine((val) => !val || ["LOW", "MODERATE", "HIGH", "ALL"].includes(val), {
+      message: "Invalid risk category",
+    }),
+
+  gender: z
+    .string()
+    .optional()
+    .transform((val) => {
+      if (!val) return undefined;
+      const normalized = val.trim().toLowerCase();
+      if (normalized === "male") return "Male";
+      if (normalized === "female") return "Female";
+      if (normalized === "other") return "Other";
+      if (normalized === "all") return "All";
+      return val;
+    })
+    .refine((val) => !val || ["Male", "Female", "Other", "All"].includes(val), {
+      message: "Invalid gender value",
+    }),
+
+  minAge: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .max(120)
+    .optional(),
+
+  maxAge: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .max(120)
+    .optional(),
+
+  startDate: z
+    .string()
+    .optional()
+    .refine((val) => !val || !Number.isNaN(Date.parse(val)), {
+      message: "Invalid start date format",
+    }),
+
+  endDate: z
+    .string()
+    .optional()
+    .refine((val) => !val || !Number.isNaN(Date.parse(val)), {
+      message: "Invalid end date format",
+    }),
+});
+
+export type AssessmentsQueryParams = z.infer<typeof assessmentsQuerySchema>;

--- a/shared/routes.ts
+++ b/shared/routes.ts
@@ -38,7 +38,11 @@ export const api = {
       responses: {
         200: z.object({
           data: z.array(z.custom<typeof assessments.$inferSelect>()),
-          nextCursor: z.number().nullable(),
+          nextCursor: z.number().nullable().optional(),
+          total: z.number(),
+          page: z.number(),
+          limit: z.number(),
+          totalPages: z.number(),
         }),
       },
     },


### PR DESCRIPTION
## Description

This PR implements server-side filtering, sorting, and offset-based pagination for the Patient History assessment list. Previously, all assessment entries were pulled into the client-side state and filtered/sorted in the browser's main thread. This PR offloads these query operations directly to the database layer (via Drizzle ORM), optimizing memory usage, load times, and interface responsiveness on large datasets.

## Related Issue

Closes #904

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [x] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- **Backend Route & Request Validation**:
  - Configured `assessmentsQuerySchema` in `searchValidation.ts` to validate sorting columns (`sortBy`, `order`), age range (`minAge`, `maxAge`), gender, riskCategory, start/end dates, search query (`searchTerm`), and pagination limits.
  - Integrated this validator on the `GET /api/assessments` endpoint in `assessments.routes.ts`.
- **Database Query Offloading**:
  - Refactored `AssessmentRepository.getAssessments()` in `assessment.repository.ts` to dynamically construct `.where(...)` and `.orderBy(...)` clauses.
  - Added a count query to return the total matching assessments count.
  - Removed duplicate deprecated inline methods in `DatabaseStorage` class body to clean up duplicate-member compiler warnings.
- **API Hook Refactoring**:
  - Refactored `useAssessments` in `use-assessments.ts` from `useInfiniteQuery` to page-cached `useQuery`, referencing the dynamic sorting and filtering states as caching keys.
- **Frontend UI Optimization**:
  - Cleaned up client-side `useMemo` array mutations (`filterAssessments` / `sortedAssessments`) from `History.tsx`.
  - Bound the table filters and sorting headers directly to the page state and backend queries.
  - Transitioned the pagination footer to discrete page increment navigation (Page X of Y).
  - Adapted `Dashboard.tsx` to handle the updated `useAssessments` pagination response data.

## Screenshots (if applicable)

<!-- Add before/after screenshots for UI changes -->

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors
