### PR TITLE
fix(#1321): fix RLS bypass caused by separate AsyncLocalStorage instances

### DIFF
--- a/server/db-rls.ts
+++ b/server/db-rls.ts
@@ -1,8 +1,7 @@
-import { AsyncLocalStorage } from "async_hooks";
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import pg from "pg";
 import * as schema from "@shared/schema";
-import { getPool } from "./db";
+import { getPool, dbRlsStorage } from "./db";
 
 export interface RlsUserContext {
   userId: string;
@@ -11,10 +10,8 @@ export interface RlsUserContext {
   patientName?: string;
 }
 
-const rlsStorage = new AsyncLocalStorage<NodePgDatabase<typeof schema>>();
-
 export function getRlsDb(): NodePgDatabase<typeof schema> | undefined {
-  return rlsStorage.getStore();
+  return dbRlsStorage.getStore();
 }
 
 export async function createRlsClient(context: RlsUserContext): Promise<{
@@ -56,5 +53,5 @@ export function runWithRlsDb<T>(
   db: NodePgDatabase<typeof schema>,
   fn: () => T,
 ): T {
-  return rlsStorage.run(db, fn);
+  return dbRlsStorage.run(db, fn);
 }


### PR DESCRIPTION
## Summary

The entire RLS infrastructure was completely non-functional — all repository queries bypassed Row-Level Security because `db-rls.ts` and `db.ts` used **separate `AsyncLocalStorage` instances**, so the per-request RLS client set by the middleware was never found by `getDb()`.

### Root Cause

- `db.ts` (line 7): `export const dbRlsStorage = new AsyncLocalStorage(...)` — used by `getDb()` to check for a per-request RLS database client
- `db-rls.ts` (line 14): `const rlsStorage = new AsyncLocalStorage(...)` — used by `runWithRlsDb()` called from the `rlsContext` middleware

Since these were **two different `AsyncLocalStorage` instances**, the RLS database client set by the middleware (stored in `rlsStorage`) was **never found** by `getDb()` (which only checked `dbRlsStorage`). Every repository query fell through to the global connection pool, completely bypassing all RLS policies.

### Fix

| File | Change |
|---|---|
| `server/db-rls.ts` | Import and reuse `dbRlsStorage` from `db.ts` instead of creating a separate `AsyncLocalStorage` instance |

Now both `runWithRlsDb()` and `getDb()` read from and write to the **same** `AsyncLocalStorage`, making the full RLS chain functional:

1. `rlsContext` middleware creates a dedicated DB client with `SET LOCAL` session variables
2. Stores it via `dbRlsStorage.run(db, next)` 
3. Repository methods call `getDb()` which finds the RLS client in `dbRlsStorage`
4. PostgreSQL RLS policies are triggered via the session variables

Closes #1321