### PR TITLE
Add configurable data retention policy

### DIFF
--- a/docs/data-privacy.md
+++ b/docs/data-privacy.md
@@ -1,3 +1,24 @@
 # Data Privacy and HIPAA Guidelines
 
 Guidelines for securing patient record values, tokens, and medical files in compliance with HIPAA mandates.
+
+## Retention Policy Defaults
+
+The backend exposes a typed retention policy helper in `server/services/data-retention-policy.ts`.
+It does not delete records by itself; it centralizes the default windows and eligibility decisions that cleanup jobs, admin tools, or future erasure endpoints can reuse.
+
+Default retention windows:
+
+- Assessments: 7 years
+- Patient records: 7 years
+- Generated exports and temporary export artifacts: 30 days
+- Audit metadata: 10 years
+
+Supported environment overrides:
+
+- `ASSESSMENT_RETENTION_DAYS`
+- `PATIENT_RETENTION_DAYS`
+- `EXPORT_RETENTION_DAYS`
+- `AUDIT_RETENTION_DAYS`
+
+PHI-bearing records should be purged once eligible unless a legal or clinical hold is active. Audit records should prefer anonymization so operational accountability can be retained without preserving direct PHI.

--- a/server/services/data-retention-policy.test.ts
+++ b/server/services/data-retention-policy.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  getRetentionDecision,
+  getRetentionPolicyConfig,
+  isRetentionEligible,
+} from "./data-retention-policy";
+
+describe("data retention policy", () => {
+  it("loads defaults and ignores invalid environment overrides", () => {
+    const config = getRetentionPolicyConfig({
+      ASSESSMENT_RETENTION_DAYS: "not-a-number",
+      PATIENT_RETENTION_DAYS: "-10",
+      EXPORT_RETENTION_DAYS: "14",
+      AUDIT_RETENTION_DAYS: "3650",
+    });
+
+    expect(config.assessmentRetentionDays).toBe(365 * 7);
+    expect(config.patientRetentionDays).toBe(365 * 7);
+    expect(config.exportRetentionDays).toBe(14);
+    expect(config.auditRetentionDays).toBe(3650);
+  });
+
+  it("detects records that have reached their retention window", () => {
+    expect(
+      isRetentionEligible(new Date("2026-01-01T00:00:00.000Z"), 30, new Date("2026-01-31T00:00:00.000Z")),
+    ).toBe(true);
+    expect(
+      isRetentionEligible(new Date("2026-01-01T00:00:00.000Z"), 30, new Date("2026-01-30T23:59:59.999Z")),
+    ).toBe(false);
+  });
+
+  it("purges PHI-bearing records after their configured window", () => {
+    const decision = getRetentionDecision(
+      "assessmentRetentionDays",
+      new Date("2026-01-01T00:00:00.000Z"),
+      {
+        now: new Date("2026-02-01T00:00:00.000Z"),
+        config: {
+          assessmentRetentionDays: 30,
+          patientRetentionDays: 30,
+          exportRetentionDays: 7,
+          auditRetentionDays: 365,
+        },
+      },
+    );
+
+    expect(decision.action).toBe("purge");
+    expect(decision.eligibleAt.toISOString()).toBe("2026-01-31T00:00:00.000Z");
+  });
+
+  it("anonymizes audit records instead of purging them by default", () => {
+    const decision = getRetentionDecision(
+      "auditRetentionDays",
+      new Date("2026-01-01T00:00:00.000Z"),
+      {
+        now: new Date("2026-02-01T00:00:00.000Z"),
+        config: {
+          assessmentRetentionDays: 30,
+          patientRetentionDays: 30,
+          exportRetentionDays: 7,
+          auditRetentionDays: 30,
+        },
+      },
+    );
+
+    expect(decision.action).toBe("anonymize");
+  });
+
+  it("retains otherwise eligible records when a hold is active", () => {
+    const decision = getRetentionDecision(
+      "patientRetentionDays",
+      new Date("2026-01-01T00:00:00.000Z"),
+      {
+        now: new Date("2026-02-01T00:00:00.000Z"),
+        hasLegalHold: true,
+        config: {
+          assessmentRetentionDays: 30,
+          patientRetentionDays: 30,
+          exportRetentionDays: 7,
+          auditRetentionDays: 30,
+        },
+      },
+    );
+
+    expect(decision.action).toBe("retain");
+    expect(decision.reason).toContain("hold");
+  });
+});

--- a/server/services/data-retention-policy.ts
+++ b/server/services/data-retention-policy.ts
@@ -1,0 +1,79 @@
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+export type RetentionAction = "retain" | "anonymize" | "purge";
+
+export interface RetentionPolicyConfig {
+  assessmentRetentionDays: number;
+  patientRetentionDays: number;
+  exportRetentionDays: number;
+  auditRetentionDays: number;
+}
+
+export interface RetentionDecision {
+  action: RetentionAction;
+  eligibleAt: Date;
+  reason: string;
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function getRetentionPolicyConfig(env: NodeJS.ProcessEnv = process.env): RetentionPolicyConfig {
+  return {
+    assessmentRetentionDays: parsePositiveInt(env.ASSESSMENT_RETENTION_DAYS, 365 * 7),
+    patientRetentionDays: parsePositiveInt(env.PATIENT_RETENTION_DAYS, 365 * 7),
+    exportRetentionDays: parsePositiveInt(env.EXPORT_RETENTION_DAYS, 30),
+    auditRetentionDays: parsePositiveInt(env.AUDIT_RETENTION_DAYS, 365 * 10),
+  };
+}
+
+export function addDays(date: Date, days: number): Date {
+  return new Date(date.getTime() + days * DAY_MS);
+}
+
+export function isRetentionEligible(
+  createdAt: Date,
+  retentionDays: number,
+  now: Date = new Date(),
+): boolean {
+  return addDays(createdAt, retentionDays).getTime() <= now.getTime();
+}
+
+export function getRetentionDecision(
+  recordType: keyof RetentionPolicyConfig,
+  createdAt: Date,
+  options: {
+    config?: RetentionPolicyConfig;
+    now?: Date;
+    hasLegalHold?: boolean;
+  } = {},
+): RetentionDecision {
+  const config = options.config ?? getRetentionPolicyConfig();
+  const retentionDays = config[recordType];
+  const eligibleAt = addDays(createdAt, retentionDays);
+
+  if (options.hasLegalHold) {
+    return {
+      action: "retain",
+      eligibleAt,
+      reason: "Record is under legal or clinical hold.",
+    };
+  }
+
+  if (eligibleAt.getTime() > (options.now ?? new Date()).getTime()) {
+    return {
+      action: "retain",
+      eligibleAt,
+      reason: "Record has not reached its configured retention window.",
+    };
+  }
+
+  return {
+    action: recordType === "auditRetentionDays" ? "anonymize" : "purge",
+    eligibleAt,
+    reason: "Record has reached its configured retention window.",
+  };
+}


### PR DESCRIPTION
## Summary
- adds a typed retention policy helper for assessments, patients, exports, and audit metadata
- supports environment-driven retention windows with safe defaults
- distinguishes PHI purging from audit anonymization decisions
- documents default privacy retention windows and overrides
- adds focused tests for defaults, eligibility, purge/anonymize decisions, and hold behavior

## Related issue
Supports #1161

## Verification
- git diff --cached --check

Note: focused Vitest execution is blocked in this checkout because dependency installation fails: npm ci reports existing package-lock drift around optional bufferutil, and npm install exits with npm's internal 'Exit handler never called' error.