### PR TITLE
improve toast notification timing

### DIFF
--- a/client/src/components/ui/toast.tsx
+++ b/client/src/components/ui/toast.tsx
@@ -104,7 +104,7 @@ const ToastDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Description
     ref={ref}
-    className={cn("text-sm opacity-90", className)}
+    className={cn("text-sm leading-relaxed opacity-90 break-words", className)}
     {...props}
   />
 ))

--- a/client/src/components/ui/toaster.tsx
+++ b/client/src/components/ui/toaster.tsx
@@ -13,7 +13,7 @@ export function Toaster() {
 
   return (
     <ToastProvider>
-      {toasts.map(function ({ id, title, description, action, ...props }) {
+      {toasts.map(function ({ id, title, description, action, severity: _severity, ...props }) {
         return (
           <Toast key={id} {...props}>
             <div className="grid gap-1">

--- a/client/src/hooks/use-toast.test.ts
+++ b/client/src/hooks/use-toast.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { getToastDuration } from "./use-toast";
+
+describe("getToastDuration", () => {
+  it("uses a short duration for success/default toasts", () => {
+    expect(getToastDuration({ title: "Saved" })).toBe(3000);
+    expect(getToastDuration({ title: "Saved", severity: "success" })).toBe(3000);
+  });
+
+  it("keeps warnings and informational messages visible longer", () => {
+    expect(getToastDuration({ title: "Review", severity: "warning" })).toBe(5000);
+    expect(getToastDuration({ title: "Heads up", severity: "info" })).toBe(5000);
+  });
+
+  it("keeps destructive error toasts visible long enough to read", () => {
+    expect(getToastDuration({ title: "Failed", variant: "destructive" })).toBe(7000);
+    expect(getToastDuration({ title: "Failed", severity: "error" })).toBe(7000);
+  });
+
+  it("preserves caller-provided duration overrides", () => {
+    expect(getToastDuration({ title: "Custom", duration: 9000 })).toBe(9000);
+  });
+});

--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -7,12 +7,21 @@ import type {
 
 const TOAST_LIMIT = 1
 const TOAST_REMOVE_DELAY = 1000000
+const TOAST_DURATIONS = {
+  success: 3000,
+  warning: 5000,
+  error: 7000,
+  info: 5000,
+} as const
+
+type ToastSeverity = keyof typeof TOAST_DURATIONS
 
 type ToasterToast = ToastProps & {
   id: string
   title?: React.ReactNode
   description?: React.ReactNode
   action?: ToastActionElement
+  severity?: ToastSeverity
 }
 
 const actionTypes = {
@@ -139,8 +148,25 @@ function dispatch(action: Action) {
 
 type Toast = Omit<ToasterToast, "id">
 
+function getToastDuration(props: Toast) {
+  if (typeof props.duration === "number") {
+    return props.duration
+  }
+
+  if (props.severity) {
+    return TOAST_DURATIONS[props.severity]
+  }
+
+  if (props.variant === "destructive") {
+    return TOAST_DURATIONS.error
+  }
+
+  return TOAST_DURATIONS.success
+}
+
 function toast({ ...props }: Toast) {
   const id = genId()
+  const duration = getToastDuration(props)
 
   const update = (props: ToasterToast) =>
     dispatch({
@@ -153,6 +179,7 @@ function toast({ ...props }: Toast) {
     type: "ADD_TOAST",
     toast: {
       ...props,
+      duration,
       id,
       open: true,
       onOpenChange: (open) => {
@@ -188,4 +215,4 @@ function useToast() {
   }
 }
 
-export { useToast, toast }
+export { useToast, toast, getToastDuration }


### PR DESCRIPTION
## Summary
- Add centralized toast duration defaults by severity in `use-toast`.
- Keep destructive/error toasts visible longer while success toasts dismiss quickly.
- Preserve explicit duration overrides and improve long toast description readability.
- Add focused Vitest coverage for the duration-selection helper.

## Validation
- npm run check
- npx vitest run client/src/hooks/use-toast.test.ts
- git diff --check

Fixes #1234
