### PR TITLE
feat: add patient summary PDF export

### DIFF
--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -31,6 +31,7 @@ import { ActiveFilterChips } from "@/components/ActiveFilterChips";
 import { ClearFiltersButton } from "@/components/ClearFiltersButton";
 import { validateSearchInput } from "@/validation/filterValidation";
 import AssessmentComparisonCard from "@/components/AssessmentComparisonCard";
+import { downloadPatientSummaryPdf } from "@/utils/clinicalPdfReport";
 
 function HighlightText({ text, search }: { text: string; search: string }) {
   if (!search.trim()) return <>{text}</>;
@@ -380,6 +381,29 @@ export default function History() {
     return calculateHealthBadges(sortedHistory[0], sortedHistory);
   }, [selectedPatientHistory]);
 
+  const sortedSelectedPatientHistory = useMemo(
+    () =>
+      [...selectedPatientHistory].sort(
+        (a, b) =>
+          new Date(b.createdAt || 0).getTime() -
+          new Date(a.createdAt || 0).getTime()
+      ),
+    [selectedPatientHistory]
+  );
+
+  const handleExportPatientSummary = () => {
+    if (sortedSelectedPatientHistory.length === 0) {
+      toast({
+        title: "No patient history available",
+        description: "Select a patient with assessment history before exporting a summary.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    downloadPatientSummaryPdf(sortedSelectedPatientHistory);
+  };
+
   // Reset to first page when filters or sort change
   useEffect(() => {
     setCurrentPage(1);
@@ -390,6 +414,7 @@ export default function History() {
   const filteredRecords = assessmentsData?.total ?? 0;
   const totalPages = assessmentsData?.totalPages ?? 1;
   const safePage = currentPage;
+  const sortedAssessments = assessments;
   const paginatedAssessments = assessments;
 
   const formatAssessmentDate = (dateVal: any) => {
@@ -738,7 +763,7 @@ export default function History() {
         )}
       </div>
 
-      <Sheet open={!!selectedPatientName} onOpenChange={(open) => !open && setSelectedPatientName(null)}>
+      <Sheet open={!!selectedPatientName} onOpenChange={(open) => !open && setSelectedPatientKey(null)}>
         <SheetContent className="w-full sm:max-w-2xl overflow-y-auto sm:border-l sm:border-slate-200">
           <SheetHeader className="mb-6">
             <SheetTitle className="text-2xl font-bold font-display">Longitudinal Trajectory</SheetTitle>
@@ -747,6 +772,15 @@ export default function History() {
           
           {selectedPatientHistory.length > 0 && (
             <div className="space-y-6 pb-12">
+              <button
+                type="button"
+                onClick={handleExportPatientSummary}
+                className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-3 text-sm font-bold text-white shadow-sm transition-colors hover:bg-blue-700 sm:w-auto"
+              >
+                <FileText className="h-4 w-4" />
+                Export Patient Summary PDF
+              </button>
+
               <HealthBadges
                 badges={selectedPatientBadges}
                 title="Patient improvement badges"
@@ -765,7 +799,7 @@ export default function History() {
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-border">
-                    {selectedPatientHistory.sort((a, b) => new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime()).map((a) => (
+                    {sortedSelectedPatientHistory.map((a) => (
                       <tr key={a.id} className="hover:bg-muted/30 transition-colors">
                         <td className="p-3 whitespace-nowrap">{formatAssessmentDate(a.createdAt)}</td>
                         <td className="p-3 font-bold text-foreground">{Number(a.riskScore).toFixed(1)}%</td>
@@ -783,6 +817,5 @@ export default function History() {
     </AppLayout>
   );
 }
-
 
 

--- a/client/src/utils/clinicalPdfReport.test.ts
+++ b/client/src/utils/clinicalPdfReport.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { preparePatientSummaryReport, type PatientSummaryAssessment } from "./clinicalPdfReport";
+
+const baseAssessment: PatientSummaryAssessment = {
+  id: 1,
+  patientName: "Jane Doe",
+  gender: "Female",
+  age: 52,
+  createdAt: "2026-01-01T10:00:00.000Z",
+  riskScore: 22,
+  riskCategory: "LOW",
+  bmi: 25.2,
+  hba1cLevel: 6.1,
+  bloodGlucoseLevel: 105,
+  hypertension: false,
+  heartDisease: false,
+  smokingHistory: "never",
+  factors: [
+    {
+      name: "BMI",
+      impact: "positive",
+      description: "BMI increased risk.",
+    },
+  ],
+};
+
+describe("preparePatientSummaryReport", () => {
+  it("sorts patient history and summarizes latest assessment details", () => {
+    const summary = preparePatientSummaryReport([
+      baseAssessment,
+      {
+        ...baseAssessment,
+        id: 2,
+        createdAt: "2026-03-01T10:00:00.000Z",
+        riskScore: 18,
+        riskCategory: "LOW",
+        bmi: 24.1,
+        hba1cLevel: 5.8,
+        bloodGlucoseLevel: 98,
+      },
+    ]);
+
+    expect(summary.patientName).toBe("Jane Doe");
+    expect(summary.latest?.id).toBe(2);
+    expect(summary.assessmentCount).toBe(2);
+    expect(summary.historyRows[0][1]).toBe("18.0%");
+    expect(summary.trendSummary).toContain("Risk score: decreased by 4.0% from first to latest assessment.");
+    expect(summary.trendSummary).toContain("BMI: decreased by 1.1 from first to latest assessment.");
+  });
+
+  it("handles a single assessment without failing trend preparation", () => {
+    const summary = preparePatientSummaryReport([baseAssessment]);
+
+    expect(summary.assessmentCount).toBe(1);
+    expect(summary.latestRows).toContainEqual(["Assessments Reviewed", "1"]);
+    expect(summary.trendSummary).toContain("Risk score: remained stable by 0.0% from first to latest assessment.");
+  });
+
+  it("handles empty or missing patient fields gracefully", () => {
+    const summary = preparePatientSummaryReport([
+      {
+        ...baseAssessment,
+        patientName: "",
+        gender: "",
+        age: undefined as unknown as number,
+        riskScore: undefined as unknown as number,
+      },
+    ]);
+
+    expect(summary.patientName).toBe("Unknown Patient");
+    expect(summary.demographics).toContainEqual(["Gender", "N/A"]);
+    expect(summary.demographics).toContainEqual(["Age", "N/A"]);
+    expect(summary.latestRows).toContainEqual(["Latest Risk Score", "N/A"]);
+  });
+
+  it("deduplicates recent risk factors by name", () => {
+    const factors = JSON.stringify([
+      { name: "BMI", impact: "positive", description: "BMI risk." },
+      { name: "HbA1c Level", impact: "positive", description: "Glucose control risk." },
+    ]);
+
+    const summary = preparePatientSummaryReport([
+      { ...baseAssessment, id: 2, createdAt: "2026-02-01T10:00:00.000Z", factors },
+      { ...baseAssessment, id: 1, factors },
+    ]);
+
+    expect(summary.recentFactors.map((factor) => factor.name)).toEqual(["BMI", "HbA1c Level"]);
+  });
+});

--- a/client/src/utils/clinicalPdfReport.ts
+++ b/client/src/utils/clinicalPdfReport.ts
@@ -1,6 +1,23 @@
 import { type AssessmentResponse } from "@shared/routes";
 
 type ReportAssessment = AssessmentResponse;
+export type PatientSummaryAssessment = Pick<
+  ReportAssessment,
+  | "id"
+  | "patientName"
+  | "gender"
+  | "age"
+  | "createdAt"
+  | "riskScore"
+  | "riskCategory"
+  | "bmi"
+  | "hba1cLevel"
+  | "bloodGlucoseLevel"
+  | "hypertension"
+  | "heartDisease"
+  | "smokingHistory"
+  | "factors"
+>;
 
 type PdfFont = "regular" | "bold" | "italic";
 
@@ -340,6 +357,167 @@ function getReportFilename(assessment: ReportAssessment): string {
   const id = assessment.id ?? "report";
   const patient = (assessment.patientName || "patient").replace(/[^a-z0-9]+/gi, "-").replace(/^-|-$/g, "");
   return `clinical-risk-assessment-${patient || "patient"}-${id}.pdf`;
+}
+
+function toNumber(value: unknown): number | null {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function compareAssessmentDatesDesc(a: PatientSummaryAssessment, b: PatientSummaryAssessment): number {
+  return new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime();
+}
+
+function trendLine(label: string, latestValue: unknown, baselineValue: unknown, suffix = ""): string {
+  const latest = toNumber(latestValue);
+  const baseline = toNumber(baselineValue);
+
+  if (latest === null || baseline === null) {
+    return `${label}: not enough numeric data to calculate a trend.`;
+  }
+
+  const delta = latest - baseline;
+  const direction = delta > 0 ? "increased" : delta < 0 ? "decreased" : "remained stable";
+  const absoluteDelta = Math.abs(delta).toFixed(1);
+  return `${label}: ${direction} by ${absoluteDelta}${suffix} from first to latest assessment.`;
+}
+
+export interface PatientSummaryReport {
+  patientName: string;
+  demographics: Array<[string, string]>;
+  latest: PatientSummaryAssessment | null;
+  latestRows: Array<[string, string]>;
+  trendSummary: string[];
+  recentFactors: RiskFactor[];
+  historyRows: Array<[string, string, string, string, string]>;
+  assessmentCount: number;
+}
+
+export function preparePatientSummaryReport(
+  assessments: PatientSummaryAssessment[],
+): PatientSummaryReport {
+  const sorted = [...assessments].sort(compareAssessmentDatesDesc);
+  const latest = sorted[0] ?? null;
+  const baseline = sorted[sorted.length - 1] ?? null;
+  const patientName = formatValue(latest?.patientName || assessments[0]?.patientName || "Unknown Patient");
+  const factorsByName = new Map<string, RiskFactor>();
+
+  sorted.slice(0, 3).forEach((assessment) => {
+    normalizeFactors(assessment.factors).forEach((factor) => {
+      const key = factor.name.trim().toLowerCase();
+      if (key && !factorsByName.has(key)) {
+        factorsByName.set(key, factor);
+      }
+    });
+  });
+
+  return {
+    patientName,
+    demographics: [
+      ["Patient Name", patientName],
+      ["Gender", formatValue(latest?.gender)],
+      ["Age", formatValue(latest?.age)],
+      ["Smoking History", formatValue(latest?.smokingHistory)],
+      ["Hypertension", formatValue(latest?.hypertension)],
+      ["Heart Disease", formatValue(latest?.heartDisease)],
+    ],
+    latest,
+    latestRows: [
+      ["Latest Assessment", formatDate(latest?.createdAt)],
+      ["Latest Risk Category", formatValue(latest?.riskCategory)],
+      ["Latest Risk Score", formatNumber(latest?.riskScore, 1, "%")],
+      ["Assessments Reviewed", String(sorted.length)],
+    ],
+    trendSummary: latest && baseline
+      ? [
+          trendLine("Risk score", latest.riskScore, baseline.riskScore, "%"),
+          trendLine("BMI", latest.bmi, baseline.bmi),
+          trendLine("HbA1c", latest.hba1cLevel, baseline.hba1cLevel, "%"),
+          trendLine("Blood glucose", latest.bloodGlucoseLevel, baseline.bloodGlucoseLevel),
+        ]
+      : [
+          "Risk score: not enough assessment history to calculate a trend.",
+          "BMI: not enough assessment history to calculate a trend.",
+          "HbA1c: not enough assessment history to calculate a trend.",
+          "Blood glucose: not enough assessment history to calculate a trend.",
+        ],
+    recentFactors: Array.from(factorsByName.values()).slice(0, 6),
+    historyRows: sorted.map((assessment) => [
+      formatDate(assessment.createdAt),
+      formatNumber(assessment.riskScore, 1, "%"),
+      formatValue(assessment.riskCategory),
+      formatNumber(assessment.bmi, 1),
+      formatNumber(assessment.hba1cLevel, 1, "%"),
+    ]),
+    assessmentCount: sorted.length,
+  };
+}
+
+function getPatientSummaryFilename(patientName: string): string {
+  const patient = patientName.replace(/[^a-z0-9]+/gi, "-").replace(/^-|-$/g, "");
+  return `patient-longitudinal-summary-${patient || "patient"}.pdf`;
+}
+
+export function downloadPatientSummaryPdf(assessments: PatientSummaryAssessment[]) {
+  const summary = preparePatientSummaryReport(assessments);
+  const pdf = new PdfDocument();
+
+  pdf.text("Patient Longitudinal Risk Summary", MARGIN, { size: 21, font: "bold", color: SLATE });
+  pdf.text(`Generated ${formatDate(new Date().toISOString())}`, MARGIN, { size: 9, color: MUTED });
+  pdf.moveDown(6);
+  pdf.line(MARGIN, pdf.y, PAGE_WIDTH - MARGIN, pdf.y, BORDER);
+  pdf.moveDown(20);
+
+  pdf.sectionTitle("Patient Overview");
+  pdf.keyValueRows(summary.demographics);
+
+  pdf.sectionTitle("Latest Assessment Snapshot");
+  pdf.keyValueRows(summary.latestRows);
+
+  pdf.sectionTitle("Longitudinal Trend Summary");
+  summary.trendSummary.forEach((line) => pdf.bullet(line));
+
+  pdf.sectionTitle("Assessment Timeline");
+  if (summary.historyRows.length === 0) {
+    pdf.text("No assessments were available for this patient.", MARGIN, { size: 10, color: MUTED });
+  } else {
+    summary.historyRows.slice(0, 12).forEach(([date, riskScore, category, bmi, hba1c]) => {
+      pdf.ensureSpace(36);
+      pdf.rect(MARGIN, pdf.y - 28, CONTENT_WIDTH, 28, LIGHT_FILL);
+      pdf.textAt(date, MARGIN + 10, pdf.y - 18, { size: 8.5, font: "bold", color: SLATE });
+      pdf.textAt(`Risk ${riskScore} (${category})`, MARGIN + 170, pdf.y - 18, { size: 8.5, color: MUTED });
+      pdf.textAt(`BMI ${bmi}`, MARGIN + 320, pdf.y - 18, { size: 8.5, color: MUTED });
+      pdf.textAt(`HbA1c ${hba1c}`, MARGIN + 410, pdf.y - 18, { size: 8.5, color: MUTED });
+      pdf.y -= 34;
+    });
+  }
+
+  pdf.sectionTitle("Recent Key Risk Factors");
+  if (summary.recentFactors.length === 0) {
+    pdf.text("No model risk factors were available in the recent assessments.", MARGIN, { size: 10, color: MUTED });
+  } else {
+    summary.recentFactors.forEach((factor) => {
+      const impact = factor.impact === "positive" ? "Increases risk" : "Reduces risk";
+      pdf.ensureSpace(42);
+      pdf.text(factor.name, MARGIN, { size: 10.5, font: "bold", color: SLATE, lineHeight: 14 });
+      pdf.text(`${impact}: ${factor.description || "No description provided."}`, MARGIN, {
+        size: 9.5,
+        color: MUTED,
+        maxWidth: CONTENT_WIDTH,
+        lineHeight: 13,
+      });
+      pdf.moveDown(5);
+    });
+  }
+
+  pdf.sectionTitle("Clinical Summary");
+  pdf.text(
+    `This report summarizes ${summary.assessmentCount} assessment${summary.assessmentCount === 1 ? "" : "s"} for ${summary.patientName}. Use it to review trajectory, discuss follow-up priorities, and compare the latest result against prior records. It is not a standalone diagnosis.`,
+    MARGIN,
+    { size: 10, color: MUTED, maxWidth: CONTENT_WIDTH, lineHeight: 14 },
+  );
+
+  pdf.save(getPatientSummaryFilename(summary.patientName));
 }
 
 export function downloadClinicalAssessmentPdf(assessment: ReportAssessment) {

--- a/server/repositories/assessment.repository.ts
+++ b/server/repositories/assessment.repository.ts
@@ -71,7 +71,10 @@ export class AssessmentRepository {
 
     if (gender && gender !== "All") {
       if (gender === "Other") {
-        filters.push(not(or(eq(assessments.gender, "Male"), eq(assessments.gender, "Female"))));
+        const binaryGenderFilter = or(eq(assessments.gender, "Male"), eq(assessments.gender, "Female"));
+        if (binaryGenderFilter) {
+          filters.push(not(binaryGenderFilter));
+        }
       } else {
         filters.push(eq(assessments.gender, gender));
       }


### PR DESCRIPTION
@gopaljilab Please Add Gssoc 26 tag in it
## Description

Adds a patient-level longitudinal PDF summary export from Assessment History. Users can open a selected patient’s trajectory and download a clean clinical summary PDF containing demographics, latest risk snapshot, metric trends, recent risk factors, assessment timeline, and a clinical summary section.

## Related Issue

Closes #978 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- Added patient-level PDF summary generation to the existing clinical PDF utility.
- Added an `Export Patient Summary PDF` action in the Assessment History patient trajectory view.
- Included latest risk score/category, demographics, trend summaries, recent risk factors, and assessment timeline in the PDF.
- Added tests for multi-assessment trends, single-assessment summaries, missing-field handling, and risk-factor deduplication.

## Screenshots (if applicable)

Not applicable.

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

```bash
npm run check
npx vitest run client/src/utils/clinicalPdfReport.test.ts
npm run build