### PR TITLE
fix: return 200 for unknown email in forgot-password to prevent account enumeration

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -534,7 +534,9 @@ out
         .limit(1);
 
       if (!user) {
-        return res.status(404).json({ message: "No account found with this email." });
+        // Always return 200 regardless of whether the email exists — returning
+        // 404 leaks user account existence and enables email enumeration attacks.
+        return res.status(200).json({ success: true, message: "If an account exists with this email, a reset link has been sent." });
       }
 
       const token = randomBytes(32).toString("hex");


### PR DESCRIPTION
## Description
`server/auth.ts` returned `404` with `"No account found with this email."` when the submitted email was not registered:

```ts
if (!user) {
  return res.status(404).json({ message: "No account found with this email." });
}
```

This leaked whether an email address is registered — an attacker could enumerate valid user accounts by submitting addresses and observing the `404` vs `200` status code difference. This is a standard account enumeration vulnerability (OWASP API Security Top 10 — API3:2023).

Note: `ForgotPassword.tsx` already displayed the correct generic message `"If an account exists with this email, a password reset link has been sent."` — the backend was contradicting this by leaking the truth to anyone calling the API directly.

Changes made:
- Replaced `res.status(404).json(...)` with `res.status(200).json({ success: true, message: "If an account exists with this email, a reset link has been sent." })` for the unknown email case
- The response is now identical in structure to the success case — no observable difference between registered and unregistered emails
- Added a comment explaining why 404 must not be returned here
- Verified zero new TypeScript errors introduced by this change

Fixes #807

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings