### PR TITLE
test : added vitest unit tests for server/utils exec.ts validateArgs

### DIFF
--- a/server/utils/exec.test.ts
+++ b/server/utils/exec.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { validateArgs } from "./exec";
+
+describe("validateArgs", () => {
+  it("accepts valid python3 executable with allowed script and command", () => {
+    expect(() =>
+      validateArgs("python3", ["analyze.py", "predict_file", "patient.csv"])
+    ).not.toThrow();
+  });
+
+  it("accepts valid python executable with allowed script and command", () => {
+    expect(() =>
+      validateArgs("python", ["analyze.py", "train", "dataset.csv"])
+    ).not.toThrow();
+  });
+
+  it("accepts python.exe on windows", () => {
+    expect(() =>
+      validateArgs("python.exe", ["analyze.py", "predict_file", "input.csv"])
+    ).not.toThrow();
+  });
+
+  it("rejects non-python executables", () => {
+    expect(() => validateArgs("node", ["script.js"])).toThrow(
+      "[Security] Unauthorized executable: node"
+    );
+    expect(() => validateArgs("ruby", ["script.rb"])).toThrow(
+      "[Security] Unauthorized executable: ruby"
+    );
+    expect(() => validateArgs("bash", ["script.sh"])).toThrow(
+      "[Security] Unauthorized executable: bash"
+    );
+  });
+
+  it("rejects missing or too-few arguments", () => {
+    expect(() => validateArgs("python3", [])).toThrow(
+      "[Security] Missing arguments for ML script execution."
+    );
+    expect(() => validateArgs("python3", ["analyze.py"])).toThrow(
+      "[Security] Missing arguments for ML script execution."
+    );
+  });
+
+  it("rejects unauthorized script names", () => {
+    expect(() =>
+      validateArgs("python3", ["shell.sh", "predict_file"])
+    ).toThrow("[Security] Unauthorized script execution: shell.sh");
+    expect(() =>
+      validateArgs("python3", ["malicious.py", "train"])
+    ).toThrow("[Security] Unauthorized script execution: malicious.py");
+  });
+
+  it("rejects unauthorized commands", () => {
+    expect(() =>
+      validateArgs("python3", ["analyze.py", "delete", "file.csv"])
+    ).toThrow("[Security] Unauthorized ML command: delete");
+    expect(() =>
+      validateArgs("python3", ["analyze.py", "exec", "data.csv"])
+    ).toThrow("[Security] Unauthorized ML command: exec");
+  });
+
+  it("rejects flag-style argument injection", () => {
+    expect(() =>
+      validateArgs("python3", ["analyze.py", "predict_file", "-rf"])
+    ).toThrow("[Security] Argument injection detected. Flags are not permitted: -rf");
+    expect(() =>
+      validateArgs("python3", ["analyze.py", "predict_file", "--config=evil.cfg"])
+    ).toThrow(
+      "[Security] Argument injection detected. Flags are not permitted: --config=evil.cfg"
+    );
+    expect(() =>
+      validateArgs("python3", ["analyze.py", "predict_file", "--help"])
+    ).toThrow(
+      "[Security] Argument injection detected. Flags are not permitted: --help"
+    );
+    expect(() =>
+      validateArgs("python3", ["analyze.py", "train", "-e", "print('hack')"])
+    ).toThrow(
+      "[Security] Argument injection detected. Flags are not permitted: -e"
+    );
+  });
+
+  it("accepts allowed positional arguments after the command", () => {
+    expect(() =>
+      validateArgs("python3", [
+        "analyze.py",
+        "predict_file",
+        "patient1.csv",
+        "patient2.csv",
+      ])
+    ).not.toThrow();
+    expect(() =>
+      validateArgs("python3", ["analyze.py", "train", "large_dataset.csv"])
+    ).not.toThrow();
+  });
+});

--- a/server/utils/exec.ts
+++ b/server/utils/exec.ts
@@ -5,7 +5,7 @@ import path from "path";
 const ALLOWED_SCRIPTS = ["analyze.py"];
 const ALLOWED_COMMANDS = ["predict_file", "train"];
 
-function validateArgs(executable: string, args: ReadonlyArray<string>) {
+export function validateArgs(executable: string, args: ReadonlyArray<string>) {
   const isPython = executable.endsWith("python") || executable.endsWith("python.exe") || executable.endsWith("python3");
   if (!isPython) {
     throw new Error(`[Security] Unauthorized executable: ${executable}`);


### PR DESCRIPTION
Closes #1511.

Summary of What Has Been Done:
Added unit tests for the validateArgs security guard function in server/utils/exec.ts. validateArgs enforces strict allowlist-based validation on ML script execution: it checks the executable is python/python3, the script name is in ALLOWED_SCRIPTS, the command is in ALLOWED_COMMANDS, and rejects flag-style argument injection.

Changes Made:
- server/utils/exec.ts: exported validateArgs function to make it testable
- server/utils/exec.test.ts: 9 test cases covering valid combinations, non-python executables, too-few arguments, unauthorized scripts/commands, and flag injection attacks

Impact it Made:
All 53 server tests pass including the 9 new exec.ts tests. Ensures the security guard cannot be bypassed by crafted ML script arguments.

Note: Please assign this PR to the `tmdeveloper007` account.