### PR TITLE
bug(ml): allow custom gender strings in validate_assessment_input 

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -538,7 +538,7 @@ def validate_assessment_input(data):
         raise ValueError("Invalid age")
 
     gender = data.get("gender")
-    if gender not in ("Male", "Female"):
+    if not isinstance(gender, str) or not gender:
         raise ValueError("Invalid gender")
 
     bmi = data.get("bmi")

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -413,11 +413,12 @@ def test_validate_assessment_input_rejects_invalid_age():
 def test_validate_assessment_input_rejects_invalid_gender():
     from analyze import validate_assessment_input
 
+    # Rejects non-string gender
     with pytest.raises(ValueError):
         validate_assessment_input(
             {
                 "age": 40,
-                "gender": "Robot",
+                "gender": 123,
                 "hypertension": False,
                 "heartDisease": False,
                 "bmi": 25,
@@ -426,3 +427,41 @@ def test_validate_assessment_input_rejects_invalid_gender():
                 "smokingHistory": "never",
             }
         )
+
+    # Rejects empty gender
+    with pytest.raises(ValueError):
+        validate_assessment_input(
+            {
+                "age": 40,
+                "gender": "",
+                "hypertension": False,
+                "heartDisease": False,
+                "bmi": 25,
+                "hba1cLevel": 5.5,
+                "bloodGlucoseLevel": 100,
+                "smokingHistory": "never",
+            }
+        )
+
+
+def test_validate_assessment_input_allows_other_genders_and_warns():
+    from analyze import validate_assessment_input, interpret_predictions_batch, get_model
+
+    # Validates successfully for custom gender
+    input_data = {
+        "age": 40,
+        "gender": "Other",
+        "hypertension": False,
+        "heartDisease": False,
+        "bmi": 25,
+        "hba1cLevel": 5.5,
+        "bloodGlucoseLevel": 100,
+        "smokingHistory": "never",
+    }
+    assert validate_assessment_input(input_data) == input_data
+
+    # Check that interpret_predictions_batch returns warning for custom gender
+    model, scaler, features, cov_beta = get_model()
+    results = interpret_predictions_batch(model, scaler, features, [input_data], cov_beta)
+    assert "warning" in results[0]
+    assert "Gender value 'Other' was not present in the model's training data" in results[0]["warning"]


### PR DESCRIPTION
Fixes #1386 

Branch Checkout: Checked out a new branch fix/issue-1386 based on upstream/main.
Logic Fix: Modified  
validate_assessment_input
 in 
analyze.py
 to check if gender is a non-empty string rather than strictly rejecting any value other than "Male" or "Female". This enables the out-of-distribution demographic warning logic to run instead of crashing early.
Test Update: Updated 
test_analyze.py
 by modifying the invalid gender test to assert on empty/non-string values and adding test_validate_assessment_input_allows_other_genders_and_warns to verify that custom/unrecognized gender inputs correctly generate the caution warning.
Validation: Ran both Python unit tests (all 39 tests passed) and Node.js backend tests (all 177 tests passed) to ensure zero regressions.