### PR TITLE
test : added regression tests for getRetentionPolicyConfig fallback

### DIFF
--- a/server/services/data-retention-policy.test.ts
+++ b/server/services/data-retention-policy.test.ts
@@ -86,3 +86,91 @@ describe("data retention policy", () => {
     expect(decision.reason).toContain("hold");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression tests for getRetentionPolicyConfig fallback behavior.
+//
+// Locks down that every non-positive or non-numeric environment value triggers
+// the documented default. These tests document the intended behavior in
+// machine-readable form so future refactors of parsePositiveInt cannot
+// accidentally weaken it.
+// ---------------------------------------------------------------------------
+
+describe("getRetentionPolicyConfig fallback regression", () => {
+  it("falls back to defaults when ALL four retention fields are non-positive", () => {
+    const config = getRetentionPolicyConfig({
+      ASSESSMENT_RETENTION_DAYS: "-1",
+      PATIENT_RETENTION_DAYS: "0",
+      EXPORT_RETENTION_DAYS: "-100",
+      AUDIT_RETENTION_DAYS: "-3650",
+    });
+
+    expect(config.assessmentRetentionDays).toBe(365 * 7);
+    expect(config.patientRetentionDays).toBe(365 * 7);
+    expect(config.exportRetentionDays).toBe(30);
+    expect(config.auditRetentionDays).toBe(365 * 10);
+  });
+
+  it("falls back to defaults when ALL four retention fields are non-numeric", () => {
+    const config = getRetentionPolicyConfig({
+      ASSESSMENT_RETENTION_DAYS: "abc",
+      PATIENT_RETENTION_DAYS: "",
+      EXPORT_RETENTION_DAYS: "NaN",
+      AUDIT_RETENTION_DAYS: "not-a-number",
+    });
+
+    expect(config.assessmentRetentionDays).toBe(365 * 7);
+    expect(config.patientRetentionDays).toBe(365 * 7);
+    expect(config.exportRetentionDays).toBe(30);
+    expect(config.auditRetentionDays).toBe(365 * 10);
+  });
+
+  it("preserves valid values while falling back on invalid ones (mixed env)", () => {
+    const config = getRetentionPolicyConfig({
+      ASSESSMENT_RETENTION_DAYS: "30",       // valid
+      PATIENT_RETENTION_DAYS: "-1",          // invalid (negative)
+      EXPORT_RETENTION_DAYS: "7",            // valid
+      AUDIT_RETENTION_DAYS: "0",             // invalid (zero)
+    });
+
+    expect(config.assessmentRetentionDays).toBe(30);
+    expect(config.patientRetentionDays).toBe(365 * 7); // fallback
+    expect(config.exportRetentionDays).toBe(7);
+    expect(config.auditRetentionDays).toBe(365 * 10);  // fallback
+  });
+
+  it("accepts the boundary value 1 as positive", () => {
+    const config = getRetentionPolicyConfig({
+      ASSESSMENT_RETENTION_DAYS: "1",
+    });
+    expect(config.assessmentRetentionDays).toBe(1);
+  });
+
+  it("treats the string '0' as non-positive and falls back", () => {
+    const config = getRetentionPolicyConfig({
+      EXPORT_RETENTION_DAYS: "0",
+    });
+    expect(config.exportRetentionDays).toBe(30); // fallback
+  });
+
+  it("documents parseInt truncation for floating-point strings (1.5 -> 1, 30.5 -> 30)", () => {
+    // The implementation uses Number.parseInt, which truncates toward zero.
+    // 1.5 -> 1 (positive, accepted); 30.5 -> 30 (positive, accepted).
+    // This is the existing behavior and is documented here so a future
+    // change to use Number() instead would require updating this test.
+    const config = getRetentionPolicyConfig({
+      EXPORT_RETENTION_DAYS: "1.5",
+      ASSESSMENT_RETENTION_DAYS: "30.5",
+    });
+    expect(config.exportRetentionDays).toBe(1);
+    expect(config.assessmentRetentionDays).toBe(30);
+  });
+
+  it("treats leading/trailing whitespace as part of the value (parseInt skips it)", () => {
+    // parseInt("  10  ", 10) === 10. Whitespace is silently ignored.
+    const config = getRetentionPolicyConfig({
+      ASSESSMENT_RETENTION_DAYS: "  10  ",
+    });
+    expect(config.assessmentRetentionDays).toBe(10);
+  });
+});


### PR DESCRIPTION
Closes #1441.

Summary of What Has Been Done:
Added 7 regression tests to `server/services/data-retention-policy.test.ts` that lock down the fallback behavior of `getRetentionPolicyConfig` for every retention field, the boundary at 1, and the explicit zero-rejection case.

Changes Made:
- Extended: `server/services/data-retention-policy.test.ts` (+88 lines, 7 new test cases in a new `describe("getRetentionPolicyConfig fallback regression", ...)` block).
  - All four fields non-positive -> all four fall back to defaults.
  - All four fields non-numeric -> all four fall back to defaults.
  - Mixed valid + invalid -> valid fields keep their values, invalid fields fall back.
  - Boundary at exactly 1 -> accepted as positive.
  - Zero string -> rejected, falls back.
  - Floating-point strings -> documents parseInt truncation behavior (1.5 -> 1, 30.5 -> 30).
  - Whitespace-padded strings -> documents parseInt whitespace skipping.
- No source files modified.

Impact it Made:
- Documents the exact fallback policy in machine-readable form.
- Catches a future bug where someone simplifies `parsePositiveInt` and accidentally accepts zero or negative values.
- Clarifies the parseInt truncation behavior for floating-point and whitespace inputs.
- All 12 tests in the file pass locally (5 pre-existing + 7 new).