### PR TITLE
fix: move reset token out of query string

### DIFF
--- a/client/src/pages/ResetPassword.tsx
+++ b/client/src/pages/ResetPassword.tsx
@@ -10,15 +10,20 @@ export default function ResetPassword() {
   const [isLoading, setIsLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [, setLocation] = useLocation();
-  const params = new URLSearchParams(window.location.search);
-  const token = params.get("token");
+  const queryToken = new URLSearchParams(window.location.search).get("token");
+  const hashToken = new URLSearchParams(window.location.hash.replace(/^#/, "")).get("token");
+  const token = hashToken || queryToken;
 
   useEffect(() => {
     document.title = "Reset Password - Clinical Insight Engine";
     if (!token) {
       setError("Invalid or missing reset token.");
+      return;
     }
-  }, [token]);
+    if (hashToken) {
+      window.history.replaceState(null, "", window.location.pathname);
+    }
+  }, [hashToken, token]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -651,7 +651,7 @@ out
 
       await authRepository.createPasswordResetToken(user.id, token, expiresAt);
 
-      const resetLink = `${process.env.APP_URL || "http://localhost:5173"}/reset-password?token=${token}`;
+      const resetLink = `${process.env.APP_URL || "http://localhost:5173"}/reset-password#token=${token}`;
 
       const emailSent = await sendPasswordResetEmail(email, resetLink);
       if (!emailSent) {
@@ -741,6 +741,5 @@ export function requireAdmin(req: Request, res: Response, next: NextFunction) {
   }
   return res.status(403).json({ message: "Admin access required." });
 }
-
 
 


### PR DESCRIPTION
## Summary
- Changes generated password reset links from query tokens to hash-fragment tokens
- Updates the reset password page to read hash tokens first while preserving backward compatibility for existing query-token links
- Removes the hash token from the visible URL after parsing to reduce exposure in browser history/address bar

## Related Issue
Closes #1507

## Validation
- npm run check *(fails before validating this change because untouched server/auth/oauth2.ts reports TS1005: '}' expected)*

## Notes
- Scope is limited to the reset-link generation and reset-page token parsing flow.