### PR TITLE
fix: replace window.location.href CSV export with fetch-based download

### DIFF
--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -319,8 +319,34 @@ export default function History() {
     return params;
   };
 
-  const exportFilteredCsv = () => {
-    window.location.href = `/api/assessments/export.csv?${buildExportParams().toString()}`;
+  const exportFilteredCsv = async () => {
+    try {
+      const res = await fetch(`/api/assessments/export.csv?${buildExportParams().toString()}`, {
+        credentials: "include",
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ message: "Export failed" }));
+        toast({
+          title: "Export failed",
+          description: body.message ?? "Unable to export assessments.",
+          variant: "destructive",
+        });
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = "assessments.csv";
+      anchor.click();
+      URL.revokeObjectURL(url);
+    } catch (err: any) {
+      toast({
+        title: "Export failed",
+        description: err.message ?? "An unexpected error occurred.",
+        variant: "destructive",
+      });
+    }
   };
 
   const exportFilteredPdf = async () => {


### PR DESCRIPTION
## Description

The `exportFilteredCsv` function in `client/src/pages/History.tsx` navigated the browser to the export URL via `window.location.href`. When the server returned an error (401 session expired, 429 rate limited, 500 database error), the browser would navigate away and render the raw JSON error body on a blank page. The user had no recovery path except pressing Back, and saw no helpful feedback.

**After this fix:**
- Uses `fetch` with `credentials: "include"` (matches how all other API calls are made)
- On `!res.ok`, parses the error body and shows a destructive toast — user stays on the History page
- On success, creates a `Blob` URL and triggers a programmatic anchor download
- Revokes the object URL after click to avoid memory leaks

This pattern is already used by `exportFilteredPdf` (the function directly above in the same file), so the change is consistent with the existing codebase approach.

## Related Issue

Closes #1182

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Replaced `window.location.href = ...` navigation with a `fetch`-based download in `exportFilteredCsv`
- Added error handling with `toast` notifications for all failure cases (network, 4xx, 5xx)
- Added `URL.revokeObjectURL` cleanup after anchor click

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

`npx tsc --noEmit` — no errors in `History.tsx`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors