### PR TITLE
feat: add FHIR R4 bundle ingestion endpoint and parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,7 @@ Clinical-Insight-Engine/
 | `POST` | `/api/assessments` | Submit a new risk assessment |
 | `GET` | `/api/assessments` | Retrieve assessment history |
 | `GET` | `/api/assessments/:id` | Get a specific assessment by ID |
+| `POST` | `/api/ingest/fhir` | Ingest a FHIR R4 JSON bundle |
 
 ### Example Request
 
@@ -606,6 +607,60 @@ curl -X POST http://localhost:3000/api/assessments \
     "bmi": 30.1,
     "hba1cLevel": 6.4,
     "bloodGlucoseLevel": 148
+  }'
+```
+
+### FHIR Ingestion
+
+Allows submitting standard FHIR R4 JSON bundles containing patient demographic details and clinical vitals/lab values.
+
+#### Supported Resources
+* **Patient**: Extracts `id`, `name`, `gender` (mapped to `Male`/`Female`), and calculates patient `age` from `birthDate`.
+* **Observation**: Extracts clinical values such as `BMI`, `HbA1c`, `Blood Glucose`, and flags `hypertension` and `heartDisease` using LOINC codes and display terms.
+* **DocumentReference**: Scans titles, descriptions, and decoded base64 attachments for cardiovascular and smoking history keywords.
+
+#### Example Request
+```bash
+curl -X POST http://localhost:3000/api/ingest/fhir \
+  -H "Content-Type: application/json" \
+  -d '{
+    "resourceType": "Bundle",
+    "type": "collection",
+    "entry": [
+      {
+        "resource": {
+          "resourceType": "Patient",
+          "id": "pat-123",
+          "name": [
+            {
+              "use": "official",
+              "given": ["John", "Edward"],
+              "family": "Smith"
+            }
+          ],
+          "gender": "male",
+          "birthDate": "1980-01-01"
+        }
+      },
+      {
+        "resource": {
+          "resourceType": "Observation",
+          "code": {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "39156-5",
+                "display": "Body Mass Index"
+              }
+            ]
+          },
+          "valueQuantity": {
+            "value": 24.5,
+            "unit": "kg/m2"
+          }
+        }
+      }
+    ]
   }'
 ```
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -7,6 +7,7 @@ import type { Express } from "express";
 import type { Server } from "http";
 
 import assessmentsRouter from "./routes/assessments.routes";
+import fhirRouter from "./routes/fhir.routes";
 import { storage, type AssessmentCreateInput } from "./storage";
 import { requireAuth, requireAdmin, requireVerified } from "./auth";
 import { logger } from "./logger";
@@ -189,6 +190,7 @@ export async function registerRoutes(
 
   // Mount auth router
   app.use("/api/auth", authRouter);
+  app.use("/api/ingest", fhirRouter);
   app.post(
     api.assessments.preview.path,
     requireAuth,

--- a/server/routes/fhir.routes.ts
+++ b/server/routes/fhir.routes.ts
@@ -1,0 +1,113 @@
+import { Router } from "express";
+import { requireAuth, requireVerified } from "../auth";
+import { validateFhirBundle, parseFhirBundle, convertToInternalSchema } from "../services/fhirParser";
+import { MLService } from "../services/mlService";
+import { generateRecommendations } from "../services/recommendation-engine";
+import { storage } from "../storage";
+import { logger } from "../logger";
+
+const fhirRouter = Router();
+
+fhirRouter.post(
+  "/fhir",
+  requireAuth,
+  requireVerified,
+  async (req, res) => {
+    try {
+      const payload = req.body;
+
+      // 1. Validate FHIR Bundle Structure
+      try {
+        validateFhirBundle(payload);
+      } catch (err: any) {
+        return res.status(400).json({
+          status: "error",
+          message: err.message || "Invalid FHIR payload",
+        });
+      }
+
+      // 2. Parse FHIR Bundle
+      const parsed = parseFhirBundle(payload);
+
+      // 3. Convert to internal schema & validate fields
+      let assessmentInput;
+      try {
+        assessmentInput = convertToInternalSchema(parsed);
+      } catch (err: any) {
+        return res.status(400).json({
+          status: "error",
+          message: err.message || "Validation failed for parsed clinical data",
+        });
+      }
+
+      // 4. Run ML Pipeline Inference (with fallback)
+      const { prediction } = await MLService.runAssessmentInference(assessmentInput);
+
+      // 5. Generate recommendations
+      const recommendations = generateRecommendations({
+        ...assessmentInput,
+        riskCategory: prediction.riskCategory,
+      });
+
+      // 6. Persist assessment to DB
+      const userEmail = req.session.user?.email || "system@clinical-insight-engine.dev";
+      const userId = (req.session.user as any)?.id;
+
+      const savedAssessment = await storage.createAssessment({
+        ...assessmentInput,
+        riskScore: prediction.riskScore,
+        riskCategory: prediction.riskCategory,
+        factors: prediction.factors ?? [],
+        confidenceInterval: prediction.confidenceInterval ?? null,
+        modelConfidence: prediction.modelConfidence ?? null,
+        createdBy: userEmail,
+        userId: userId ? String(userId) : null,
+      });
+
+      // 7. Format insights array
+      const insights: any[] = [
+        {
+          type: "risk",
+          category: prediction.riskCategory,
+          score: prediction.riskScore,
+          confidence: prediction.modelConfidence ?? null,
+          confidenceInterval: prediction.confidenceInterval ?? null,
+        },
+        ...recommendations.map(r => ({
+          type: "recommendation",
+          id: r.id,
+          title: r.title,
+          description: r.description,
+          urgency: r.urgency,
+          audience: r.audience,
+          checklist: r.checklist,
+        })),
+        ...(prediction.clinicianAdvice || []).map(advice => ({
+          type: "clinician_advice",
+          text: advice,
+        })),
+        ...(prediction.patientAdvice || []).map(advice => ({
+          type: "patient_advice",
+          text: advice,
+        })),
+      ];
+
+      return res.status(200).json({
+        status: "success",
+        patient_id: parsed.patient?.id || String(savedAssessment.id),
+        observations_processed: parsed.observations.length,
+        documents_processed: parsed.documents.length,
+        insights,
+      });
+
+    } catch (err: any) {
+      logger.error({ err }, "FHIR Ingestion failed");
+      return res.status(500).json({
+        status: "error",
+        message: err.message || "Internal server error during FHIR ingestion",
+      });
+    }
+  }
+);
+
+export default fhirRouter;

--- a/server/services/fhirParser.ts
+++ b/server/services/fhirParser.ts
@@ -1,0 +1,378 @@
+import { insertAssessmentSchema, type InsertAssessment } from "../../shared/schema";
+
+export interface NormalizedPatient {
+  id?: string;
+  name: string;
+  gender: "Male" | "Female";
+  birthDate?: string;
+}
+
+export interface NormalizedObservation {
+  codeDisplay?: string;
+  code?: string;
+  valueQuantity?: {
+    value: number;
+    unit?: string;
+  };
+  valueString?: string;
+  effectiveDateTime?: string;
+  component?: Array<{
+    code?: {
+      coding?: Array<{
+        code?: string;
+        display?: string;
+      }>;
+      text?: string;
+    };
+    valueQuantity?: {
+      value: number;
+    };
+  }>;
+}
+
+export interface NormalizedDocument {
+  description?: string;
+  type?: string;
+  attachmentContent?: string;
+  attachmentTitle?: string;
+}
+
+export interface NormalizedFhirStructure {
+  patient?: NormalizedPatient;
+  observations: NormalizedObservation[];
+  documents: NormalizedDocument[];
+}
+
+/**
+ * Validates the structure of a FHIR R4 Bundle.
+ * Throws clean, informative validation errors if validation fails.
+ */
+export function validateFhirBundle(payload: any): void {
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Invalid FHIR payload");
+  }
+
+  if (!("resourceType" in payload)) {
+    throw new Error("Invalid FHIR payload");
+  }
+
+  if (payload.resourceType !== "Bundle") {
+    throw new Error("Unsupported FHIR structure");
+  }
+
+  if (!payload.type || typeof payload.type !== "string") {
+    throw new Error("Unsupported FHIR structure");
+  }
+
+  if (!payload.entry || !Array.isArray(payload.entry)) {
+    throw new Error("Missing Bundle entries");
+  }
+
+  if (payload.entry.length === 0) {
+    throw new Error("Missing Bundle entries");
+  }
+}
+
+/**
+ * Parses supported FHIR R4 resources (Patient, Observation, DocumentReference)
+ * and returns a normalized structure.
+ */
+export function parseFhirBundle(payload: any): NormalizedFhirStructure {
+  const result: NormalizedFhirStructure = {
+    observations: [],
+    documents: [],
+  };
+
+  for (const entry of payload.entry) {
+    if (!entry || typeof entry !== "object" || !entry.resource) {
+      continue;
+    }
+
+    const resource = entry.resource;
+    const resourceType = resource.resourceType;
+
+    if (resourceType === "Patient") {
+      let patientName = "";
+      if (resource.name && Array.isArray(resource.name) && resource.name.length > 0) {
+        // Try to find official or usual name, otherwise use the first one
+        const nameObj = resource.name.find((n: any) => n.use === "official" || n.use === "usual") || resource.name[0];
+        if (nameObj) {
+          const given = Array.isArray(nameObj.given) ? nameObj.given.join(" ") : "";
+          const family = nameObj.family || "";
+          patientName = `${given} ${family}`.trim();
+        }
+      }
+
+      let gender: "Male" | "Female" | undefined;
+      if (resource.gender === "male") {
+        gender = "Male";
+      } else if (resource.gender === "female") {
+        gender = "Female";
+      }
+
+      result.patient = {
+        id: resource.id,
+        name: patientName,
+        gender: gender as any,
+        birthDate: resource.birthDate,
+      };
+    } else if (resourceType === "Observation") {
+      const codeCoding = resource.code?.coding?.[0];
+      const codeDisplay = codeCoding?.display || resource.code?.text || "";
+      const codeVal = codeCoding?.code || "";
+
+      const obs: NormalizedObservation = {
+        codeDisplay,
+        code: codeVal,
+        effectiveDateTime: resource.effectiveDateTime,
+      };
+
+      if (resource.valueQuantity) {
+        obs.valueQuantity = {
+          value: Number(resource.valueQuantity.value),
+          unit: resource.valueQuantity.unit,
+        };
+      }
+
+      if (resource.valueString) {
+        obs.valueString = resource.valueString;
+      }
+
+      if (resource.component && Array.isArray(resource.component)) {
+        obs.component = resource.component.map((comp: any) => ({
+          code: comp.code,
+          valueQuantity: comp.valueQuantity ? { value: Number(comp.valueQuantity.value) } : undefined,
+        }));
+      }
+
+      result.observations.push(obs);
+    } else if (resourceType === "DocumentReference") {
+      const doc: NormalizedDocument = {
+        description: resource.description,
+        type: resource.type?.text || resource.type?.coding?.[0]?.display,
+      };
+
+      const attachment = resource.content?.[0]?.attachment;
+      if (attachment) {
+        doc.attachmentTitle = attachment.title;
+        if (attachment.data) {
+          try {
+            doc.attachmentContent = Buffer.from(attachment.data, "base64").toString("utf-8");
+          } catch (e) {
+            // Ignore decoding errors
+          }
+        }
+      }
+
+      result.documents.push(doc);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Maps the normalized FHIR structure to the internal InsertAssessment schema.
+ * Performs rigorous validations and throws clean error messages.
+ */
+export function convertToInternalSchema(structure: NormalizedFhirStructure): InsertAssessment {
+  if (!structure.patient) {
+    throw new Error("Missing required field: Patient Name");
+  }
+
+  if (!structure.patient.name) {
+    throw new Error("Missing required field: Patient Name");
+  }
+
+  if (!structure.patient.gender) {
+    throw new Error("Missing required field: Gender");
+  }
+
+  if (structure.patient.gender !== "Male" && structure.patient.gender !== "Female") {
+    throw new Error("Gender must be 'Male' or 'Female'");
+  }
+
+  if (!structure.patient.birthDate) {
+    throw new Error("Missing required field: Age");
+  }
+
+  const birthDate = new Date(structure.patient.birthDate);
+  if (isNaN(birthDate.getTime())) {
+    throw new Error("Invalid birth date format");
+  }
+
+  const today = new Date();
+  let age = today.getFullYear() - birthDate.getFullYear();
+  const m = today.getMonth() - birthDate.getMonth();
+  if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {
+    age--;
+  }
+
+  if (age < 1 || age > 120) {
+    throw new Error("Age must be between 1 and 120");
+  }
+
+  let bmi: number | undefined;
+  let hba1cLevel: number | undefined;
+  let bloodGlucoseLevel: number | undefined;
+  let hypertension = false;
+  let heartDisease = false;
+  let smokingHistory: "never" | "No Info" | "current" | "former" = "No Info";
+
+  // Scan observations
+  for (const obs of structure.observations) {
+    const code = (obs.code || "").toLowerCase();
+    const display = (obs.codeDisplay || "").toLowerCase();
+
+    // 1. BMI
+    if (code === "39156-5" || display.includes("bmi") || display.includes("body mass index")) {
+      if (obs.valueQuantity) {
+        bmi = obs.valueQuantity.value;
+      }
+    }
+
+    // 2. HbA1c
+    if (code === "4548-4" || display.includes("hba1c") || display.includes("hemoglobin a1c") || display.includes("glycated hemoglobin")) {
+      if (obs.valueQuantity) {
+        hba1cLevel = obs.valueQuantity.value;
+      }
+    }
+
+    // 3. Blood Glucose
+    if (code === "2339-0" || display.includes("glucose") || display.includes("blood glucose")) {
+      if (obs.valueQuantity) {
+        bloodGlucoseLevel = obs.valueQuantity.value;
+      }
+    }
+
+    // 4. Hypertension (BP component observations or keyword)
+    if (code === "85354-9" || code === "55284-4" || display.includes("blood pressure")) {
+      if (obs.component && Array.isArray(obs.component)) {
+        for (const comp of obs.component) {
+          const compCode = comp.code?.coding?.[0]?.code || "";
+          const compDisplay = (comp.code?.coding?.[0]?.display || comp.code?.text || "").toLowerCase();
+          const val = comp.valueQuantity?.value;
+
+          if (val !== undefined) {
+            if (compCode === "8480-6" || compDisplay.includes("systolic")) {
+              if (val > 140) hypertension = true;
+            }
+            if (compCode === "8462-4" || compDisplay.includes("diastolic")) {
+              if (val > 90) hypertension = true;
+            }
+          }
+        }
+      }
+    }
+
+    if (display.includes("hypertension") || display.includes("high blood pressure") || display.includes("htn")) {
+      if (obs.valueString) {
+        const valStr = obs.valueString.toLowerCase();
+        if (valStr.includes("yes") || valStr.includes("true") || valStr.includes("active") || valStr.includes("present")) {
+          hypertension = true;
+        }
+      } else {
+        hypertension = true;
+      }
+    }
+
+    // 5. Heart Disease
+    if (
+      display.includes("heart disease") ||
+      display.includes("coronary artery disease") ||
+      display.includes("cad") ||
+      display.includes("myocardial infarction") ||
+      display.includes("mi") ||
+      display.includes("heart failure") ||
+      display.includes("atrial fibrillation")
+    ) {
+      if (obs.valueString) {
+        const valStr = obs.valueString.toLowerCase();
+        if (valStr.includes("yes") || valStr.includes("true") || valStr.includes("active") || valStr.includes("present")) {
+          heartDisease = true;
+        }
+      } else {
+        heartDisease = true;
+      }
+    }
+
+    // 6. Smoking History
+    if (display.includes("smoking") || display.includes("tobacco")) {
+      const checkText = `${display} ${obs.valueString || ""}`.toLowerCase();
+      if (checkText.includes("never smoked") || checkText.includes("non-smoker") || checkText.includes("never smoker")) {
+        smokingHistory = "never";
+      } else if (checkText.includes("current smoker") || checkText.includes("active smoker") || checkText.includes("smokes daily") || checkText.includes("smokes")) {
+        smokingHistory = "current";
+      } else if (checkText.includes("former smoker") || checkText.includes("ex-smoker") || checkText.includes("quit smoking") || checkText.includes("history of smoking")) {
+        smokingHistory = "former";
+      }
+    }
+  }
+
+  // Scan documents
+  for (const doc of structure.documents) {
+    const textToScan = `${doc.description || ""} ${doc.type || ""} ${doc.attachmentTitle || ""} ${doc.attachmentContent || ""}`.toLowerCase();
+
+    if (textToScan.includes("hypertension") || textToScan.includes("high blood pressure") || textToScan.includes("htn")) {
+      hypertension = true;
+    }
+
+    if (
+      textToScan.includes("heart disease") ||
+      textToScan.includes("coronary artery") ||
+      textToScan.includes("cad") ||
+      textToScan.includes("myocardial infarction") ||
+      textToScan.includes("mi") ||
+      textToScan.includes("heart failure") ||
+      textToScan.includes("atrial fibrillation")
+    ) {
+      heartDisease = true;
+    }
+
+    if (textToScan.includes("never smoked") || textToScan.includes("non-smoker") || textToScan.includes("never smoker")) {
+      if (smokingHistory !== "current") {
+        smokingHistory = "never";
+      }
+    } else if (textToScan.includes("current smoker") || textToScan.includes("active smoker") || textToScan.includes("smokes tobacco") || textToScan.includes("smoking daily")) {
+      smokingHistory = "current";
+    } else if (textToScan.includes("former smoker") || textToScan.includes("ex-smoker") || textToScan.includes("quit smoking") || textToScan.includes("history of smoking")) {
+      if (smokingHistory !== "current") {
+        smokingHistory = "former";
+      }
+    }
+  }
+
+  if (bmi === undefined) {
+    throw new Error("Missing required field: BMI");
+  }
+
+  if (hba1cLevel === undefined) {
+    throw new Error("Missing required field: HbA1c Level");
+  }
+
+  if (bloodGlucoseLevel === undefined) {
+    throw new Error("Missing required field: Blood Glucose Level");
+  }
+
+  const assessment: InsertAssessment = {
+    patientName: structure.patient.name,
+    gender: structure.patient.gender,
+    age,
+    hypertension,
+    heartDisease,
+    smokingHistory,
+    bmi,
+    hba1cLevel,
+    bloodGlucoseLevel,
+  };
+
+  // Zod parsing will validate range values
+  try {
+    return insertAssessmentSchema.parse(assessment);
+  } catch (err: any) {
+    if (err.errors && err.errors.length > 0) {
+      throw new Error(err.errors[0].message);
+    }
+    throw err;
+  }
+}

--- a/tests/fhirIngestion.test.ts
+++ b/tests/fhirIngestion.test.ts
@@ -1,0 +1,416 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+import session from "express-session";
+import { createServer } from "http";
+import { registerRoutes } from "../server/routes";
+import {
+  validateFhirBundle,
+  parseFhirBundle,
+  convertToInternalSchema,
+} from "../server/services/fhirParser";
+
+// 1. Mock MLService directly to isolate routes from Python ML daemon
+const { mockCreateAssessment, mockRunAssessmentInference } = vi.hoisted(() => ({
+  mockCreateAssessment: vi.fn(),
+  mockRunAssessmentInference: vi.fn(),
+}));
+
+vi.mock("../server/services/mlService", () => {
+  return {
+    MLService: {
+      runAssessmentInference: mockRunAssessmentInference,
+      generateRequestFingerprint: vi.fn().mockReturnValue("mock-fingerprint"),
+      activeInferenceRequests: new Set(),
+    },
+  };
+});
+
+// 2. Mock database storage layer
+vi.mock("../server/storage", () => {
+  const mockStorageInstance = {
+    createAssessment: mockCreateAssessment,
+    getUserByEmail: vi.fn().mockResolvedValue({ id: "admin-id" }),
+    getUserById: vi.fn().mockResolvedValue({ id: "test-user-id", email: "test@example.com", isActive: true, role: "provider" }),
+  };
+  return {
+    storage: mockStorageInstance,
+    DatabaseStorage: vi.fn().mockImplementation(() => mockStorageInstance),
+  };
+});
+
+// Helper to create authenticated Express app
+function createAuthenticatedApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    session({
+      secret: "test-secret",
+      resave: false,
+      saveUninitialized: false,
+    })
+  );
+  app.use((req, res, next) => {
+    req.session.user = {
+      id: "test-user-id",
+      email: "test@example.com",
+      name: "Test User",
+      emailVerified: true,
+    };
+    next();
+  });
+  return app;
+}
+
+// Helper to create unauthenticated Express app
+function createUnauthenticatedApp() {
+  const app = express();
+  app.use(express.json());
+  return app;
+}
+
+// Mock ML pipeline daemon output
+const pythonSuccessOutput = JSON.stringify({
+  requestId: "some-uuid",
+  prediction: {
+    riskScore: 12.3,
+    riskCategory: "LOW",
+    factors: [{ name: "Age", impact: "positive", description: "Increases risk" }],
+    clinicianAdvice: ["Monitor annually."],
+    patientAdvice: ["Keep it up!"],
+    confidenceInterval: "8.5% - 16.1%",
+    modelConfidence: 0.877,
+  }
+});
+
+// Sample valid FHIR Bundle
+const validFhirBundle = {
+  resourceType: "Bundle",
+  type: "collection",
+  entry: [
+    {
+      resource: {
+        resourceType: "Patient",
+        id: "pat-123",
+        name: [
+          {
+            use: "official",
+            given: ["John", "Edward"],
+            family: "Smith",
+          },
+        ],
+        gender: "male",
+        birthDate: "1980-01-01",
+      },
+    },
+    {
+      resource: {
+        resourceType: "Observation",
+        code: {
+          coding: [
+            {
+              system: "http://loinc.org",
+              code: "39156-5",
+              display: "Body Mass Index",
+            },
+          ],
+        },
+        valueQuantity: {
+          value: 24.5,
+          unit: "kg/m2",
+        },
+      },
+    },
+    {
+      resource: {
+        resourceType: "Observation",
+        code: {
+          coding: [
+            {
+              system: "http://loinc.org",
+              code: "4548-4",
+              display: "Hemoglobin A1c",
+            },
+          ],
+        },
+        valueQuantity: {
+          value: 5.4,
+          unit: "%",
+        },
+      },
+    },
+    {
+      resource: {
+        resourceType: "Observation",
+        code: {
+          coding: [
+            {
+              system: "http://loinc.org",
+              code: "2339-0",
+              display: "Blood Glucose",
+            },
+          ],
+        },
+        valueQuantity: {
+          value: 95,
+          unit: "mg/dL",
+        },
+      },
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCreateAssessment.mockImplementation((input) =>
+    Promise.resolve({ id: 1, ...input, createdAt: new Date() })
+  );
+  mockRunAssessmentInference.mockResolvedValue({
+    prediction: {
+      riskScore: 12.3,
+      riskCategory: "LOW",
+      factors: [{ name: "Age", impact: "positive", description: "Increases risk" }],
+      clinicianAdvice: ["Monitor annually."],
+      patientAdvice: ["Keep it up!"],
+      confidenceInterval: "8.5% - 16.1%",
+      modelConfidence: 0.877,
+    },
+    isFallback: false,
+  });
+});
+
+describe("FHIR Parser Unit Tests", () => {
+  describe("validateFhirBundle", () => {
+    it("throws for null or empty payload", () => {
+      expect(() => validateFhirBundle(null)).toThrow("Invalid FHIR payload");
+      expect(() => validateFhirBundle({})).toThrow("Invalid FHIR payload");
+    });
+
+    it("throws for unsupported resourceType", () => {
+      expect(() => validateFhirBundle({ resourceType: "Patient" })).toThrow("Unsupported FHIR structure");
+    });
+
+    it("throws for missing entry list", () => {
+      expect(() => validateFhirBundle({ resourceType: "Bundle", type: "collection" })).toThrow("Missing Bundle entries");
+      expect(() => validateFhirBundle({ resourceType: "Bundle", type: "collection", entry: [] })).toThrow("Missing Bundle entries");
+    });
+  });
+
+  describe("parseFhirBundle", () => {
+    it("successfully parses Patient details", () => {
+      const parsed = parseFhirBundle(validFhirBundle);
+      expect(parsed.patient).toBeDefined();
+      expect(parsed.patient?.id).toBe("pat-123");
+      expect(parsed.patient?.name).toBe("John Edward Smith");
+      expect(parsed.patient?.gender).toBe("Male");
+      expect(parsed.patient?.birthDate).toBe("1980-01-01");
+    });
+
+    it("successfully parses Observations", () => {
+      const parsed = parseFhirBundle(validFhirBundle);
+      expect(parsed.observations.length).toBe(3);
+      expect(parsed.observations[0].codeDisplay).toBe("Body Mass Index");
+      expect(parsed.observations[0].valueQuantity?.value).toBe(24.5);
+    });
+
+    it("ignores unsupported resources", () => {
+      const bundleWithMedication = {
+        resourceType: "Bundle",
+        type: "collection",
+        entry: [
+          ...validFhirBundle.entry,
+          {
+            resource: {
+              resourceType: "MedicationRequest",
+              id: "med-1",
+            },
+          },
+        ],
+      };
+      const parsed = parseFhirBundle(bundleWithMedication);
+      expect(parsed.patient?.name).toBe("John Edward Smith");
+      expect(parsed.observations.length).toBe(3);
+    });
+
+    it("successfully parses DocumentReferences with base64 content", () => {
+      const bundleWithDoc = {
+        resourceType: "Bundle",
+        type: "collection",
+        entry: [
+          {
+            resource: {
+              resourceType: "DocumentReference",
+              description: "Clinical summary note",
+              type: {
+                text: "Discharge summary",
+              },
+              content: [
+                {
+                  attachment: {
+                    title: "Summary attachment",
+                    data: Buffer.from("Patient has history of hypertension and former smoker.").toString("base64"),
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      };
+      const parsed = parseFhirBundle(bundleWithDoc);
+      expect(parsed.documents.length).toBe(1);
+      expect(parsed.documents[0].description).toBe("Clinical summary note");
+      expect(parsed.documents[0].attachmentTitle).toBe("Summary attachment");
+      expect(parsed.documents[0].attachmentContent).toContain("hypertension and former smoker");
+    });
+  });
+
+  describe("convertToInternalSchema", () => {
+    it("converts valid FHIR structure to InsertAssessment and validates age", () => {
+      const parsed = parseFhirBundle(validFhirBundle);
+      const assessment = convertToInternalSchema(parsed);
+
+      expect(assessment.patientName).toBe("John Edward Smith");
+      expect(assessment.gender).toBe("Male");
+      expect(assessment.bmi).toBe(24.5);
+      expect(assessment.hba1cLevel).toBe(5.4);
+      expect(assessment.bloodGlucoseLevel).toBe(95);
+      expect(assessment.hypertension).toBe(false);
+      expect(assessment.heartDisease).toBe(false);
+      expect(assessment.smokingHistory).toBe("No Info");
+    });
+
+    it("computes hypertension and heart disease flags from document content keywords", () => {
+      const parsed = parseFhirBundle(validFhirBundle);
+      parsed.documents.push({
+        attachmentContent: "Patient diagnosed with hypertension and congestive heart failure. Also a former smoker.",
+      });
+
+      const assessment = convertToInternalSchema(parsed);
+      expect(assessment.hypertension).toBe(true);
+      expect(assessment.heartDisease).toBe(true);
+      expect(assessment.smokingHistory).toBe("former");
+    });
+
+    it("computes hypertension flags from blood pressure observation component vitals", () => {
+      const parsed = parseFhirBundle(validFhirBundle);
+      parsed.observations.push({
+        codeDisplay: "Blood Pressure Vitals",
+        code: "85354-9",
+        component: [
+          {
+            code: { coding: [{ code: "8480-6", display: "Systolic Blood Pressure" }] },
+            valueQuantity: { value: 145 },
+          },
+          {
+            code: { coding: [{ code: "8462-4", display: "Diastolic Blood Pressure" }] },
+            valueQuantity: { value: 85 },
+          },
+        ],
+      });
+
+      const assessment = convertToInternalSchema(parsed);
+      expect(assessment.hypertension).toBe(true);
+    });
+
+    it("throws detailed validation errors for missing patient name", () => {
+      const parsed = parseFhirBundle(validFhirBundle);
+      if (parsed.patient) parsed.patient.name = "";
+      expect(() => convertToInternalSchema(parsed)).toThrow("Missing required field: Patient Name");
+    });
+
+    it("throws detailed validation errors for missing BMI", () => {
+      const parsed = parseFhirBundle(validFhirBundle);
+      parsed.observations = parsed.observations.filter(o => !o.codeDisplay?.includes("Index"));
+      expect(() => convertToInternalSchema(parsed)).toThrow("Missing required field: BMI");
+    });
+  });
+});
+
+describe("FHIR Ingestion Router Integration Tests", () => {
+  it("returns 401 for unauthenticated request", async () => {
+    const app = createUnauthenticatedApp();
+    await registerRoutes(createServer(), app);
+
+    const res = await request(app)
+      .post("/api/ingest/fhir")
+      .send(validFhirBundle);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when submitting invalid JSON structure", async () => {
+    const app = createAuthenticatedApp();
+    await registerRoutes(createServer(), app);
+
+    const res = await request(app)
+      .post("/api/ingest/fhir")
+      .send({ invalid: "payload" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.status).toBe("error");
+    expect(res.body.message).toBe("Invalid FHIR payload");
+  });
+
+  it("returns 400 when required clinical data is missing", async () => {
+    const app = createAuthenticatedApp();
+    await registerRoutes(createServer(), app);
+
+    const incompleteBundle = {
+      resourceType: "Bundle",
+      type: "collection",
+      entry: [
+        {
+          resource: {
+            resourceType: "Patient",
+            name: [{ given: ["Bob"], family: "Johnson" }],
+            gender: "male",
+            birthDate: "1995-10-10",
+          },
+        },
+      ],
+    };
+
+    const res = await request(app)
+      .post("/api/ingest/fhir")
+      .send(incompleteBundle);
+
+    expect(res.status).toBe(400);
+    expect(res.body.status).toBe("error");
+    expect(res.body.message).toContain("Missing required field");
+  });
+
+  it("returns 200 and synchronous insights on successful ingestion", async () => {
+    const app = createAuthenticatedApp();
+    await registerRoutes(createServer(), app);
+
+    const res = await request(app)
+      .post("/api/ingest/fhir")
+      .send(validFhirBundle);
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("success");
+    expect(res.body.patient_id).toBe("pat-123");
+    expect(res.body.observations_processed).toBe(3);
+    expect(res.body.documents_processed).toBe(0);
+
+    const riskInsight = res.body.insights.find((i: any) => i.type === "risk");
+    expect(riskInsight).toBeDefined();
+    expect(riskInsight.category).toBe("LOW");
+    expect(riskInsight.score).toBe(12.3);
+  });
+
+  it("returns 500 when processing throws an error in the pipeline", async () => {
+    const app = createAuthenticatedApp();
+    await registerRoutes(createServer(), app);
+
+    mockCreateAssessment.mockRejectedValueOnce(new Error("Database write failure"));
+
+    const res = await request(app)
+      .post("/api/ingest/fhir")
+      .send(validFhirBundle);
+
+    expect(res.status).toBe(500);
+    expect(res.body.status).toBe("error");
+    expect(res.body.message).toContain("Database write failure");
+  });
+});


### PR DESCRIPTION
Closes #1264

## Summary
- Added FHIR R4 bundle validation and parsing
- Added support for Patient, Observation, and DocumentReference resources
- Added POST /api/ingest/fhir
- Integrated parsed data into the existing clinical processing pipeline
- Added unit and integration tests
- Added README documentation and examples

Additional extraction logic was added to map common FHIR observations into the project's existing risk assessment schema.

## Testing
- npm run check
- npm run test
- FHIR ingestion tests
- Coverage verification (>80% for new files)