### PR TITLE
fix: resolve CSV row delimiter backslash typo

### DIFF
--- a/server/utils/csvExport.ts
+++ b/server/utils/csvExport.ts
@@ -1,5 +1,9 @@
 import { escapeCsvCell } from "./csvSanitizer";
 
+/**
+ * Converts assessment records to a CSV string.
+ * Rows are joined using the standard newline control character (\n) as the delimiter.
+ */
 export function assessmentsToCsv(data: Record<string, unknown>[]): string {
   if (data.length === 0) return "";
   const headers = Object.keys(data[0]);


### PR DESCRIPTION
Fixes #963

### Description
This PR resolves the row delimiter backslash typo (`\\n` vs `\n`) in the CSV export utility. Note: This typo was already addressed in upstream `main` via PR #943. This PR formally resolves issue #963 by documenting the newline row delimiter format directly in the codebase for clarity.