### PR TITLE
fix: add VITE_API_BASE resolution to ApiClient so all API calls use correct base URL

### DIFF
--- a/client/src/lib/apiClient.ts
+++ b/client/src/lib/apiClient.ts
@@ -2,6 +2,18 @@
  * Centralized API Utility Class for Data Fetching
  * Consolidates fetch logic, error handling, credentials, and JSON parsing.
  */
+
+/**
+ * Resolves a relative API path against VITE_API_BASE when configured.
+ * This ensures all ApiClient calls work correctly when the app is deployed
+ * with a separate backend origin or behind a reverse proxy with a path prefix.
+ * Falls back to the relative path when VITE_API_BASE is not set (local dev).
+ */
+function resolveUrl(path: string): string {
+  const base = (import.meta.env.VITE_API_BASE as string | undefined)?.replace(/\/+$/, "") ?? "";
+  return base ? `${base}${path}` : path;
+}
+
 export class ApiClient {
   /**
    * Helper to check the response and throw standardized errors
@@ -38,7 +50,7 @@ export class ApiClient {
   }
 
   static async get<T = any>(url: string, options?: RequestInit): Promise<T> {
-    const res = await fetch(url, {
+    const res = await fetch(resolveUrl(url), {
       method: "GET",
       credentials: "include",
       ...options,
@@ -51,7 +63,7 @@ export class ApiClient {
     if (options?.headers) {
       Object.assign(headers, options.headers);
     }
-    const res = await fetch(url, {
+    const res = await fetch(resolveUrl(url), {
       method: "POST",
       credentials: "include",
       ...options,
@@ -66,7 +78,7 @@ export class ApiClient {
     if (options?.headers) {
       Object.assign(headers, options.headers);
     }
-    const res = await fetch(url, {
+    const res = await fetch(resolveUrl(url), {
       method: "PUT",
       credentials: "include",
       ...options,
@@ -77,7 +89,7 @@ export class ApiClient {
   }
 
   static async delete<T = any>(url: string, options?: RequestInit): Promise<T> {
-    const res = await fetch(url, {
+    const res = await fetch(resolveUrl(url), {
       method: "DELETE",
       credentials: "include",
       ...options,
@@ -86,7 +98,7 @@ export class ApiClient {
   }
   
   static async requestRaw(url: string, options?: RequestInit): Promise<Response> {
-    return fetch(url, {
+    return fetch(resolveUrl(url), {
       credentials: "include",
       ...options,
     });


### PR DESCRIPTION
## Description
`ForgotPassword.tsx` and `ResetPassword.tsx` used `ApiClient` which passed relative paths directly to `fetch()` with no base URL resolution:

```ts
await ApiClient.post("/api/auth/forgot-password", { email });
await ApiClient.post("/api/auth/reset-password", { token, newPassword: password });
```

`ApiClient` had no `VITE_API_BASE` awareness — all methods called `fetch(url, ...)` directly. This failed when:
- `VITE_API_BASE` pointed to a separate backend origin (`https://api.example.com`) — requests went to the frontend origin instead
- The app was deployed behind a reverse proxy with a path prefix
- The client and server were on different hosts

Changes made:
- Added `resolveUrl(path: string)` helper to `client/src/lib/apiClient.ts` that prepends `VITE_API_BASE` (stripped of trailing slashes) to all relative paths when the env var is configured, falling back to the relative path for local development
- Applied `resolveUrl()` to all five `fetch` call sites in `ApiClient`: `get`, `post`, `put`, `delete`, and `requestRaw`
- All `ApiClient` callers (`ForgotPassword.tsx`, `ResetPassword.tsx`, `AuthFlow.tsx`, `AppLayout.tsx`, and any future callers) now automatically use the correct base URL without any changes at the call sites
- Verified zero new TypeScript errors introduced by this change

Fixes #805

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings