### PR TITLE
fix: add staleTime to AdminDashboard tab queries to prevent redundant refetches

### DIFF
--- a/client/src/pages/AdminDashboard.tsx
+++ b/client/src/pages/AdminDashboard.tsx
@@ -69,6 +69,9 @@ function UsersTab() {
       if (!res.ok) throw new Error("Failed to fetch users");
       return res.json();
     },
+    // Cache for 2 minutes — prevents redundant refetches when switching
+    // back to a previously visited tab within the same session.
+    staleTime: 2 * 60 * 1000,
   });
   const { toast } = useToast();
 
@@ -174,6 +177,7 @@ function AuditLogsTab() {
       if (!res.ok) throw new Error("Failed to fetch audit logs");
       return res.json();
     },
+    staleTime: 2 * 60 * 1000,
   });
 
   if (isLoading) {
@@ -243,6 +247,7 @@ function StatsTab() {
       if (!res.ok) throw new Error("Failed to fetch stats");
       return res.json();
     },
+    staleTime: 2 * 60 * 1000,
   });
 
   if (isLoading) {


### PR DESCRIPTION
## Description
`AdminDashboard.tsx` has three tab components (`UsersTab`, `AuditLogsTab`, `StatsTab`) each with their own `useQuery` call and no `staleTime`:

```ts
const { data, isLoading } = useQuery<SystemStats>({
  queryKey: ["/api/admin/stats"],
  queryFn: async () => { ... },
  // no staleTime — data is immediately stale after every fetch
});
```

Each tab component only mounts when its tab is active (conditional rendering via `&&`) so initial fetches are already lazy — data is only fetched when a tab is first visited. However, without `staleTime`, TanStack Query treats all cached data as immediately stale. Every time an admin switches back to a previously visited tab, it refetches the data unnecessarily — hitting `/api/admin/users`, `/api/admin/audit-logs`, and `/api/admin/stats` on every tab switch even if the data hasn't changed.

Changes made:
- Added `staleTime: 2 * 60 * 1000` (2 minutes) to all three `useQuery` calls in `UsersTab`, `AuditLogsTab`, and `StatsTab`
- Cached data is now reused within a session — the database is not hit on every tab switch
- The `refetch` function on `UsersTab` still allows manual refresh when needed (e.g. after toggling user active status)
- Verified zero new TypeScript errors introduced by this change

Fixes #806

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings