### PR TITLE
fix: eliminate credential exposure, OTP leak, and PHI temp file risks(#890)

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -293,7 +293,7 @@ export function createAuthRouter(): Router {
         loginStatus: "registration",
       });
 
-      return res.status(201).json({ success: true, pendingEmail: email, ...(process.env.NODE_ENV !== "production" && { devOtp: otp }) });
+      return res.status(201).json({ success: true, pendingEmail: email });
     } catch (err) {
       logger.error({ err }, "Registration error");
       return res.status(500).json({ message: "Registration failed due to a server error." });
@@ -358,7 +358,7 @@ export function createAuthRouter(): Router {
     // In production, send OTP via email. For development, return it in the response.
     logDevOtp(email, otp);
 
-    return res.json({ success: true, pendingEmail: email, ...(process.env.NODE_ENV !== "production" && { devOtp: otp }) });
+    return res.json({ success: true, pendingEmail: email });
   });
 
   /**
@@ -396,7 +396,7 @@ export function createAuthRouter(): Router {
         }
         logDevOtp(email, otp);
 
-        return res.json({ success: true, pendingEmail: email, ...(process.env.NODE_ENV !== "production" && { devOtp: otp }) });
+        return res.json({ success: true, pendingEmail: email });
       }
 
       const db = getDb();
@@ -438,7 +438,7 @@ export function createAuthRouter(): Router {
       }
       logDevOtp(email, otp);
 
-      return res.json({ success: true, pendingEmail: email, ...(process.env.NODE_ENV !== "production" && { devOtp: otp }) });
+      return res.json({ success: true, pendingEmail: email });
     } catch (err) {
       logger.error({ err }, "OTP resend error");
       return res.status(500).json({ message: "Failed to resend verification code." });
@@ -502,20 +502,20 @@ export function createAuthRouter(): Router {
 
       pendingOtps.delete(email);
 
-      const devEmail = process.env.DEV_CLINICIAN_EMAIL || "";
-
-      let id: string;
-      let name: string;
-      let role: string;
-
+      let id = "";
+      let name = "";
+      let role = "";
       let emailVerified = false;
 
-      if (email === devEmail) {
+      // Dev shortcut for local development — never active in production
+      if (process.env.NODE_ENV !== "production" && email === (process.env.DEV_CLINICIAN_EMAIL || "")) {
         name = "Dr. Smith";
         id = "dev";
         role = "DOCTOR";
         emailVerified = true;
-      } else {
+      }
+
+      if (!id) {
         const db = getDb();
         const [user] = await db
           .select()

--- a/tests/auth.routes.test.ts
+++ b/tests/auth.routes.test.ts
@@ -98,7 +98,7 @@ describe("Auth Router - Resend OTP integration tests", () => {
       expect(pendingOtps.has("expired@clinic.com")).toBe(false);
     });
 
-    it("updates pending OTP and returns devOtp in dev environment on success", async () => {
+    it("updates pending OTP on success and does not leak OTP in response", async () => {
       // Set valid pending OTP
       pendingOtps.set("valid@clinic.com", {
         otp: "111111",
@@ -116,13 +116,13 @@ describe("Auth Router - Resend OTP integration tests", () => {
         expect(res.status).toBe(200);
         expect(res.body).toHaveProperty("success", true);
         expect(res.body).toHaveProperty("pendingEmail", "valid@clinic.com");
-        expect(res.body).toHaveProperty("devOtp"); // returns devOtp in dev mode
+        expect(res.body).not.toHaveProperty("devOtp"); // OTP must never leak in response
         expect(mockSendVerificationCode).toHaveBeenCalledTimes(1);
 
         // Verify pending OTP is updated
         const updated = pendingOtps.get("valid@clinic.com");
         expect(updated).toBeDefined();
-        expect(updated?.otp).toBe(res.body.devOtp);
+        expect(updated?.otp).not.toBe("111111");
       } finally {
         process.env.NODE_ENV = originalEnv;
       }
@@ -193,7 +193,7 @@ describe("Auth Router - Resend OTP integration tests", () => {
         expect(res.status).toBe(200);
         expect(res.body).toHaveProperty("success", true);
         expect(res.body).toHaveProperty("pendingEmail", "unverified@clinic.com");
-        expect(res.body).toHaveProperty("devOtp");
+        expect(res.body).not.toHaveProperty("devOtp"); // OTP must never leak in response
         expect(mockSendVerificationCode).toHaveBeenCalledTimes(1);
       } finally {
         process.env.NODE_ENV = originalEnv;

--- a/tests/otp-lockout.test.ts
+++ b/tests/otp-lockout.test.ts
@@ -89,9 +89,7 @@ describe("OTP Brute-Force Lockout Integration", () => {
     expect(loginRes.body.success).toBe(true);
     expect(loginRes.body.pendingEmail).toBe("doc@example.com");
     
-    // In development/test mode, the devOtp is returned in the body
-    const correctOtp = loginRes.body.devOtp;
-    expect(correctOtp).toBeDefined();
+    // OTP is never leaked in the response — only sent via email / dev log
 
     // 2. First failed attempt: should return 401 with 2 attempts remaining
     const fail1 = await request(app)


### PR DESCRIPTION
## Description

Four security fixes addressing sensitive data exposure vectors across the codebase:

1. **Dev backdoor guarded by NODE_ENV** — The `DEV_CLINICIAN_EMAIL` bypass in `server/auth.ts` now only activates when `NODE_ENV !== "production"`. Previously it worked in any environment if the env var was set, allowing authentication bypass in production deployments.

2. **OTP no longer leaked in API responses** — Removed `devOtp` from all four response bodies (register, login, resend-otp login mode, resend-otp register mode). Developers can still see the OTP via `logDevOtp()` which logs to console in non-production.

3. **PHI temp files use restricted directory** — `server/routes/ml.routes.ts` now uses `fs.mkdtemp` to create a dedicated subdirectory under `os.tmpdir()` instead of writing patient data directly to the world-readable `/tmp` root. The entire directory is securely wiped via `rm -r -f` in the finally block.

4. **.env already gitignored** — Verified `.env` is on line 14 of `.gitignore` and has never been committed to git history. No action needed.

## Related Issue

Closes #890

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/auth.ts`: Guard dev credential bypass with NODE_ENV check; remove devOtp from all 4 response bodies
- `server/routes/ml.routes.ts`: Use mkdtemp + recursive cleanup for PHI temp files
- `tests/auth.routes.test.ts`: Assert devOtp is NOT present in responses
- `tests/otp-lockout.test.ts`: Remove devOtp reference

## Screenshots (if applicable)

N/A — server-side security fixes

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [ ] All existing tests pass (15 pre-existing failures on main due to missing node_modules deps remain unchanged; 82 tests pass)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors