### PR TITLE
fix(#1357): updated LinkedIn link to maintainer profile

### DIFF
--- a/client/src/components/CardioGuardLanding.tsx
+++ b/client/src/components/CardioGuardLanding.tsx
@@ -59,7 +59,7 @@ const footerLinks = [
 ];
 
 const socialLinks = [
-  { href: "https://www.linkedin.com", icon: Linkedin, label: "LinkedIn" },
+  { href: "https://www.linkedin.com/in/guptagopal001/", icon: Linkedin, label: "LinkedIn" },
   { href: "https://github.com/gopaljilab/Clinical-Insight-Engine", icon: Github, label: "GitHub" },
   { href: "mailto:hello@cardioguard.ai", icon: Mail, label: "Email" },
 ];

--- a/client/src/components/ClinicalInsightLanding.tsx
+++ b/client/src/components/ClinicalInsightLanding.tsx
@@ -69,7 +69,7 @@ const footerLinks = [
 ];
 
 const socialLinks = [
-  { href: "https://www.linkedin.com", icon: Linkedin, label: "LinkedIn" },
+  { href: "https://www.linkedin.com/in/guptagopal001/", icon: Linkedin, label: "LinkedIn" },
   { href: "https://github.com/gopaljilab/Clinical-Insight-Engine", icon: Github, label: "GitHub" },
   { href: "mailto:hello@cardioguard.ai", icon: Mail, label: "Email" },
 ];

--- a/client/src/pages/Landing.tsx
+++ b/client/src/pages/Landing.tsx
@@ -74,7 +74,7 @@ const footerLinks = [
 ];
 
 const socialLinks = [
-  { href: "https://www.linkedin.com", icon: Linkedin, label: "LinkedIn" },
+  { href: "https://www.linkedin.com/in/guptagopal001/", icon: Linkedin, label: "LinkedIn" },
   {
     href: "https://github.com/gopaljilab/Clinical-Insight-Engine",
     icon: Github,


### PR DESCRIPTION
## Description

Updated the LinkedIn footer link across landing components to point to the correct maintainer profile.

## Related Issue

Closes #1357

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Replaced generic LinkedIn homepage link with the correct profile: `https://www.linkedin.com/in/guptagopal001/`
- Updated `CardioGuardLanding.tsx`, `ClinicalInsightLanding.tsx`, and `Landing.tsx` in `client/src`
- Verified locally that the footer LinkedIn icon now redirects properly

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
---
I am a GSSoC'26 contributor and I am glad to contribute to this issue.
