### PR TITLE
perf: memoize distData and avgData in Analytics page to prevent unnecessary chart re-renders

### DIFF
--- a/client/src/pages/Analytics.tsx
+++ b/client/src/pages/Analytics.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useAnalytics, type CriticalAlert } from "@/hooks/use-analytics";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from "recharts";
@@ -14,16 +15,26 @@ const COLORS = {
 export default function Analytics() {
   const { data: stats, isLoading, error } = useAnalytics();
 
-  const distData = stats?.distribution.map(d => ({
-    name: d.category,
-    value: d.count,
-    color: COLORS[d.category as keyof typeof COLORS] || "#94a3b8"
-  })) || [];
+  const distData = useMemo(
+    () =>
+      stats?.distribution.map((d) => ({
+        name: d.category,
+        value: d.count,
+        color: COLORS[d.category as keyof typeof COLORS] ?? "#94a3b8",
+      })) ?? [],
+    [stats?.distribution]
+  );
 
-  const avgData = stats ? [
-    { name: "Average BMI", value: stats.averages.bmi.toFixed(1) },
-    { name: "Average HbA1c", value: stats.averages.hba1c.toFixed(1) }
-  ] : [];
+  const avgData = useMemo(
+    () =>
+      stats
+        ? [
+            { name: "Average BMI", value: stats.averages.bmi.toFixed(1) },
+            { name: "Average HbA1c", value: stats.averages.hba1c.toFixed(1) },
+          ]
+        : [],
+    [stats]
+  );
 
   return (
     <AppLayout>


### PR DESCRIPTION
## Description

`distData` and `avgData` in `client/src/pages/Analytics.tsx` were computed inline in the component body on every render. Because they produce new array and object references each time, Recharts re-renders all chart children — including playing entrance animations — on every re-render triggered by unrelated events (tooltip hover, theme toggle, window resize). On lower-end devices this causes visible chart jank.

Wrapping both values in `useMemo` makes the references stable between renders. Recharts and its child `Cell` components will only re-render when the underlying `stats` data actually changes.

Also replaces the `|| "#94a3b8"` fallback with `?? "#94a3b8"` (nullish coalescing) which is strictly more correct for the colour lookup — `||` would incorrectly substitute the fallback colour for any falsy string value.

## Related Issue

Closes #1185

## Type of Change

- [x] ⚡ Performance improvement

## Changes Made

- Added `import { useMemo } from "react"` 
- Wrapped `distData` in `useMemo` with `[stats?.distribution]` as the dependency
- Wrapped `avgData` in `useMemo` with `[stats]` as the dependency
- Changed `|| "#94a3b8"` to `?? "#94a3b8"` in the colour fallback

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

`npx tsc --noEmit` — no errors in `Analytics.tsx`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors