### PR TITLE
fix(#1320): add authorization check on patient name in trends endpoints

### DIFF
--- a/server/repositories/assessment.repository.ts
+++ b/server/repositories/assessment.repository.ts
@@ -359,34 +359,22 @@ export class AssessmentRepository {
     return rows.map((r) => r.patientName).filter(Boolean) as string[];
   }
 
-  async getPatientTrends(patientName: string): Promise<{ date: string; riskScore: number; riskCategory: string }[]> {
-    const db = getDb();
-    const rows = await db
-      .select({
-        date: assessments.createdAt,
-        riskScore: assessments.riskScore,
-        riskCategory: assessments.riskCategory,
-      })
-      .from(assessments)
-      .where(eq(assessments.patientName, patientName))
-      .orderBy(asc(assessments.createdAt));
-    return rows.map((r) => ({
-      date: r.date?.toISOString() ?? "",
-      riskScore: r.riskScore,
-      riskCategory: r.riskCategory,
-    }));
-  }
-
   async getAssessmentsByPatientName(
     patientName: string,
     limit: number = 100,
     offset: number = 0,
+    createdBy?: string,
     startDate?: string,
     endDate?: string
   ): Promise<{ data: Assessment[]; total: number }> {
     const db = getDb();
     const filters: any[] = [eq(assessments.patientName, patientName)];
-    if (startDate && !isNaN(Date.parse(startDate))) filters.push(gte(assessments.createdAt, new Date(startDate)));
+    if (createdBy) {
+      filters.push(eq(assessments.createdBy, createdBy));
+    }
+    if (startDate && !isNaN(Date.parse(startDate))) {
+      filters.push(gte(assessments.createdAt, new Date(startDate)));
+    }
     if (endDate && !isNaN(Date.parse(endDate))) {
       const end = new Date(endDate);
       end.setHours(23, 59, 59, 999);
@@ -406,6 +394,28 @@ export class AssessmentRepository {
       .limit(limit)
       .offset(offset);
     return { data, total };
+  }
+
+  async getPatientTrends(patientName: string, createdBy?: string): Promise<{ date: string; riskScore: number; riskCategory: string }[]> {
+    const db = getDb();
+    const conditions: ReturnType<typeof eq>[] = [eq(assessments.patientName, patientName)];
+    if (createdBy) {
+      conditions.push(eq(assessments.createdBy, createdBy));
+    }
+    const rows = await db
+      .select({
+        date: assessments.createdAt,
+        riskScore: assessments.riskScore,
+        riskCategory: assessments.riskCategory,
+      })
+      .from(assessments)
+      .where(and(...conditions))
+      .orderBy(asc(assessments.createdAt));
+    return rows.map((r) => ({
+      date: r.date?.toISOString() ?? "",
+      riskScore: r.riskScore,
+      riskCategory: r.riskCategory,
+    }));
   }
 
   async getTrendsDashboardData(patientName: string, startDate?: string, endDate?: string) {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -488,7 +488,7 @@ export async function registerRoutes(
       try {
         const patientName = Array.isArray(req.params.patientName) ? req.params.patientName[0] : req.params.patientName;
         const userEmail = req.session.user?.email;
-        const result = await storage.getAssessmentsByPatientName(patientName, 100, 0);
+        const result = await storage.getAssessmentsByPatientName(patientName, 100, 0, userEmail);
         return res.json(result);
       } catch (err) {
         logger.error({ err }, "Patient trends fetch error:");

--- a/server/routes/assessments.routes.ts
+++ b/server/routes/assessments.routes.ts
@@ -341,9 +341,10 @@ assessmentsRouter.get(
   async (req, res) => {
     try {
       const patientName = Array.isArray(req.params.patientName) ? req.params.patientName[0] : req.params.patientName;
+      const userEmail = req.session.user?.email;
       const startDate = typeof req.query.startDate === "string" ? req.query.startDate : undefined;
       const endDate = typeof req.query.endDate === "string" ? req.query.endDate : undefined;
-      const result = await storage.getAssessmentsByPatientName(patientName, 100, 0, startDate, endDate);
+      const result = await storage.getAssessmentsByPatientName(patientName, 100, 0, userEmail, startDate, endDate);
       return res.json(result);
     } catch (err) {
       logger.error({ err }, "Patient trends fetch error:");

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -91,8 +91,8 @@ export interface IStorage {
   getPatientUserByPatientName(patientName: string): Promise<PatientUser | undefined>;
   getPatientUserById(id: string): Promise<PatientUser | undefined>;
   createPatientUser(data: InsertPatientUser): Promise<PatientUser>;
-  getAssessmentsByPatientName(patientName: string, limit?: number, offset?: number, startDate?: string, endDate?: string): Promise<{ data: Assessment[]; total: number }>;
-  getPatientTrends(patientName: string): Promise<{ date: string; riskScore: number; riskCategory: string }[]>;
+  getAssessmentsByPatientName(patientName: string, limit?: number, offset?: number, createdBy?: string, startDate?: string, endDate?: string): Promise<{ data: Assessment[]; total: number }>;
+  getPatientTrends(patientName: string, createdBy?: string): Promise<{ date: string; riskScore: number; riskCategory: string }[]>;
   getTrendsDashboardData(patientName: string, startDate?: string, endDate?: string): Promise<{
     assessments: any[];
     summary: { total: number; latestRiskScore: number | null; latestRiskCategory: string | null; earliestRiskScore: number | null; trend: string; avgRiskScore: number; change: number };
@@ -274,12 +274,12 @@ export class DatabaseStorage implements IStorage {
     return this.patientUserRepository.create(data);
   }
 
-  async getAssessmentsByPatientName(patientName: string, limit?: number, offset?: number, startDate?: string, endDate?: string) {
-    return this.assessmentRepository.getAssessmentsByPatientName(patientName, limit, offset, startDate, endDate);
+  async getAssessmentsByPatientName(patientName: string, limit?: number, offset?: number, createdBy?: string, startDate?: string, endDate?: string) {
+    return this.assessmentRepository.getAssessmentsByPatientName(patientName, limit, offset, createdBy, startDate, endDate);
   }
 
-  async getPatientTrends(patientName: string) {
-    return this.assessmentRepository.getPatientTrends(patientName);
+  async getPatientTrends(patientName: string, createdBy?: string) {
+    return this.assessmentRepository.getPatientTrends(patientName, createdBy);
   }
 
   async getTrendsDashboardData(patientName: string, startDate?: string, endDate?: string) {


### PR DESCRIPTION
## Summary

The `GET /patient/:patientName/trends` and `GET /api/assessments/patient/:patientName/trends` endpoints accepted a patient name from the URL parameter and returned full clinical assessment data **without verifying that the requesting clinician has any relationship to that patient** (Insecure Direct Object Reference at the patient-name level).

### Changes

| File | Change |
|---|---|
| `server/repositories/assessment.repository.ts` | Added `createdBy?` parameter to `getAssessmentsByPatientName()` and `getPatientTrends()` with Drizzle ORM `and(...conditions)` filtering |
| `server/storage.ts` | Updated `IStorage` interface and `DatabaseStorage` to accept and forward `createdBy` parameter |
| `server/routes/assessments.routes.ts` | Extract `userEmail` from session and pass to `getAssessmentsByPatientName()` |
| `server/routes.ts` | Extract `userEmail` from session and pass to `getAssessmentsByPatientName()` (duplicate route) |

### Impact

- A clinician can only retrieve trends/assessments for patients they created records for
- Administrators retain full access via the existing `canAccessPatientRecord()` check on individual record endpoints
- Prevents patient enumeration attack through trend endpoints
- HIPAA-compliant access control enforced at the query layer

Closes #1320