### PR TITLE
fix: persist language selection to localStorage in LanguageSwitcher

### DIFF
--- a/client/src/components/LanguageSwitcher.tsx
+++ b/client/src/components/LanguageSwitcher.tsx
@@ -13,6 +13,7 @@ export function LanguageSwitcher({ variant = "default" }: { variant?: "default" 
 
   const handleChange = (code: string) => {
     i18n.changeLanguage(code);
+    localStorage.setItem("clinical-insight-language", code);
   };
 
   if (variant === "minimal") {


### PR DESCRIPTION
## Description

The `LanguageSwitcher` component was calling `i18n.changeLanguage(code)` but not writing the choice anywhere persistent. Every page refresh reset the language to English because `i18next-browser-languagedetector` found no stored preference.

The i18n configuration in `client/src/i18n/index.ts` already has `LanguageDetector` set up with `localStorage` caching under the key `"clinical-insight-language"`:

```ts
detection: {
  order: ["localStorage", "navigator"],
  caches: ["localStorage"],
  lookupLocalStorage: "clinical-insight-language",
},
```

The fix is to write the selected code to that same key in `handleChange`:

```ts
const handleChange = (code: string) => {
  i18n.changeLanguage(code);
  localStorage.setItem("clinical-insight-language", code);
};
```

No package changes needed — `i18next-browser-languagedetector` is already installed and configured. This is a one-line addition that wires the component to the existing persistence infrastructure.

## Related Issue

Closes #1184

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added `localStorage.setItem("clinical-insight-language", code)` inside `handleChange` in `LanguageSwitcher.tsx`

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

Verified: switch to Spanish → refresh → language stays Spanish.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors