### PR TITLE
fix: replace any types with Assessment and AssessmentFactor in exportAsPdf

### DIFF
--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -1,4 +1,5 @@
 import { AppLayout } from "@/components/layout/AppLayout";
+import type { Assessment, AssessmentFactor } from "@shared/schema";
 import { useAssessments, usePatientAssessments, useClearPatientCache, useDeleteAssessment } from "@/hooks/use-assessments";
 import {
   format,
@@ -410,7 +411,7 @@ export default function History() {
       .replace(/'/g, "&#039;");
   }
 
-  function exportAsPdf(assessment: any) {
+  function exportAsPdf(assessment: Assessment) {
     if (!assessment) return;
 
     const patientName = escapeHtml(assessment.patientName || "Unknown Patient");
@@ -433,7 +434,7 @@ export default function History() {
       assessment.factors || []
     )
       .slice(0, 5)
-      .map((f: any) => `<li>${escapeHtml(f.name || "Unknown")} — ${escapeHtml(f.description || "")} (${escapeHtml(f.impact || "N/A")})</li>`)
+      .map((f: AssessmentFactor) => `<li>${escapeHtml(f.name || "Unknown")} — ${escapeHtml(f.description || "")} (${escapeHtml(f.impact || "N/A")})</li>`)
       .join("")}</ul></div></div></body></html>`;
 
     const w = window.open("", "_blank", "noopener,noreferrer");


### PR DESCRIPTION
## Description
`History.tsx` typed the `exportAsPdf` function parameter as `any`:

```ts
function exportAsPdf(assessment: any) {
  const patientName = assessment.patientName || "Unknown Patient";
  // ... uses assessment.id, assessment.createdAt, assessment.riskScore, etc.
```

And the `factors` array map also used `any`:

```ts
.map((f: any) => `<li>${escapeHtml(f.name || "Unknown")} ...`)
```

Using `any` bypassed TypeScript's compile-time checks on all assessment field accesses in the HTML template string. If the `Assessment` type ever changes (a field is renamed or removed), TypeScript would not catch the mismatch and the exported PDF would silently contain `undefined` values with no compile-time warning. The `Assessment` and `AssessmentFactor` types are already defined and exported from `@shared/schema` — there was no reason for `any` here.

Changes made:
- Added `import type { Assessment, AssessmentFactor } from "@shared/schema"` to `History.tsx`
- Replaced `assessment: any` with `assessment: Assessment` on `exportAsPdf`
- Replaced `(f: any)` with `(f: AssessmentFactor)` in the factors array map
- All pre-existing TypeScript errors are from missing third-party type declarations unrelated to this change
- Verified zero new TypeScript errors introduced by this change

Fixes #808

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings