### PR TITLE
perf(logging): log JWT_SECRET security warning only once to avoid 

### DIFF
--- a/server/services/auth/tokenValidator.ts
+++ b/server/services/auth/tokenValidator.ts
@@ -52,6 +52,8 @@ export type VerifyFailure = {
 
 export type VerifyResult = VerifySuccess | VerifyFailure;
 
+let warnedJwtSecretMissing = false;
+
 /**
  * Returns the JWT signing secret from the environment.
  * Throws at startup if the secret is missing or too short in production.
@@ -64,10 +66,13 @@ export function getJwtSecret(): string {
       throw new Error("JWT_SECRET environment variable is required in production.");
     }
     // Development fallback — weak and obvious so it is never mistaken for production
-    logger.warn(
-      "[SECURITY WARNING] JWT_SECRET is not set. Using insecure development default. " +
-      "Set JWT_SECRET in your .env file before deploying."
-    );
+    if (!warnedJwtSecretMissing) {
+      logger.warn(
+        "[SECURITY WARNING] JWT_SECRET is not set. Using insecure development default. " +
+        "Set JWT_SECRET in your .env file before deploying."
+      );
+      warnedJwtSecretMissing = true;
+    }
     return "clinical-insight-engine-insecure-dev-jwt-secret-change-me";
   }
 


### PR DESCRIPTION
Fixes #1385 

Branch Checkout: Checked out a new branch fix/issue-1385 based on upstream/main.
Warning Log Rate-limiting: Modified 
tokenValidator.ts
 to declare a module-level warnedJwtSecretMissing flag, wrapping the security warning print logic inside 
getJwtSecret
. Now, the console log only prints once instead of flooding stdout logs on every authenticated request.
Validation: Ran the 177 backend unit/integration tests with a custom Vitest configuration and verified that they all pass successfully and log flooding is prevented.