### PR TITLE
refactor(ui): migrate hardcoded inline styles to Tailwind CSS utilities

### DIFF
--- a/client/src/components/AssessmentResult.tsx
+++ b/client/src/components/AssessmentResult.tsx
@@ -634,8 +634,8 @@ function ExplainabilityPanel({
                 </div>
                 <div className="h-2.5 rounded-full bg-muted overflow-hidden">
                   <div
-                    className={`h-full rounded-full ${increasesRisk ? "bg-red-500" : "bg-green-500"}`}
-                    style={{ width: `${factor.strength}%` }}
+                    className={`h-full rounded-full w-[var(--factor-strength)] ${increasesRisk ? "bg-red-500" : "bg-green-500"}`}
+                    style={{ '--factor-strength': `${factor.strength}%` } as React.CSSProperties}
                   />
                 </div>
               </div>

--- a/client/src/components/CardioGuardLanding.tsx
+++ b/client/src/components/CardioGuardLanding.tsx
@@ -145,8 +145,8 @@ function DashboardPreview() {
                 {[46, 58, 52, 64, 48, 42].map((height, index) => (
                   <div key={height + index} className="flex flex-1 flex-col items-center gap-2">
                     <div
-                      className="w-full rounded-t-xl bg-gradient-to-t from-[#2563EB] to-cyan-300"
-                      style={{ height: `${height}%` }}
+                      className="w-full rounded-t-xl bg-gradient-to-t from-[#2563EB] to-cyan-300 h-[var(--height)]"
+                      style={{ '--height': `${height}%` } as React.CSSProperties}
                     />
                     <span className="text-[10px] font-semibold text-slate-500">M{index + 1}</span>
                   </div>

--- a/client/src/components/RiskTrendChart.tsx
+++ b/client/src/components/RiskTrendChart.tsx
@@ -114,12 +114,12 @@ export default function RiskTrendChart({ assessments, patientGroups }: Props) {
               onClick={() => toggleMetric(key)}
               className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold border transition-all ${
                 activeMetrics[key]
-                  ? "text-white border-transparent"
+                  ? "text-white bg-[var(--chart-color)] border-[var(--chart-color)]"
                   : "bg-transparent text-muted-foreground border-border hover:border-foreground/30"
               }`}
-              style={activeMetrics[key] ? { backgroundColor: color, borderColor: color } : {}}
+              style={{ '--chart-color': color } as React.CSSProperties}
             >
-              <span className="w-2 h-2 rounded-full" style={{ backgroundColor: color }} />
+              <span className="w-2 h-2 rounded-full bg-[var(--chart-color)]" />
               {label}
             </button>
           ))}

--- a/client/src/components/ui/ConfidenceRange.tsx
+++ b/client/src/components/ui/ConfidenceRange.tsx
@@ -28,8 +28,8 @@ export default function ConfidenceRange({
     <div className="flex items-center gap-2" title={`${clampedLow.toFixed(1)}% — ${clampedHigh.toFixed(1)}%`} aria-label={`Confidence interval: ${clampedLow.toFixed(1)}% to ${clampedHigh.toFixed(1)}%`}>
       <div style={{ width }} className="relative h-3 rounded-full bg-slate-100">
         <div
-          style={{ left, width: rangeWidth, backgroundColor: "#c7e4ff" }}
-          className="absolute h-3 rounded-full"
+          style={{ left, width: rangeWidth }}
+          className="absolute h-3 rounded-full bg-blue-200 dark:bg-blue-900/40"
         />
         {markerLeft != null && (
           <div

--- a/client/src/components/ui/StatusPill.tsx
+++ b/client/src/components/ui/StatusPill.tsx
@@ -11,14 +11,14 @@ export default function StatusPill({
   label?: string;
   highlightedLabel?: React.ReactNode;
 }) {
-  const mapping: Record<Variant, { bg: string; text: string }> = {
-    low: { bg: "#E6F4EA", text: "#065f46" }, // soft green bg, dark green text
-    moderate: { bg: "#FEF7E0", text: "#92400e" }, // soft amber bg, dark amber text
-    high: { bg: "#FCE8E6", text: "#7f1d1d" }, // soft red bg, dark red text
-    default: { bg: "#F3F4F6", text: "#374151" },
+  const mapping: Record<Variant, string> = {
+    low: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+    moderate: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
+    high: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+    default: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
   };
 
-  const { bg, text } = mapping[variant] ?? mapping.default;
+  const colorClasses = mapping[variant] ?? mapping.default;
   const display = label ?? variant.toUpperCase();
 
   return (
@@ -26,8 +26,7 @@ export default function StatusPill({
       role="status"
       aria-label={`Risk: ${display}`}
       title={`Risk: ${display}`}
-      style={{ backgroundColor: bg, color: text }}
-      className="px-3 py-1 rounded-full text-xs font-bold tracking-wide"
+      className={`px-3 py-1 rounded-full text-xs font-bold tracking-wide ${colorClasses}`}
     >
       {highlightedLabel ?? display}
     </span>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -675,12 +675,11 @@ export default function Dashboard() {
                               cx="50"
                               cy="50"
                               r="42"
-                              className="stroke-blue-500/20 dark:stroke-blue-500/10 fill-none"
+                              className="stroke-blue-500/20 dark:stroke-blue-500/10 fill-none animate-[dash_3s_ease-in-out_infinite]"
                               strokeWidth="8"
                               strokeDasharray="264"
                               strokeDashoffset="180"
                               strokeLinecap="round"
-                              style={{ animation: 'dash 3s ease-in-out infinite' }}
                             />
                           </svg>
                           
@@ -707,8 +706,8 @@ export default function Dashboard() {
                               </div>
                               <div className="h-2 w-full bg-slate-200/50 dark:bg-slate-800/50 rounded-full overflow-hidden">
                                 <div 
-                                  className="h-full bg-slate-300 dark:bg-slate-700/60 rounded-full animate-pulse" 
-                                  style={{ width: `${width}%` }} 
+                                  className="h-full bg-slate-300 dark:bg-slate-700/60 rounded-full animate-pulse w-[var(--width)]" 
+                                  style={{ '--width': `${width}%` } as React.CSSProperties} 
                                 />
                               </div>
                             </div>


### PR DESCRIPTION
This PR fundamentally resolves the dark mode and responsive rendering bugs caused by inline styles bypassing the Tailwind engine. In StatusPill.tsx and ConfidenceRange.tsx, raw hex colors mapping has been fully replaced with strict Tailwind semantic tokens (e.g., bg-green-100 dark:bg-green-900/30). Furthermore, for components requiring runtime calculations like AssessmentResult.tsx, RiskTrendChart.tsx, and Dashboard.tsx (where progress bars rely on dynamic percentages), the styling logic has been refactored to securely pipe dynamic data into inline CSS variables (--chart-color). This allows Tailwind's utility classes to consume those variables securely (e.g., bg-[var(--chart-color)]), fully restoring the responsive design system without causing merge conflicts across other feature branches.

Closes #1339  