### PR TITLE
Add assessment draft storage utilities

### DIFF
--- a/client/src/utils/assessmentDrafts.test.ts
+++ b/client/src/utils/assessmentDrafts.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearAssessmentDraft,
+  getAssessmentDraftKey,
+  loadAssessmentDraft,
+  saveAssessmentDraft,
+} from "./assessmentDrafts";
+
+const assessment = {
+  patientName: "Synthetic Patient",
+  gender: "Female",
+  age: 45,
+  hypertension: false,
+  heartDisease: false,
+  smokingHistory: "never",
+  bmi: 24.5,
+  hba1cLevel: 5.4,
+  bloodGlucoseLevel: 96,
+};
+
+class MemoryStorage implements Storage {
+  private values = new Map<string, string>();
+
+  get length() {
+    return this.values.size;
+  }
+
+  clear() {
+    this.values.clear();
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+describe("assessment draft storage", () => {
+  it("saves and restores a non-expired assessment draft", () => {
+    const storage = new MemoryStorage();
+    const key = getAssessmentDraftKey("clinician@example.com");
+
+    const saved = saveAssessmentDraft(assessment, { storage, key, ttlMs: 1000 });
+    const loaded = loadAssessmentDraft({
+      storage,
+      key,
+      currentTimeMs: Date.parse(saved?.savedAt ?? "") + 500,
+    });
+
+    expect(loaded?.data.patientName).toBe("Synthetic Patient");
+    expect(loaded?.expiresAt).toBe(saved?.expiresAt);
+  });
+
+  it("clears expired drafts instead of returning stale PHI", () => {
+    const storage = new MemoryStorage();
+    const key = getAssessmentDraftKey("clinician@example.com");
+
+    const saved = saveAssessmentDraft(assessment, { storage, key, ttlMs: 1000 });
+    const loaded = loadAssessmentDraft({
+      storage,
+      key,
+      currentTimeMs: Date.parse(saved?.savedAt ?? "") + 1001,
+    });
+
+    expect(loaded).toBeNull();
+    expect(storage.getItem(key)).toBeNull();
+  });
+
+  it("removes a draft when explicitly cleared", () => {
+    const storage = new MemoryStorage();
+    const key = getAssessmentDraftKey("clinician@example.com");
+
+    saveAssessmentDraft(assessment, { storage, key });
+    clearAssessmentDraft({ storage, key });
+
+    expect(loadAssessmentDraft({ storage, key })).toBeNull();
+  });
+});

--- a/client/src/utils/assessmentDrafts.ts
+++ b/client/src/utils/assessmentDrafts.ts
@@ -1,0 +1,81 @@
+import type { AssessmentInput } from "@shared/routes";
+
+const DRAFT_VERSION = 1;
+const DEFAULT_TTL_MS = 1000 * 60 * 60 * 24;
+
+export interface AssessmentDraftRecord {
+  version: number;
+  savedAt: string;
+  expiresAt: string;
+  data: AssessmentInput;
+}
+
+function nowMs() {
+  return Date.now();
+}
+
+function getStorage(storage?: Storage): Storage | null {
+  if (storage) return storage;
+  if (typeof window === "undefined") return null;
+  return window.localStorage;
+}
+
+export function getAssessmentDraftKey(userIdOrEmail?: string | null): string {
+  return `clinical-insight:assessment-draft:${userIdOrEmail || "anonymous"}`;
+}
+
+export function saveAssessmentDraft(
+  data: AssessmentInput,
+  options: { storage?: Storage; key?: string; ttlMs?: number } = {},
+): AssessmentDraftRecord | null {
+  const storage = getStorage(options.storage);
+  if (!storage) return null;
+
+  const savedAtMs = nowMs();
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  const record: AssessmentDraftRecord = {
+    version: DRAFT_VERSION,
+    savedAt: new Date(savedAtMs).toISOString(),
+    expiresAt: new Date(savedAtMs + ttlMs).toISOString(),
+    data,
+  };
+
+  storage.setItem(options.key ?? getAssessmentDraftKey(), JSON.stringify(record));
+  return record;
+}
+
+export function loadAssessmentDraft(
+  options: { storage?: Storage; key?: string; currentTimeMs?: number } = {},
+): AssessmentDraftRecord | null {
+  const storage = getStorage(options.storage);
+  if (!storage) return null;
+
+  const key = options.key ?? getAssessmentDraftKey();
+  const raw = storage.getItem(key);
+  if (!raw) return null;
+
+  try {
+    const record = JSON.parse(raw) as AssessmentDraftRecord;
+    const currentTimeMs = options.currentTimeMs ?? nowMs();
+    if (
+      record.version !== DRAFT_VERSION ||
+      !record.expiresAt ||
+      Date.parse(record.expiresAt) <= currentTimeMs
+    ) {
+      storage.removeItem(key);
+      return null;
+    }
+    return record;
+  } catch {
+    storage.removeItem(key);
+    return null;
+  }
+}
+
+export function clearAssessmentDraft(
+  options: { storage?: Storage; key?: string } = {},
+): void {
+  const storage = getStorage(options.storage);
+  if (!storage) return;
+  storage.removeItem(options.key ?? getAssessmentDraftKey());
+}


### PR DESCRIPTION
## Summary
- adds a versioned local assessment draft storage utility
- expires stale drafts automatically to avoid indefinite PHI persistence
- adds explicit draft clearing support for successful submit/logout flows
- covers restore, expiration cleanup, and manual clear behavior with tests

## Related issue
Supports #1160

## Verification
- git diff --cached --check

Note: focused Vitest execution is blocked in this checkout because dependency installation fails: npm ci reports existing package-lock drift around optional bufferutil, and npm install exits with npm's internal 'Exit handler never called' error.