### PR TITLE
Fix #1039: undefined-mapped-variable

### DIFF
--- a/server/routes/assessments.routes.ts
+++ b/server/routes/assessments.routes.ts
@@ -158,7 +158,7 @@ assessmentsRouter.get(
         createdBy: userEmail,
       });
 
-      res.json(mapped);
+      res.json(result);
     } catch (err) {
       logger.error({ err }, "Fetch assessments error:");
       return res.status(500).json({ message: "Failed to fetch assessments" });


### PR DESCRIPTION
## Description

Fixes a runtime error in the `GET /api/assessments` endpoint caused by an undefined variable reference. The route handler attempted to return `mapped`, which was never declared, resulting in a `ReferenceError` and a `500 Internal Server Error`.

The response now correctly returns the value stored in `result`, allowing assessment data to be retrieved successfully.

## Related Issue

Closes #1039

## Type of Change

* [x] 🐛 Bug fix (non-breaking change that fixes an issue)
* [ ] ✨ New feature (non-breaking change that adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] 📝 Documentation update
* [ ] 🎨 Style / UI improvement
* [ ] ♻️ Refactor (no functional changes)
* [ ] ⚡ Performance improvement
* [ ] 🧪 Test addition or update
* [ ] 🔧 Chore / Tooling / Config

## Changes Made

* Replaced the undefined `mapped` variable with `result`
* Fixed `GET /api/assessments` response handling
* Prevented `ReferenceError` and restored successful assessment retrieval

## Screenshots (if applicable)

Not applicable.

## Testing

* [x] I have tested these changes locally
* [ ] I have added/updated tests where applicable
* [x] All existing tests pass

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my own code
* [ ] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings or errors
