### PR TITLE
standardize readable date formatting

### DIFF
--- a/client/src/components/AssessmentComparisonCard.tsx
+++ b/client/src/components/AssessmentComparisonCard.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
-import { format } from "date-fns";
 import { type AssessmentResponse } from "@shared/routes";
 import AssessmentSelector from "@/components/AssessmentSelector";
 import ComparisonTable from "@/components/ComparisonTable";
+import { formatReadableDate } from "@/utils/dateFormat";
 
 interface Props {
   assessments: AssessmentResponse[];
@@ -51,9 +51,7 @@ export default function AssessmentComparisonCard({
   const formatSummary = (assessment: AssessmentResponse | null) => {
     if (!assessment) return "No assessment selected";
 
-    const date = assessment.createdAt
-      ? format(new Date(assessment.createdAt), "MMM d, yyyy")
-      : "Unknown date";
+    const date = formatReadableDate(assessment.createdAt, { includeTime: false });
     const risk = assessment.riskScore !== undefined && assessment.riskScore !== null
       ? `${Number(assessment.riskScore).toFixed(1)}%`
       : "N/A";

--- a/client/src/components/AssessmentSelector.tsx
+++ b/client/src/components/AssessmentSelector.tsx
@@ -1,5 +1,5 @@
-import { format } from "date-fns";
 import { type AssessmentResponse } from "@shared/routes";
+import { formatReadableDate } from "@/utils/dateFormat";
 
 interface AssessmentSelectorProps {
   label: string;
@@ -19,12 +19,7 @@ export default function AssessmentSelector({
   disabled,
 }: AssessmentSelectorProps) {
   const formatOption = (assessment: AssessmentResponse) => {
-    const dateValue = assessment.createdAt
-      ? new Date(assessment.createdAt)
-      : new Date();
-    const dateLabel = isNaN(dateValue.getTime())
-      ? "Unknown date"
-      : format(dateValue, "MMM d, yyyy");
+    const dateLabel = formatReadableDate(assessment.createdAt, { includeTime: false });
     const score = Number(assessment.riskScore);
 
     return `${assessment.patientName || "Patient"} • ${dateLabel} • ${

--- a/client/src/components/BiomarkerAlerts.tsx
+++ b/client/src/components/BiomarkerAlerts.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
 import type { BiomarkerAlert } from "@shared/routes";
+import { formatCompactDate } from "@/utils/dateFormat";
 
 export function BiomarkerAlerts({ alerts }: { alerts?: BiomarkerAlert[] }) {
   if (!alerts || alerts.length === 0) return null;
@@ -19,7 +20,7 @@ export function BiomarkerAlerts({ alerts }: { alerts?: BiomarkerAlert[] }) {
               </div>
               <div style={{ width: 180, height: 80 }} className="shrink-0">
                 <ResponsiveContainer width="100%" height="100%">
-                  <LineChart data={a.values.map((v) => ({ ...v, label: v.ts ? new Date(v.ts).toLocaleDateString() : "" }))}>
+                  <LineChart data={a.values.map((v) => ({ ...v, label: formatCompactDate(v.ts, "") }))}>
                     <XAxis dataKey="label" hide />
                     <YAxis hide domain={["dataMin - 1", "dataMax + 1"]} />
                     <Tooltip />

--- a/client/src/components/RiskTrendChart.tsx
+++ b/client/src/components/RiskTrendChart.tsx
@@ -10,8 +10,9 @@ import {
   ResponsiveContainer,
   ReferenceLine,
 } from "recharts";
-import { format, isValid } from "date-fns";
+import { isValid } from "date-fns";
 import type { Assessment } from "@shared/schema";
+import { formatCompactDate } from "@/utils/dateFormat";
 
 interface PatientGroup {
   patientName: string;
@@ -141,8 +142,7 @@ export default function RiskTrendChart({ assessments, patientGroups }: Props) {
             tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
             tickFormatter={(iso: string) => {
               if (iso === "?") return "?";
-              const d = new Date(iso);
-              return isValid(d) ? format(d, "MMM d, HH:mm") : "?";
+              return formatCompactDate(iso);
             }}
           />
           <YAxis tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} />

--- a/client/src/pages/AdminDashboard.tsx
+++ b/client/src/pages/AdminDashboard.tsx
@@ -8,6 +8,7 @@ import { Switch } from "@/components/ui/switch";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/EmptyState";
 import { useToast } from "@/hooks/use-toast";
+import { formatReadableDate } from "@/utils/dateFormat";
 
 type Tab = "users" | "audit" | "stats";
 
@@ -216,7 +217,7 @@ function AuditLogsTab({ active }: { active: boolean }) {
           {data?.data.map((log) => (
             <tr key={log.id} className="border-b border-slate-100 dark:border-gray-800">
               <td className="py-3 pr-4 text-slate-500 dark:text-slate-400">
-                {log.createdAt ? new Date(log.createdAt).toLocaleString() : "-"}
+                {formatReadableDate(log.createdAt, { fallback: "-" })}
               </td>
               <td className="py-3 pr-4 text-slate-500 dark:text-slate-400">{log.userId ? log.userId.slice(0, 8) + "..." : "-"}</td>
               <td className="py-3 pr-4 dark:text-gray-300">{log.ipAddress || "-"}</td>

--- a/client/src/pages/Analytics.tsx
+++ b/client/src/pages/Analytics.tsx
@@ -5,6 +5,7 @@ import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveCo
 import { Activity, Users, AlertTriangle, BarChart3 } from "lucide-react";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { EmptyState } from "@/components/EmptyState";
+import { formatReadableDate } from "@/utils/dateFormat";
 
 const COLORS = {
   LOW: "#10b981", // Emerald 500
@@ -152,7 +153,7 @@ export default function Analytics() {
                           <div>
                             <p className="font-bold text-foreground">{alert.patientName}</p>
                             <p className="text-xs font-semibold text-muted-foreground">
-                              {alert.gender}, {alert.age} yrs • Assessed: {alert.createdAt ? new Date(alert.createdAt).toLocaleDateString() : "Unknown"}
+                              {alert.gender}, {alert.age} yrs • Assessed: {formatReadableDate(alert.createdAt, { fallback: "Unknown", includeTime: false })}
                             </p>
                           </div>
                         </div>

--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -2,10 +2,6 @@ import { AppLayout } from "@/components/layout/AppLayout";
 import type { Assessment, AssessmentFactor } from "@shared/schema";
 import { useAssessments, usePatientAssessments, useClearPatientCache, useDeleteAssessment } from "@/hooks/use-assessments";
 import {
-  format,
-  isValid,
-} from "date-fns";
-import {
   Loader2,
   User,
   Activity,
@@ -30,6 +26,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import RiskTrendChart, { PATIENT_COLORS } from "@/components/RiskTrendChart";
 import { EmptyState } from "@/components/EmptyState";
 import HealthBadges from "@/components/HealthBadges";
+import { formatReadableDate } from "@/utils/dateFormat";
 import { calculateHealthBadges } from "@/utils/healthBadges";
 import { AssessmentSearchBar } from "@/components/AssessmentSearchBar";
 import { AssessmentFilters } from "@/components/AssessmentFilters";
@@ -273,8 +270,8 @@ export default function History() {
       chips.push({ id: 'age', label: `Age: ${min} - ${max}`, onRemove: () => { setMinAge(undefined); setMaxAge(undefined); } });
     }
     if (startDate || endDate) {
-      const start = startDate ? format(new Date(startDate), "MMM d, yyyy") : "Any";
-      const end = endDate ? format(new Date(endDate), "MMM d, yyyy") : "Any";
+      const start = startDate ? formatReadableDate(startDate, { includeTime: false }) : "Any";
+      const end = endDate ? formatReadableDate(endDate, { includeTime: false }) : "Any";
       chips.push({ id: 'date', label: `Date: ${start} - ${end}`, onRemove: () => { setStartDate(""); setEndDate(""); } });
     }
     return chips;
@@ -415,7 +412,7 @@ export default function History() {
     if (!assessment) return;
 
     const patientName = escapeHtml(assessment.patientName || "Unknown Patient");
-    const date = escapeHtml(assessment.createdAt ? new Date(assessment.createdAt).toLocaleString() : "Unknown Date");
+    const date = escapeHtml(formatReadableDate(assessment.createdAt, { fallback: "Unknown Date" }));
     const age = escapeHtml(assessment.age ?? "N/A");
     const bmi = escapeHtml(assessment.bmi ?? "N/A");
     const hba1cLevel = escapeHtml(assessment.hba1cLevel ?? "N/A");
@@ -539,9 +536,7 @@ export default function History() {
 
 
   const formatAssessmentDate = (dateVal: any) => {
-    if (!dateVal) return "Unknown";
-    const dateObj = new Date(dateVal);
-    return isValid(dateObj) ? format(dateObj, "MMM d, yyyy") : "Unknown";
+    return formatReadableDate(dateVal, { fallback: "Unknown", includeTime: false });
   };
 
   const clearDateFilters = () => {

--- a/client/src/pages/ModelMonitoring.tsx
+++ b/client/src/pages/ModelMonitoring.tsx
@@ -20,6 +20,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { EmptyState } from "@/components/EmptyState";
+import { formatReadableDate } from "@/utils/dateFormat";
 
 type ModelVersion = {
   id: number;
@@ -189,7 +190,7 @@ function MetricsTab({ versions }: { versions: ModelVersion[] }) {
             </div>
             <div>
               <dt className="text-slate-500 dark:text-slate-400">Trained At</dt>
-              <dd className="font-semibold dark:text-gray-100">{latest.createdAt ? new Date(latest.createdAt).toLocaleString() : "—"}</dd>
+              <dd className="font-semibold dark:text-gray-100">{formatReadableDate(latest.createdAt, { fallback: "—" })}</dd>
             </div>
           </dl>
         </CardContent>
@@ -331,7 +332,7 @@ function VersionHistoryTab({ versions }: { versions: ModelVersion[] }) {
                   <td className="py-3">{v.f1Score !== null ? (v.f1Score * 100).toFixed(1) + "%" : "—"}</td>
                   <td className="py-3">{v.aucRoc !== null ? v.aucRoc.toFixed(4) : "—"}</td>
                   <td className="py-3"><StatusBadge status={v.status} /></td>
-                  <td className="py-3 text-slate-500 dark:text-slate-400">{v.createdAt ? new Date(v.createdAt).toLocaleDateString() : "—"}</td>
+                  <td className="py-3 text-slate-500 dark:text-slate-400">{formatReadableDate(v.createdAt, { fallback: "—", includeTime: false })}</td>
                 </tr>
               ))}
             </tbody>

--- a/client/src/pages/MyHealth.tsx
+++ b/client/src/pages/MyHealth.tsx
@@ -9,6 +9,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from "recharts";
 import { Loader2, LogOut, Download, AlertTriangle, Heart, Activity, FileText, ChevronLeft } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { formatReadableDate } from "@/utils/dateFormat";
 
 interface PatientUser {
   id: string;
@@ -69,14 +70,6 @@ function riskColorHex(category: string): string {
     case "MODERATE": return "#d97706";
     default: return "#16a34a";
   }
-}
-
-function formatDate(dateStr: string): string {
-  try {
-    return new Date(dateStr).toLocaleDateString("en-US", {
-      year: "numeric", month: "short", day: "numeric",
-    });
-  } catch { return dateStr; }
 }
 
 export default function MyHealth() {
@@ -150,7 +143,7 @@ export default function MyHealth() {
     doc.text("Patient Health Summary", 14, 22);
     doc.setFontSize(11);
     doc.text(`Patient: ${assessment.patientName}`, 14, 32);
-    doc.text(`Date: ${formatDate(assessment.createdAt)}`, 14, 40);
+    doc.text(`Date: ${formatReadableDate(assessment.createdAt, { includeTime: false })}`, 14, 40);
     doc.text(`Risk Score: ${assessment.riskScore.toFixed(1)}%`, 14, 50);
     doc.text(`Risk Category: ${assessment.riskCategory}`, 14, 58);
     doc.text(`Age: ${assessment.age}  |  Gender: ${assessment.gender}`, 14, 66);
@@ -201,7 +194,7 @@ export default function MyHealth() {
               <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-4">
                 <div className="rounded-lg bg-gray-50 p-3 sm:p-4">
                   <p className="text-xs text-gray-500">Date</p>
-                  <p className="font-medium text-sm sm:text-base">{formatDate(sa.createdAt)}</p>
+                  <p className="font-medium text-sm sm:text-base">{formatReadableDate(sa.createdAt, { includeTime: false })}</p>
                 </div>
                 <div className="rounded-lg bg-gray-50 p-3 sm:p-4">
                   <p className="text-xs text-gray-500">Risk Score</p>
@@ -320,7 +313,7 @@ export default function MyHealth() {
                     <TableBody>
                       {assessments.map((a) => (
                         <TableRow key={a.id} className="cursor-pointer hover:bg-gray-50" onClick={() => setSelectedAssessment(a)}>
-                          <TableCell className="text-sm sticky left-0 bg-white z-10">{formatDate(a.createdAt)}</TableCell>
+                          <TableCell className="text-sm sticky left-0 bg-white z-10">{formatReadableDate(a.createdAt, { includeTime: false })}</TableCell>
                           <TableCell className="font-medium">{a.riskScore.toFixed(1)}%</TableCell>
                           <TableCell>
                             <Badge className={riskColor(a.riskCategory)}>{a.riskCategory}</Badge>
@@ -353,7 +346,7 @@ export default function MyHealth() {
                 ) : (
                   <div className="h-60 sm:h-80">
                     <ResponsiveContainer width="100%" height="100%">
-                      <LineChart data={trends.map((t) => ({ ...t, date: formatDate(t.date) }))}>
+                      <LineChart data={trends.map((t) => ({ ...t, date: formatReadableDate(t.date, { includeTime: false }) }))}>
                         <CartesianGrid strokeDasharray="3 3" className="dark:stroke-gray-700" />
                         <XAxis dataKey="date" tick={{ fontSize: 12 }} className="dark:text-gray-400" />
                         <YAxis domain={[0, 100]} tick={{ fontSize: 12 }} className="dark:text-gray-400" />

--- a/client/src/pages/ProgressTracking.tsx
+++ b/client/src/pages/ProgressTracking.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend, ReferenceLine } from "recharts";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { Search, TrendingUp, Activity, Weight, HeartPulse, Loader2, AlertCircle } from "lucide-react";
+import { formatCompactDate, formatReadableDate } from "@/utils/dateFormat";
 
 interface Assessment {
   id: number;
@@ -17,18 +18,6 @@ interface Assessment {
   riskScore: number;
   riskCategory: string;
   createdAt: string;
-}
-
-function formatDate(dateStr: string): string {
-  try {
-    return new Date(dateStr).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "2-digit" });
-  } catch { return dateStr; }
-}
-
-function formatDateFull(dateStr: string): string {
-  try {
-    return new Date(dateStr).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-  } catch { return dateStr; }
 }
 
 function cn(...classes: (string | boolean | undefined | null)[]): string {
@@ -111,8 +100,8 @@ export default function ProgressTracking() {
     .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
     .map((a) => ({
       ...a,
-      date: formatDate(a.createdAt),
-      dateFull: formatDateFull(a.createdAt),
+      date: formatCompactDate(a.createdAt),
+      dateFull: formatReadableDate(a.createdAt, { includeTime: false }),
     }));
 
   return (
@@ -321,7 +310,7 @@ export default function ProgressTracking() {
                       <tbody>
                         {[...assessments].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()).map((a) => (
                           <tr key={a.id} className="border-b border-slate-100 dark:border-slate-800">
-                            <td className="px-4 py-3 whitespace-nowrap">{formatDateFull(a.createdAt)}</td>
+                            <td className="px-4 py-3 whitespace-nowrap">{formatReadableDate(a.createdAt, { includeTime: false })}</td>
                             <td className="px-4 py-3">{a.age}</td>
                             <td className="px-4 py-3">{a.bmi.toFixed(1)}</td>
                             <td className="px-4 py-3">{a.hba1cLevel.toFixed(1)}%</td>

--- a/client/src/utils/bulkPdfExport.ts
+++ b/client/src/utils/bulkPdfExport.ts
@@ -1,4 +1,5 @@
 import { jsPDF } from "jspdf";
+import { formatReadableDate } from "./dateFormat";
 
 interface BulkExportAssessment {
   id: number;
@@ -49,7 +50,7 @@ export function downloadBulkAssessmentPdf(assessments: BulkExportAssessment[]): 
 
   doc.setFont("Helvetica", "normal");
   doc.setFontSize(11);
-  doc.text(`Generated: ${new Date().toLocaleString()}`, pw / 2, 50, { align: "center" });
+  doc.text(`Generated: ${formatReadableDate(new Date())}`, pw / 2, 50, { align: "center" });
   doc.text(`Total assessments: ${assessments.length}`, pw / 2, 58, { align: "center" });
 
   // Risk distribution
@@ -162,7 +163,7 @@ export function downloadBulkAssessmentPdf(assessments: BulkExportAssessment[]): 
     let cx = m;
     const vals = [
       String(i + 1),
-      a.createdAt ? new Date(a.createdAt).toLocaleDateString() : "—",
+      formatReadableDate(a.createdAt, { fallback: "—", includeTime: false }),
       fmt(a.patientName),
       fmt(a.age),
       fmt(a.gender),
@@ -210,7 +211,7 @@ export function downloadBulkAssessmentPdf(assessments: BulkExportAssessment[]): 
     doc.text("Assessment Details", m, yy);
     yy += 8;
 
-    yy = labelVal("Date:", a.createdAt ? new Date(a.createdAt).toLocaleString() : "—", yy);
+    yy = labelVal("Date:", formatReadableDate(a.createdAt, { fallback: "—" }), yy);
     yy = labelVal("Gender:", fmt(a.gender), yy);
     yy = labelVal("Age:", fmt(a.age), yy);
     yy = labelVal("BMI:", a.bmi != null ? Number(a.bmi).toFixed(1) : "—", yy);

--- a/client/src/utils/clinicalPdfReport.ts
+++ b/client/src/utils/clinicalPdfReport.ts
@@ -1,4 +1,5 @@
 import { type AssessmentResponse } from "@shared/routes";
+import { formatReadableDate } from "./dateFormat";
 
 type ReportAssessment = AssessmentResponse;
 export type PatientSummaryAssessment = Pick<
@@ -96,20 +97,7 @@ function formatNumber(value: unknown, fractionDigits = 1, suffix = ""): string {
 }
 
 function formatDate(value: unknown): string {
-  if (!value) {
-    return "N/A";
-  }
-
-  const date = new Date(value as string);
-  return Number.isNaN(date.getTime())
-    ? "N/A"
-    : date.toLocaleString(undefined, {
-        year: "numeric",
-        month: "short",
-        day: "2-digit",
-        hour: "2-digit",
-        minute: "2-digit",
-      });
+  return formatReadableDate(value as string | Date | null | undefined, { fallback: "N/A" });
 }
 
 function getRiskColor(category: string): string {

--- a/client/src/utils/dateFormat.test.ts
+++ b/client/src/utils/dateFormat.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { formatCompactDate, formatReadableDate } from "./dateFormat";
+
+describe("date formatting utilities", () => {
+  it("formats timestamps with a readable date and time", () => {
+    expect(formatReadableDate("2026-06-13T12:00:00Z")).toMatch(
+      /^Jun 13, 2026 at \d{1,2}:\d{2} (AM|PM)$/,
+    );
+  });
+
+  it("can omit time for compact table and chart labels", () => {
+    expect(formatReadableDate("2026-06-13T12:00:00Z", { includeTime: false })).toBe("Jun 13, 2026");
+    expect(formatCompactDate("2026-06-13T12:00:00Z")).toBe("Jun 13");
+  });
+
+  it("uses fallbacks for empty or invalid dates", () => {
+    expect(formatReadableDate(null)).toBe("Unknown date");
+    expect(formatReadableDate("not-a-date", { fallback: "N/A" })).toBe("N/A");
+  });
+});

--- a/client/src/utils/dateFormat.ts
+++ b/client/src/utils/dateFormat.ts
@@ -1,0 +1,42 @@
+type DateInput = string | number | Date | null | undefined;
+
+interface DateFormatOptions {
+  fallback?: string;
+  includeTime?: boolean;
+}
+
+function parseDate(value: DateInput): Date | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function formatReadableDate(value: DateInput, options: DateFormatOptions = {}): string {
+  const { fallback = "Unknown date", includeTime = true } = options;
+  const date = parseDate(value);
+  if (!date) return fallback;
+
+  const formatted = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    ...(includeTime
+      ? {
+          hour: "numeric",
+          minute: "2-digit",
+        }
+      : {}),
+  }).format(date);
+
+  return includeTime ? formatted.replace(/, (?=\d{1,2}:)/, " at ") : formatted;
+}
+
+export function formatCompactDate(value: DateInput, fallback = "?"): string {
+  const date = parseDate(value);
+  if (!date) return fallback;
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}


### PR DESCRIPTION
## Summary
- Add reusable readable and compact date formatting utilities.
- Replace visible raw/toLocale date displays across history, analytics, model monitoring, progress, patient health, assessment selectors, charts, and PDF exports.
- Add focused Vitest coverage for the shared formatter.

## Validation
- npm run check
- npx vitest run client/src/utils/dateFormat.test.ts
- git diff --check

Fixes #1231
