### PR TITLE
add shared button loading state

### DIFF
--- a/client/src/components/ConfirmDeleteDialog.tsx
+++ b/client/src/components/ConfirmDeleteDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Loader2, Trash2 } from "lucide-react";
+import { Trash2 } from "lucide-react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -68,17 +68,11 @@ export function ConfirmDeleteDialog({
           <Button
             variant="destructive"
             onClick={handleConfirm}
-            disabled={isDeleting}
+            isLoading={isDeleting}
+            loadingText="Deleting..."
             className="gap-2"
           >
-            {isDeleting ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Deleting...
-              </>
-            ) : (
-              "Delete"
-            )}
+            Delete
           </Button>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/client/src/components/ui/button.test.ts
+++ b/client/src/components/ui/button.test.ts
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { Button } from "./button";
+
+describe("Button loading state", () => {
+  it("disables the button and exposes busy state while loading", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(Button, { isLoading: true, loadingText: "Saving..." }, "Save"),
+    );
+
+    expect(html).toContain("disabled=\"\"");
+    expect(html).toContain("aria-busy=\"true\"");
+    expect(html).toContain("data-loading=\"true\"");
+    expect(html).toContain("Saving...");
+    expect(html).toContain("animate-spin");
+  });
+
+  it("preserves normal children when not loading", () => {
+    const html = renderToStaticMarkup(React.createElement(Button, null, "Save"));
+
+    expect(html).toContain(">Save</button>");
+    expect(html).not.toContain("aria-busy");
+    expect(html).not.toContain("data-loading");
+  });
+});

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
+import { Loader2 } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
@@ -43,17 +44,44 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean
+  isLoading?: boolean
+  loadingText?: string
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  (
+    {
+      className,
+      variant,
+      size,
+      asChild = false,
+      children,
+      disabled,
+      isLoading = false,
+      loadingText,
+      ...props
+    },
+    ref
+  ) => {
     const Comp = asChild ? Slot : "button"
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
+        disabled={isLoading || disabled}
+        aria-busy={isLoading || undefined}
+        data-loading={isLoading ? "true" : undefined}
         ref={ref}
         {...props}
-      />
+      >
+        {isLoading && !asChild ? (
+          <>
+            <Loader2 className="animate-spin" aria-hidden="true" />
+            {loadingText ?? children}
+          </>
+        ) : (
+          children
+        )}
+      </Comp>
     )
   },
 )

--- a/client/src/pages/ModelMonitoring.tsx
+++ b/client/src/pages/ModelMonitoring.tsx
@@ -95,13 +95,9 @@ function RetrainDialog({ onConfirm, isTraining }: { onConfirm: () => void; isTra
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button disabled={isTraining} className="gap-2">
-          {isTraining ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <RefreshCw className="h-4 w-4" />
-          )}
-          {isTraining ? "Retraining…" : "Retrain Model"}
+        <Button isLoading={isTraining} loadingText="Retraining…" className="gap-2">
+          <RefreshCw className="h-4 w-4" />
+          Retrain Model
         </Button>
       </DialogTrigger>
       <DialogContent>

--- a/client/src/pages/PatientLogin.tsx
+++ b/client/src/pages/PatientLogin.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Loader2, Stethoscope, Eye, EyeOff, ShieldCheck } from "lucide-react";
+import { Stethoscope, Eye, EyeOff, ShieldCheck } from "lucide-react";
 import { PasswordStrength } from "@/components/auth/PasswordStrength";
 
 interface FieldErrors {
@@ -191,9 +191,8 @@ export default function PatientLogin() {
                     Remember me
                   </label>
                 </div>
-                <Button type="submit" className="w-full" disabled={loading}>
-                  {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-                  {loading ? "Signing In..." : "Sign In"}
+                <Button type="submit" className="w-full" isLoading={loading} loadingText="Signing In...">
+                  Sign In
                 </Button>
               </form>
             </TabsContent>
@@ -282,8 +281,7 @@ export default function PatientLogin() {
                   <Label htmlFor="reg-phone" className="text-sm sm:text-base">Phone (optional)</Label>
                   <Input id="reg-phone" type="tel" placeholder="+1-555-0123" value={phone} onChange={(e) => setPhone(e.target.value)} className="min-h-[48px] text-base" />
                 </div>
-                <Button type="submit" className="w-full min-h-[48px] text-base" disabled={loading}>
-                  {loading ? <Loader2 className="mr-2 h-5 w-5 animate-spin" /> : null}
+                <Button type="submit" className="w-full min-h-[48px] text-base" isLoading={loading}>
                   Create Account
                 </Button>
                 <div className="flex items-center justify-center gap-2 text-xs text-gray-400">


### PR DESCRIPTION
## Summary
- Add `isLoading` and `loadingText` support to the shared Button component.
- Automatically disable loading buttons, expose `aria-busy`, and render a consistent spinner.
- Convert delete, retrain, and patient auth action buttons to the shared loading pattern.
- Add focused component coverage for the Button loading state.

## Validation
- npm run check
- npx vitest run client/src/components/ui/button.test.ts
- git diff --check

Fixes #1230
