### PR TITLE
refactor: import cn from shared lib/utils in AppLayout instead of redefining it

### DIFF
--- a/client/src/components/layout/AppLayout.tsx
+++ b/client/src/components/layout/AppLayout.tsx
@@ -4,15 +4,10 @@ import { useTranslation } from "react-i18next";
 import { queryClient } from "@/lib/queryClient";
 import { ApiClient } from "@/lib/apiClient";
 import { Activity, ClipboardList, HeartPulse, LogOut, Loader2, PieChart, TrendingUp, UploadCloud, User } from "lucide-react";
-import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
 import ThemeToggle from "../ThemeToggle";
 import { LanguageSwitcher } from "../LanguageSwitcher";
 import { useToast } from "@/hooks/use-toast";
-
-function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+import { cn } from "@/lib/utils";
 
 interface AppLayoutProps {
   children: ReactNode;


### PR DESCRIPTION
## Description

`AppLayout.tsx` was defining its own local copy of the `cn` Tailwind class-merging utility (using `clsx` + `tailwind-merge`) instead of importing the identical function already exported from `@/lib/utils`. This PR removes the duplicate definition and replaces it with a single import from the shared utility module.
 
## Related Issue

Closes #1099

## Type of Change

- [x] ♻️ Refactor (no functional changes)

## Changes Made

- Removed the local `cn` function definition from `client/src/components/layout/AppLayout.tsx`
- Removed the now-unused direct imports of `clsx` and `tailwind-merge` from this file
- Added `import { cn } from "@/lib/utils"` to use the canonical shared utility

## Screenshots (if applicable)

N/A — no visual change.

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

Ran `npm run check` — TypeScript compilation passes with zero errors.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors