### PR TITLE
Add shared API contract tests

### DIFF
--- a/shared/routes.test.ts
+++ b/shared/routes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildUrl } from "./routes";
+import { api, buildUrl } from "./routes";
 
 describe("buildUrl", () => {
   it("returns the path unchanged when no params are provided", () => {
@@ -16,5 +16,46 @@ describe("buildUrl", () => {
     expect(buildUrl("/api/assessments/:id", { id: 7 })).toBe(
       "/api/assessments/7",
     );
+  });
+});
+
+describe("api route contracts", () => {
+  it("accepts the queued assessment response contract", () => {
+    const parsed = api.assessments.create.responses[202].parse({
+      message: "Assessment request accepted and is being processed.",
+      jobId: "42",
+    });
+
+    expect(parsed.jobId).toBe("42");
+  });
+
+  it("rejects queued assessment responses without a job id", () => {
+    const result = api.assessments.create.responses[202].safeParse({
+      message: "Assessment request accepted and is being processed.",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts paginated assessment list metadata", () => {
+    const parsed = api.assessments.list.responses[200].parse({
+      data: [],
+      nextCursor: null,
+      total: 0,
+      page: 1,
+      limit: 20,
+      totalPages: 0,
+    });
+
+    expect(parsed.total).toBe(0);
+    expect(parsed.nextCursor).toBeNull();
+  });
+
+  it("rejects malformed validation error responses", () => {
+    const result = api.assessments.create.responses[400].safeParse({
+      field: "age",
+    });
+
+    expect(result.success).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- adds shared route contract tests for queued assessment responses
- verifies assessment list pagination metadata shape
- checks validation error responses reject malformed payloads

## Related issue
Supports #1159

## Verification
- git diff --check

Note: focused Vitest execution is blocked in this checkout because dependency installation fails: npm ci reports existing package-lock drift around optional bufferutil, and npm install exits with npm's internal 'Exit handler never called' error.