### PR TITLE
fix: add client-side email format validation in ForgotPassword form

### DIFF
--- a/client/src/pages/ForgotPassword.tsx
+++ b/client/src/pages/ForgotPassword.tsx
@@ -23,6 +23,12 @@ export default function ForgotPassword() {
       return;
     }
 
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      setError("Please enter a valid email address.");
+      return;
+    }
+
     setIsLoading(true);
     try {
       await ApiClient.post("/api/auth/forgot-password", { email });


### PR DESCRIPTION
## Summary
Fixes #859

The Forgot Password form was only checking if the email field was empty 
before making the API request. Users could submit invalid email formats 
like "abc", "test@", or "@mail.com" and the request would still be sent 
to the backend.

## Changes Made
- Added email format validation using regex in `handleSubmit` inside 
  `client/src/pages/ForgotPassword.tsx`
- Displays an inline error message "Please enter a valid email address." 
  for invalid formats before any API call is made

## Type of Change
- [x] Bug fix

## How to Test
1. Go to the Forgot Password page
2. Enter invalid emails like `abc`, `test@`, `@mail.com` and click Send
3. Should show error without making an API request
4. Enter a valid email like `user@example.com` — should proceed normally