### PR TITLE
fix: remove duplicate rate limiter declarations from assessments.routes.ts

### DIFF
--- a/server/routes/assessments.routes.ts
+++ b/server/routes/assessments.routes.ts
@@ -2,13 +2,11 @@ import { logger } from "../logger";
 import { getAssessmentQueue } from "../queue";
 import { Router } from "express";
 import { z } from "zod";
-import { rateLimit } from "express-rate-limit";
 import { requireAuth, requireVerified } from "../auth";
 import { api } from "@shared/routes";
 import { storage } from "../storage";
-import { MLService, calculateClinicalFallback } from "../services/mlService";
-import { assessmentLimiter, previewLimiter } from "../middleware/rateLimit";
 import { MLService, isPythonAvailable, calculateClinicalFallback } from "../services/mlService";
+import { assessmentLimiter, previewLimiter } from "../middleware/rateLimit";
 
 import { generateRecommendations } from "../services/recommendation-engine";
 import {
@@ -41,28 +39,6 @@ function getPythonExecutable() {
 }
 
 const assessmentsRouter = Router();
-
-export const assessmentLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  limit: 5,
-  standardHeaders: "draft-8",
-  legacyHeaders: false,
-  message: {
-    error: "Too many assessment requests. Please try again later.",
-    retryAfter: 60,
-  },
-});
-
-export const previewLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  limit: 10,
-  standardHeaders: "draft-8",
-  legacyHeaders: false,
-  message: {
-    error: "Too many preview requests. Please try again later.",
-    retryAfter: 60,
-  },
-});
 
 assessmentsRouter.post(
   "/preview",


### PR DESCRIPTION
## Description

`server/routes/assessments.routes.ts` both imported `assessmentLimiter` and `previewLimiter` from `../middleware/rateLimit` **and** re-declared them as local exports with the same names. This created:

1. A TypeScript **duplicate identifier** compile error (`tsc --noEmit` fails)
2. Two separate `rateLimit` instances with independent in-memory hit counters, effectively doubling the allowed request rate for assessment and preview endpoints
3. The import line being dead code — the local declaration shadowed it immediately

The fix removes the local `export const` re-declarations (22 lines) and the now-unused direct `rateLimit` import from `express-rate-limit`. Also consolidates the two `MLService` import statements (lines 9 and 11) that were importing from the same module into a single import.

The centralized definitions in `server/middleware/rateLimit.ts` — which already exist and are correctly configured — are now the sole source of truth.

## Related Issue

Closes #1179

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Removed duplicate `export const assessmentLimiter` declaration (lines ~45–54)
- Removed duplicate `export const previewLimiter` declaration (lines ~56–65)
- Removed unused `import { rateLimit } from "express-rate-limit"` (line 5)
- Merged two separate `MLService` import lines into one (lines 9 and 11)

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

`npx tsc --noEmit` — no errors in `server/routes/assessments.routes.ts` after this fix.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors