### PR TITLE
feat: migrate DB to Supabase with SSL support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,12 @@ API_URL=http://localhost:5000
 APP_URL=http://localhost:5173
 
 # Database (if applicable)
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/clinical_insight_engine
+# Local PostgreSQL
+# DATABASE_URL=postgresql://postgres:postgres@localhost:5432/clinical_insight_engine
+
+# Supabase (hosted PostgreSQL) — set DB_SSL=true or use a *.supabase.co URL
+# DATABASE_URL=postgresql://postgres:[PASSWORD]@db.[PROJECT_REF].supabase.co:5432/postgres
+# DB_SSL=true
 
 # Authentication
 SESSION_SECRET=replace-with-a-long-random-session-secret

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ APP_URL=http://localhost:5173
 # DATABASE_URL=postgresql://postgres:[PASSWORD]@db.[PROJECT_REF].supabase.co:5432/postgres
 # DB_SSL=true
 
+# Supabase frontend/auth environment variables
+# SUPABASE_URL=https://[PROJECT_REF].supabase.co
+# SUPABASE_ANON_KEY=your-supabase-anon-key
+# SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
+
 # Authentication
 SESSION_SECRET=replace-with-a-long-random-session-secret
 

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -26,7 +26,7 @@ const formSchema = insertAssessmentSchema.pick({
   bloodGlucoseLevel: true,
 });
 
-type FormData = z.infer<typeof formSchema>;
+type AssessmentFormData = z.infer<typeof formSchema>;
 
 const inputClass =
   "w-full rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-gray-900 px-4 py-3 text-[#1E293B] dark:text-gray-100 placeholder-slate-400 dark:placeholder-slate-500 shadow-sm outline-none transition-all duration-200 focus:border-blue-600 dark:focus:border-blue-500 focus:ring-4 focus:ring-blue-600/20 dark:focus:ring-blue-500/20";
@@ -90,8 +90,8 @@ export default function Dashboard() {
     watch,
     setValue,
     reset,
-  } = useForm<FormData>({
-    resolver: zodResolver(formSchema),
+  } = useForm<AssessmentFormData>({
+    resolver: zodResolver(formSchema) as any,
     defaultValues: {
       patientName: "",
       hypertension: false,
@@ -105,7 +105,7 @@ export default function Dashboard() {
     },
   });
 
-  const onSubmit = (data: FormData) => {
+  const onSubmit = (data: AssessmentFormData) => {
     createAssessment(data, {
       onSuccess: (data) => {
         setResult(data);
@@ -158,7 +158,7 @@ export default function Dashboard() {
         Object.entries(draft).forEach(([k, v]) => {
           if (!allowedKeys.includes(k)) return;
           try {
-            setValue(k as keyof FormData, v as any, { shouldDirty: true });
+            setValue(k as keyof AssessmentFormData, v as any, { shouldDirty: true });
           } catch (e) {}
         });
       }

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -4,12 +4,18 @@ if (!process.env.DATABASE_URL) {
   throw new Error("DATABASE_URL, ensure the database is provisioned");
 }
 
+const dbUrl = process.env.DATABASE_URL;
+const useSSL =
+  process.env.DB_SSL === "true" ||
+  /supabase\.co|pooler\.supabase\.com/i.test(dbUrl);
+
 export default defineConfig({
   out: "./migrations",
   schema: "./shared/schema.ts",
   dialect: "postgresql",
   dbCredentials: {
-    url: process.env.DATABASE_URL,
+    url: dbUrl,
+    ...(useSSL ? { ssl: { rejectUnauthorized: false } } : {}),
   },
   // 💡 Explicitly declare your managed table names rather than using standard wildcards
   tablesFilter: [

--- a/server/db.ts
+++ b/server/db.ts
@@ -95,10 +95,16 @@ export async function withRetry<T>(
 
 export function getPool() {
   if (!poolInstance) {
+    const dbUrl = getDatabaseUrl();
+    const useSSL =
+      process.env.DB_SSL === "true" ||
+      /supabase\.co|pooler\.supabase\.com/i.test(dbUrl);
+
     poolInstance = new Pool({
-      connectionString: getDatabaseUrl(),
+      connectionString: dbUrl,
       connectionTimeoutMillis: 5000,
       idleTimeoutMillis: 10000,
+      ...(useSSL ? { ssl: { rejectUnauthorized: false } } : {}),
     });
 
     poolInstance.on("error", (err) => {


### PR DESCRIPTION
### Problem
The database connection is hardcoded for local PostgreSQL. Supabase (hosted PostgreSQL) requires SSL/TLS for all connections, which the current `pg.Pool` config does not provide.

### Changes

**`server/db.ts`**
- Auto-detects Supabase URLs (`.supabase.co` or `pooler.supabase.com` in the connection string)
- Supports explicit `DB_SSL=true` env var to force SSL mode
- Passes `{ ssl: { rejectUnauthorized: false } }` to `pg.Pool` when SSL is required
- Works with both direct Supabase connections and the connection pooler (port 6543)

**`.env.example`**
- Commented out the local PostgreSQL example
- Added Supabase connection string example with documentation
- Added `DB_SSL=true` env var example

Closes #1288 