### PR TITLE
fix: remove orphaned runAssessmentInference stub and unused imports from mlService.ts

### DIFF
--- a/server/services/mlService.ts
+++ b/server/services/mlService.ts
@@ -1,8 +1,6 @@
 import { createHash, randomUUID } from "crypto";
 import { execFile, spawn, ChildProcess } from "child_process";
 import { existsSync } from "fs";
-import { writeFile, unlink } from "fs/promises";
-import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { logger } from "../logger";
@@ -269,14 +267,6 @@ interface PendingRequest {
   reject: (reason: any) => void;
   timeoutId: NodeJS.Timeout;
 }
-export async function runAssessmentInference(input: unknown): Promise<{ prediction: PredictionResult, isFallback: boolean }> {
-  if (!isPythonAvailable) {
-    return { prediction: calculateClinicalFallback(input), isFallback: true };
-  }
-
-  const release = await mlConcurrency.acquire();
-  const tempFilePath = path.join(os.tmpdir(), `${randomUUID()}.json`);
-
 class PythonDaemonManager {
   private process: ChildProcess | null = null;
   private rl: readline.Interface | null = null;


### PR DESCRIPTION
## Description

Removes an incomplete function stub that was left behind when the ML service was refactored from subprocess-based inference to the persistent Python daemon approach.

The stub (`export async function runAssessmentInference`) was inserted before the `PythonDaemonManager` class declaration at line ~272, making the class body appear nested inside the orphaned function. This caused:

1. **TypeScript error TS1005** — duplicate `runAssessmentInference` export identifier, breaking `tsc --noEmit`.
2. **Semaphore leak** — the stub called `mlConcurrency.acquire()` with no matching `release()`, permanently consuming one concurrency slot per server start.
3. **Unreachable dead code** — `tempFilePath` was allocated via `randomUUID()` but never written to or cleaned up.

Also removes the `os` and `fs/promises` (`writeFile`, `unlink`) imports that were exclusively used by the deleted stub.

## Related Issue

Closes #1177

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Removed the 7-line orphaned `runAssessmentInference` stub (lines ~272–278)
- Removed unused `import os from "os"` (only referenced in the deleted stub)
- Removed unused `import { writeFile, unlink } from "fs/promises"` (same reason)

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

`npx tsc --noEmit` — no errors in `mlService.ts` after this fix (the duplicate-export TS1005 error is resolved).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors