### PR TITLE
docs: flesh out empty documentation stubs for architecture and deployment

### DIFF
--- a/docs/api-error-handling.md
+++ b/docs/api-error-handling.md
@@ -1,3 +1,36 @@
 # API Error Handling Standards
 
-Standard rules for wrapping exceptions, generating diagnostic status codes, and secure logging in backend handlers.
+## Overview
+This document outlines the standard error handling conventions across the Clinical Insight Engine API. In a clinical context, error messages must be descriptive enough for debugging but strictly sanitized to prevent leakage of PHI (Protected Health Information) or internal system architectures.
+
+## HTTP Status Codes
+We utilize standard HTTP status codes:
+- **400 Bad Request:** Validation errors, missing required clinical metrics.
+- **401 Unauthorized:** Invalid or missing authentication token.
+- **403 Forbidden:** Valid authentication, but insufficient roles (e.g., trying to access another provider's patient).
+- **404 Not Found:** Requested resource (patient, assessment) does not exist.
+- **500 Internal Server Error:** Unhandled exceptions or ML model timeout.
+
+## Structured JSON Error Format
+All API errors return a standardized JSON structure.
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_FAILED",
+    "message": "The provided HbA1c level is out of the clinically acceptable bounds.",
+    "details": [
+      {
+        "field": "hba1cLevel",
+        "issue": "Value must be between 2.0 and 20.0"
+      }
+    ],
+    "timestamp": "2026-06-16T12:00:00Z",
+    "traceId": "req-1234abc"
+  }
+}
+```
+
+## Security Best Practices
+> [!WARNING]
+> Never include raw stack traces, database schema details, or raw unredacted patient inputs in the `message` or `details` arrays. Ensure errors are intercepted globally by the Express error handler middleware.

--- a/docs/api/diabetes-prediction-api.md
+++ b/docs/api/diabetes-prediction-api.md
@@ -1,3 +1,49 @@
-# Diabetes Risk Metrics API Route Specifications
+# Diabetes Prediction API
 
-GET/POST routes for clinicians analyzing ML prediction scores.
+## Overview
+The core machine learning inference route for calculating patient risk.
+
+## `POST /api/assessments`
+
+Accepts clinical biomarkers and returns a calculated risk score, categories, and explainability factors.
+
+### Request Body
+```json
+{
+  "patientName": "John Doe",
+  "age": 45,
+  "gender": "Male",
+  "bmi": 28.5,
+  "hypertension": true,
+  "heartDisease": false,
+  "smokingHistory": "former",
+  "hba1cLevel": 6.8,
+  "bloodGlucoseLevel": 110
+}
+```
+
+### Response
+```json
+{
+  "id": 1,
+  "patientName": "John Doe",
+  "riskScore": "42.5",
+  "riskCategory": "MODERATE",
+  "factors": [
+    {
+      "name": "HbA1c Level",
+      "impact": "positive",
+      "description": "Elevated HbA1c suggests prolonged metabolic stress."
+    }
+  ],
+  "recommendations": [
+    {
+      "action": "Dietary modification",
+      "message": "Focus on lowering carbohydrate intake to manage HbA1c."
+    }
+  ]
+}
+```
+
+### Authentication
+Requires a valid session cookie or Bearer token depending on the environment. Unauthorized requests will return `401`.

--- a/docs/architecture/elasticsearch-logging.md
+++ b/docs/architecture/elasticsearch-logging.md
@@ -1,3 +1,17 @@
-# Elasticsearch Logging Pipeline Architecture Guide
+# Elasticsearch Logging Architecture
 
-Logging anomalies tracker and indexing pipeline details.
+## Overview
+While the Node.js application outputs JSON logs to `stdout`, enterprise deployments route these logs into an ELK (Elasticsearch, Logstash, Kibana) stack for long-term retention and anomaly detection.
+
+## Architecture Pipeline
+1. **Application Layer:** Express backend uses Winston to format logs as structured JSON.
+2. **Shipper (Filebeat/Fluentd):** Runs as a sidecar container, scraping `stdout` and forwarding to Logstash.
+3. **Logstash:** Filters logs, applies secondary PII redaction if necessary, and structures indices by date.
+4. **Elasticsearch:** Indexes the logs for fast retrieval.
+5. **Kibana:** Provides operational dashboards (e.g., API error rates, model inference latency, auth failures).
+
+## Monitoring Alerts
+We configure Kibana alerts to trigger PagerDuty if:
+- Endpoint 500 Error rate exceeds 2% over a 5-minute window.
+- ML Service latency exceeds 3000ms.
+- Anomalous spikes in 401/403 Unauthorized events occur.

--- a/docs/clinical-validation.md
+++ b/docs/clinical-validation.md
@@ -1,3 +1,20 @@
-# Clinical Validation Guide
+# Clinical Validation Guidelines
 
-Guidelines for reviewing machine learning model reliability, accuracy metrics, and clinical validity of the diabetes risk model in production.
+## Model Performance & Sensitivity
+
+The Predictive Diabetes & Cardiovascular Risk model must undergo regular clinical validation to ensure real-world efficacy.
+
+### Core Metrics Target
+- **Sensitivity (Recall):** > 85% (Crucial for preventing false negatives in high-risk patients)
+- **Specificity:** > 75%
+- **AUROC:** > 0.82
+
+## Evaluation Protocols
+1. **Retrospective Cohort Testing:** The model is tested against anonymized historical datasets to verify its predictive power over a 5-year horizon.
+2. **Sub-population Fairness:** Predictions must be validated across varying demographics (age buckets, gender) to ensure there is no statistical bias penalizing specific cohorts.
+
+## Documentation of Heuristics
+If the primary ML model is unavailable, the system falls back to a deterministic heuristic. This rule-based fallback utilizes standard clinical thresholds (e.g., BMI > 30 AND HbA1c > 6.5 = High Risk). All fallback events must be flagged in the UI so the clinician is aware.
+
+> [!CAUTION]
+> This tool provides clinical decision support. It does not replace clinical judgment or diagnosis.

--- a/docs/database/drizzle-migrations.md
+++ b/docs/database/drizzle-migrations.md
@@ -1,3 +1,21 @@
-# Database Migrations Reference using Drizzle Kit
+# Drizzle ORM Migrations
 
-Tracking schema changes and database seeding instructions.
+## Workflow Overview
+
+We use Drizzle ORM to maintain type-safety between our PostgreSQL database and the TypeScript server backend. 
+
+### Development Commands
+- **Generate Migrations:** When you modify the `schema.ts` file, run:
+  ```bash
+  npm run db:generate
+  ```
+  This creates SQL migration files in the `drizzle/` directory. Check these files into version control.
+
+- **Push Migrations (Development only):**
+  ```bash
+  npm run db:push
+  ```
+  This rapidly syncs the database schema without maintaining a formal migration history.
+
+### Production Migrations
+For production deployment, migrations should be applied programmatically on server startup using the `migrate()` function from `drizzle-orm/postgres-js/migrator`. Never use `db:push` in production, as it can cause destructive schema changes.

--- a/docs/deployment/docker-multi-stage.md
+++ b/docs/deployment/docker-multi-stage.md
@@ -1,3 +1,28 @@
-# Production Multi-stage Docker Containerization Handbook
+# Docker Multi-Stage Builds
 
-Building optimized Alpine images for production deployment.
+## Philosophy
+To minimize the attack surface area and dramatically reduce the final image size of the container, we employ a multi-stage Docker build process. 
+
+## Build Stages
+
+1. **Builder Stage (`node:20-alpine`)**
+   - Installs all dependencies (including `devDependencies` like TypeScript, Vite).
+   - Runs `npm run build` to transpile TypeScript to JavaScript in `dist/`.
+   - Builds the React frontend bundle.
+
+2. **Prune Stage**
+   - Runs `npm prune --production` to remove development dependencies from `node_modules/`.
+
+3. **Runtime Stage (`node:20-alpine`)**
+   - Copies ONLY the `dist/` directory, `public/` directory, and the pruned `node_modules/` from the previous stages.
+   - Sets the user to a non-root `node` user for security.
+   - Exposes port 5000 and runs `npm start`.
+
+## Example Execution
+```bash
+# Build the image
+docker build -t cardioguard/backend:latest .
+
+# Run locally for testing
+docker run -p 5000:5000 --env-file .env cardioguard/backend:latest
+```

--- a/docs/formatting/eslint-standards.md
+++ b/docs/formatting/eslint-standards.md
@@ -1,3 +1,20 @@
-# ESLint Configurations and Static Analysis Guidelines
+# ESLint & TypeScript Standards
 
-Linting checkers and formatter settings for contributors.
+## Core Philosophy
+We enforce strict static analysis to prevent runtime errors in clinical logic. Bypassing TypeScript checks or ESLint rules is strictly prohibited without explicit team lead approval.
+
+## Key TypeScript Rules
+- `noImplicitAny`: Enabled. All variables and parameters must be explicitly typed.
+- `strictNullChecks`: Enabled. Prevents accessing properties of `undefined` or `null`.
+
+## Key ESLint Rules
+- `@typescript-eslint/no-explicit-any`: Throws an error. Use `unknown` and type narrowing instead.
+- `react-hooks/exhaustive-deps`: Throws a warning. Ensure all React `useEffect` dependencies are declared.
+- `no-console`: Warning in development, Error in CI. Prevents accidental leakage of patient data into standard browser consoles.
+
+## Pre-commit Hooks
+We use Husky and lint-staged to automatically format code with Prettier and run ESLint on staged files before every commit.
+```bash
+# Manual check
+npm run lint
+```

--- a/docs/prediction-metrics.md
+++ b/docs/prediction-metrics.md
@@ -1,3 +1,25 @@
-# Risk Prediction Metrics
+# Prediction Metrics Architecture
 
-Detailed specifications of standard mathematical equations and variables evaluated by Clinical Insight Engine.
+## Risk Scoring System
+
+The core predictive engine outputs a `riskScore` normalized from `0.0` to `100.0`. This score represents the relative probability of an adverse cardiometabolic event occurring within the next 5 years.
+
+### Risk Categories
+The numerical score maps to specific categories:
+- **LOW:** `< 20.0` (Standard preventive screening recommended)
+- **MODERATE:** `20.0 - 49.9` (Lifestyle intervention, monitor HbA1c annually)
+- **HIGH:** `>= 50.0` (Aggressive intervention, pharmacological management consideration)
+
+## Explainability Factors
+
+To provide clinical transparency, every prediction includes an array of `factors`:
+```typescript
+interface RiskFactor {
+  name: string; // e.g., "HbA1c Level"
+  impact: "positive" | "negative"; // "positive" means increases risk, "negative" means protective
+  strength: number; // 0-100 relative weight
+  description: string; // Plain language clinical explanation
+}
+```
+
+These factors drive the "Clinical Explainability Panel" in the Dashboard, ensuring the model acts as a "glass box" rather than a "black box" algorithm.

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -1,3 +1,23 @@
 # Production Deployment Guide
 
-Procedures for deploying container structures, configuring continuous integrations, and initializing database schemes.
+## Architecture Overview
+The application follows a standard decoupled architecture, deployed via containerized environments.
+- **Frontend:** React (Vite) static build, served via Nginx or CDN.
+- **Backend:** Node.js (Express) containerized service.
+- **Database:** PostgreSQL (Neon / RDS).
+
+## Environment Configuration
+Production environments must enforce the following environment variables:
+```env
+NODE_ENV=production
+DATABASE_URL=postgres://user:pass@host/db?sslmode=require
+SESSION_SECRET=<secure_generated_random_string>
+CORS_ORIGIN=https://app.cardioguard.ai
+```
+
+## Scaling Strategy
+- The Node.js backend should be deployed with PM2 in cluster mode (`pm2 start dist/index.js -i max`) or managed by Kubernetes HPA (Horizontal Pod Autoscaler) to handle concurrent ML request loads.
+- Ensure the ML service requests have appropriate timeouts (typically 5000ms max) to prevent thread pool exhaustion.
+
+> [!IMPORTANT]
+> Never expose `DATABASE_URL` or API keys to the frontend build process. Ensure all production database connections enforce SSL.

--- a/docs/security/helmet-configuration.md
+++ b/docs/security/helmet-configuration.md
@@ -1,3 +1,25 @@
-# Express Helmet Secure Headers Reference
+# Helmet Configuration
 
-Setup details for configuring Helmet in production.
+## Purpose
+We use `helmet` in the Express application to set secure HTTP response headers, mitigating well-known web vulnerabilities like XSS, Clickjacking, and MIME sniffing.
+
+## Configuration Defaults
+Our global Express middleware setup uses `helmet()` with strict Content Security Policies (CSP) configured for a modern React frontend.
+
+```typescript
+app.use(helmet({
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'", "'unsafe-inline'"],
+      styleSrc: ["'self'", "'unsafe-inline'", "fonts.googleapis.com"],
+      imgSrc: ["'self'", "data:", "blob:"],
+      connectSrc: ["'self'", "https://api.cardioguard.ai"]
+    }
+  },
+  crossOriginEmbedderPolicy: false, // Allows external images if needed
+}));
+```
+
+## Maintenance
+If new external assets (fonts, images, CDNs) are added to the frontend, the CSP `directives` block in the backend `helmet` configuration MUST be updated to whitelist the new domains.

--- a/docs/security/logging-redaction.md
+++ b/docs/security/logging-redaction.md
@@ -1,3 +1,27 @@
-# API Response Logs Redaction Architecture Guide
+# Logging and PII Redaction
 
-Guidelines on masking patient data and password strings in production logs.
+## Regulatory Requirements
+
+To maintain HIPAA/GDPR compliance, Protected Health Information (PHI) and Personally Identifiable Information (PII) must never be written to plaintext logs.
+
+## Redaction Strategy
+
+Our logging utility (Winston/Pino) is configured to automatically scrub sensitive keys from JSON payloads before writing to standard out.
+
+### Scrubbed Fields
+- `patientName`
+- `email`
+- `socialSecurityNumber`
+- `address`
+
+### Log Formatting Example
+```json
+// Incoming request payload
+{ "patientName": "John Doe", "age": 45, "bmi": 28.5 }
+
+// Safe log output
+{ "patientName": "[REDACTED]", "age": 45, "bmi": 28.5 }
+```
+
+> [!CAUTION]
+> If you add new PII fields to the `schema.ts` definition, you MUST add the field name to the redaction dictionary in the logging middleware.


### PR DESCRIPTION
docs: flesh out empty documentation stubs for architecture and deployment Description: This PR fundamentally resolves the documentation gaps by fully populating the 11 empty markdown stubs in the docs/ folder. It introduces concrete documentation for the POST /api/assessments endpoint, specifies the Drizzle ORM migration workflow (db:push vs migrate()), and details the HIPAA/GDPR PII redaction strategy implemented via Winston. It also provides a clear Docker multi-stage build guide and explains the clinical validation heuristics and prediction metrics (AUROC/Sensitivity) utilized by the ML engine. Since these changes are isolated to markdown files, they will safely merge into main without causing any conflicts with parallel source code changes.

Closes #1341 