### PR TITLE
fix: serialize JSONB objects/arrays to JSON strings in CSV export

### DIFF
--- a/server/utils/csvExport.test.ts
+++ b/server/utils/csvExport.test.ts
@@ -37,4 +37,19 @@ describe("assessmentsToCsv", () => {
       'patientName,riskCategory,notes\n"Jane, Doe",\'=HIGH,"Needs ""follow-up"""'
     );
   });
+
+  it("serializes objects and arrays as JSON stringified values", () => {
+    const csv = assessmentsToCsv([
+      {
+        patientName: "Jane, Doe",
+        factors: [
+          { name: "Age", impact: "negative", description: "Age over 65" },
+        ],
+      },
+    ]);
+
+    expect(csv).toBe(
+      'patientName,factors\n"Jane, Doe","[{""name"":""Age"",""impact"":""negative"",""description"":""Age over 65""}]"'
+    );
+  });
 });

--- a/server/utils/csvSanitizer.ts
+++ b/server/utils/csvSanitizer.ts
@@ -9,7 +9,14 @@ export function sanitizeCsvCell(value: unknown): string {
     return String(value);
   }
 
-  let text = value instanceof Date ? value.toISOString() : String(value);
+  let text: string;
+  if (value instanceof Date) {
+    text = value.toISOString();
+  } else if (typeof value === "object") {
+    text = JSON.stringify(value);
+  } else {
+    text = String(value);
+  }
 
   // If the text can be parsed as a valid number, do not prepend a quote
   // This avoids converting negative numbers (e.g. -12.5) or standard integer fields to strings.


### PR DESCRIPTION
Fixes #964

### Description
This PR resolves the issue where the factors column (stored as JSONB) was serialized as `[object Object]` inside exported CSV files. Now, JSONB arrays and objects are correctly serialized using `JSON.stringify` before being escaped for CSV export.

### Changes Made
- Updated `sanitizeCsvCell` in `server/utils/csvSanitizer.ts` to check if the value is an object (excluding Date) and serialize it using `JSON.stringify`.
- Added robust test coverage in `server/utils/csvExport.test.ts` verifying correct serialization of object and array properties.