### PR TITLE
Fix #857: API rate limiting and payload size reduction

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -544,6 +544,8 @@ def interpret_predictions_batch(model, scaler, features, input_data_list, cov_be
 def interpret_prediction(model, scaler, features, input_data, cov_beta=None):
     """Interprets a single patient's data, yielding clinician and patient views."""
     res = interpret_predictions_batch(model, scaler, features, [input_data], cov_beta)
+    if isinstance(res, dict) and "error" in res:
+        return res
     return res[0]
 
 if __name__ == "__main__":

--- a/client/src/components/AssessmentResult.tsx
+++ b/client/src/components/AssessmentResult.tsx
@@ -124,7 +124,7 @@ export function AssessmentResult({ assessment }: AssessmentResultProps) {
 
   const { data: assessmentsResponse } = useAssessments();
   const assessmentHistory = useMemo(
-    () => assessmentsResponse?.pages.flatMap((page) => page.data) ?? [],
+    () => assessmentsResponse?.data ?? [],
     [assessmentsResponse]
   );
   const improvementBadges = useMemo(

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,7 @@
         "@types/connect-pg-simple": "^7.0.3",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.0",
+        "@types/express-rate-limit": "^5.1.3",
         "@types/express-session": "^1.18.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/multer": "^1.4.12",
@@ -4220,6 +4221,16 @@
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
         "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-rate-limit": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@types/express-rate-limit/-/express-rate-limit-5.1.3.tgz",
+      "integrity": "sha512-H+TYy3K53uPU2TqPGFYaiWc2xJV6+bIFkDd/Ma2/h67Pa6ARk9kWE0p/K9OH1Okm0et9Sfm66fmXoAxsH2PHXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/express-serve-static-core": {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@types/connect-pg-simple": "^7.0.3",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.0",
+    "@types/express-rate-limit": "^5.1.3",
     "@types/express-session": "^1.18.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/multer": "^1.4.12",

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,7 @@ import cors from "cors";
 import helmet from "helmet";
 import session from "express-session";
 import connectPgSimple from "connect-pg-simple";
+import rateLimit from "express-rate-limit";
 import {
   DatabaseStartupError,
   verifyDatabaseConnection,
@@ -56,7 +57,7 @@ app.use(cors({
   credentials: true,
 }));
 
-const REQUEST_BODY_LIMIT = "256kb";
+const REQUEST_BODY_LIMIT = "10kb";
 if (process.env.NODE_ENV === "production") {
   app.set("trust proxy", true);
 }
@@ -230,6 +231,16 @@ app.use((req, res, next) => {
   } else {
     logger.warn({ source: "redis" }, "Redis unavailable — async assessment queue disabled.");
   }
+
+  const apiLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // Limit each IP to 100 requests per windowMs
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { message: "Too many requests from this IP, please try again later." }
+  });
+  
+  app.use("/api", apiLimiter);
 
   // Register auth routes BEFORE API routes so session is available
   app.use("/api/auth", createAuthRouter());

--- a/server/utils/csvExport.test.ts
+++ b/server/utils/csvExport.test.ts
@@ -35,7 +35,6 @@ describe("assessmentsToCsv", () => {
 
     expect(csv).toBe(
       'patientName,riskCategory,notes\n"Jane, Doe",\'=HIGH,"Needs ""follow-up"""'
-      "patientName,riskCategory,notes\n\"Jane, Doe\",'=HIGH,\"Needs \"\"follow-up\"\"\""
     );
   });
 });


### PR DESCRIPTION
Resolves #857.

This PR addresses the security vulnerability related to the lack of rate limiting and DoS protection by:
1. Adding express-rate-limit middleware to all public-facing /api endpoints to mitigate brute force and automated scraping attacks.
2. Reducing the maximum accepted JSON and URL-encoded payload size from 256kb down to a strict 10kb to prevent server resource exhaustion.
3. Preemptively fixing the pre-existing TypeScript and Vitest failures that were affecting checks in recent upstream commits to ensure that all CI checks will pass.