### PR TITLE
fix(security): limit CSV uploads to 100 rows to prevent DoS (#1324)

### DIFF
--- a/server/routes/upload.routes.ts
+++ b/server/routes/upload.routes.ts
@@ -55,6 +55,10 @@ uploadRouter.post(
       try {
         const csvString = file.buffer.toString("utf-8");
         const parsed = Papa.parse(csvString, { header: true, skipEmptyLines: true });
+
+        if (parsed.data.length > 100) {
+          return res.status(400).json({ message: "CSV exceeds maximum limit of 100 rows." });
+        }
         
         let processed = 0;
         let created = 0;

--- a/tests/security/upload.test.ts
+++ b/tests/security/upload.test.ts
@@ -67,4 +67,21 @@ describe("File Upload Hardening", () => {
     expect(response.status).toBe(400);
     expect(response.body.message).toContain("File too large");
   });
+
+  it("rejects CSV files with more than 100 rows", async () => {
+    let csvContent = "name,age\n";
+    for (let i = 0; i < 101; i++) {
+      csvContent += `User${i},30\n`;
+    }
+    const response = await request(app)
+      .post("/api/upload/lab-results")
+      .attach("file", Buffer.from(csvContent), {
+        filename: "too_many_rows.csv",
+        contentType: "text/csv"
+      });
+    
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("CSV exceeds maximum limit of 100 rows.");
+  });
 });
+


### PR DESCRIPTION
### Description
Addresses a Denial of Service (DoS) vulnerability in the `/api/upload/lab-results` endpoint (fixes #1324). 

Previously, the endpoint processed uploaded CSV files sequentially, executing a synchronous ML inference call (`await MLService.runAssessmentInference(validData)`) for each row in a `for` loop. Large datasets (e.g., thousands of rows) blocked the Express event loop, causing request timeouts and a Denial of Service for all users.

### Proposed Changes
- **Enforced Row Limit**: Added a validation check after parsing the CSV via `Papa.parse`. If the parsed row count (`parsed.data.length`) exceeds **100**, the server immediately rejects the request with a `400 Bad Request` and returns `"CSV exceeds maximum limit of 100 rows."`.
- **Unit Testing**: Added a security test case in `tests/security/upload.test.ts` to assert that files containing more than 100 rows are rejected with a `400` status.

### Verification Results
- All unit and integration tests successfully pass (including the new CSV row limit security test).
- Zero regressions across server and client test suites.