### PR TITLE
fix: resolve fallback mechanism crash in bulk assessment endpoint

### DIFF
--- a/server/routes/ml.routes.ts
+++ b/server/routes/ml.routes.ts
@@ -8,7 +8,7 @@ import { writeFile, unlink } from "fs/promises";
 import { requireAuth, requireVerified } from "../auth";
 import { api } from "@shared/routes";
 import { storage } from "../storage";
-import { MLService, getPythonExecutable } from "../services/mlService";
+import { MLService, getPythonExecutable, calculateClinicalFallback } from "../services/mlService";
 import { validateDTO } from "../middleware/validateDTO";
 import { execFile } from "child_process";
 import { promisify } from "util";
@@ -34,7 +34,6 @@ mlRouter.post(
       return res.status(401).json({ message: "Authentication required." });
     }
 
-    let tempFilePath: string | null = null;
     let requestFingerprint: string | null = null;
 
     try {
@@ -46,23 +45,19 @@ mlRouter.post(
       }
       MLService.activeInferenceRequests.add(requestFingerprint);
 
-      tempFilePath = path.join(os.tmpdir(), `bulk_${randomUUID()}.json`);
-      await writeFile(tempFilePath, JSON.stringify(input));
-
       let predictions: any[];
       try {
-        const { stdout } = await execFileAsync(
-          getPythonExecutable(),
-          [analyzePyPath, "predict_file", tempFilePath],
-          { timeout: 60000, maxBuffer: 50 * 1024 * 1024 }
-        );
-
-        predictions = JSON.parse(stdout.trim());
+        const { prediction } = await MLService.runAssessmentInference(input);
+        predictions = prediction as any;
         if (!Array.isArray(predictions)) {
           throw new Error("Expected array of predictions");
         }
       } catch (error: any) {
-        return res.status(500).json({ message: "Bulk ML processing failed or timed out." });
+        logger.warn(
+          "Python prediction bulk failed or timed out, running clinical rule-based fallback:",
+          error
+        );
+        predictions = calculateClinicalFallback(input);
       }
 
       const createdAssessments = await Promise.all(
@@ -88,9 +83,6 @@ mlRouter.post(
       logger.error({ err }, "Bulk create error");
       return res.status(500).json({ message: "Failed to generate bulk assessments." });
     } finally {
-      if (tempFilePath) {
-        try { await unlink(tempFilePath); } catch {}
-      }
       if (requestFingerprint) {
         MLService.activeInferenceRequests.delete(requestFingerprint);
       }

--- a/server/services/mlService.ts
+++ b/server/services/mlService.ts
@@ -97,7 +97,10 @@ export interface PredictionResult {
   disclaimer?: string;
 }
 
-export function calculateClinicalFallback(input: unknown): PredictionResult {
+export function calculateClinicalFallback(input: unknown): any {
+  if (Array.isArray(input)) {
+    return input.map((item) => calculateClinicalFallback(item));
+  }
   const anyInput = input as any;
   let points = 0;
 

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -454,6 +454,70 @@ describe("Python inference", () => {
     expect(res.status).toBe(503);
     expect(res.body.message).toContain("timed out");
   });
+
+  it("bulk route returns 201 and falls back to rule-based model on python process failure", async () => {
+    const app = createAuthenticatedApp();
+    await registerRoutes(createServer(), app);
+
+    mockExecFile.mockImplementation((cmd, args, opts, cb) => {
+      if (typeof opts === "function") {
+        cb = opts;
+        cb(new Error("Python execution failed"), null, "error");
+        return;
+      }
+      cb(new Error("Python execution failed"), null, "error");
+    });
+
+    const res = await request(app)
+      .post("/api/assessments/bulk")
+      .send({
+        assessments: [
+          validPayload,
+          { ...validPayload, patientName: "Jane Doe" }
+        ]
+      });
+
+    console.log("DEBUG RESPONSE:", res.status, res.text, res.body);
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty("count", 2);
+    expect(res.body).toHaveProperty("assessments");
+    expect(Array.isArray(res.body.assessments)).toBe(true);
+    expect(res.body.assessments[0]).toHaveProperty("riskScore");
+    expect(res.body.assessments[1]).toHaveProperty("riskScore");
+  });
+
+  it("bulk route returns 201 and falls back to rule-based model on python process timeout", async () => {
+    const app = createAuthenticatedApp();
+    await registerRoutes(createServer(), app);
+
+    mockExecFile.mockImplementation((cmd, args, opts, cb) => {
+      const err = new Error("Process timed out");
+      (err as any).killed = true;
+      if (typeof opts === "function") {
+        cb = opts;
+        cb(err, null, "");
+        return;
+      }
+      cb(err, null, "");
+    });
+
+    const res = await request(app)
+      .post("/api/assessments/bulk")
+      .send({
+        assessments: [
+          validPayload,
+          { ...validPayload, patientName: "Jane Doe" }
+        ]
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty("count", 2);
+    expect(res.body).toHaveProperty("assessments");
+    expect(Array.isArray(res.body.assessments)).toBe(true);
+    expect(res.body.assessments[0]).toHaveProperty("riskScore");
+    expect(res.body.assessments[1]).toHaveProperty("riskScore");
+  });
 });
 
 describe("Response shape", () => {


### PR DESCRIPTION
Fixes #961

### Description
This PR resolves a bug in the bulk assessment endpoint `/api/assessments/bulk` where the fallback mechanism throws a `500 Internal Server Error` instead of returning rule-based clinical fallback predictions when the ML daemon fails or times out.

### Changes Made
- Refactored `server/routes/ml.routes.ts`'s `/bulk` endpoint handler to use `MLService.runAssessmentInference(input)` instead of duplicate manual child process execution. This ensures consistency and makes use of the global inference wrapper.
- Enhanced `calculateClinicalFallback` in `server/services/mlService.ts` to recursively handle input arrays of patient records. This enables rule-based fallback predictions for bulk inputs.
- Updated `/bulk` endpoint's catch block to gracefully fall back to the rule-based `calculateClinicalFallback(input)` predictions on both inference failures and timeouts instead of throwing 500 errors.
- Added comprehensive vitest route tests in `tests/routes.test.ts` to verify the fallback functionality for both process failure and process timeout during bulk operations.