### PR TITLE
fix: validate all clinical assessment inputs

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -533,17 +533,36 @@ def validate_assessment_input(data):
     if not isinstance(data, dict):
         raise ValueError("Input must be an object")
 
-    age = data.get("age")
-    if age is None or age < 0 or age > 130:
-        raise ValueError("Invalid age")
+    validators = {
+        "age": {"type": (int, float), "min": 0, "max": 130},
+        "gender": {"type": str, "in": ("Male", "Female")},
+        "hypertension": {"type": (bool, int), "in": (False, True, 0, 1)},
+        "heartDisease": {"type": (bool, int), "in": (False, True, 0, 1)},
+        "bmi": {"type": (int, float), "min": 0, "max": 100},
+        "hba1cLevel": {"type": (int, float), "min": 0, "max": 15},
+        "bloodGlucoseLevel": {"type": (int, float), "min": 0, "max": 500},
+        "smokingHistory": {
+            "type": str,
+            "in": ("never", "former", "current", "not specified", "ever", "No Info"),
+        },
+    }
 
-    gender = data.get("gender")
-    if gender not in ("Male", "Female"):
-        raise ValueError("Invalid gender")
+    for field, rules in validators.items():
+        if field not in data or data[field] is None:
+            raise ValueError(f"Missing or null field: {field}")
 
-    bmi = data.get("bmi")
-    if bmi is not None and (bmi < 0 or bmi > 100):
-        raise ValueError("Invalid BMI")
+        value = data[field]
+        if not isinstance(value, rules["type"]):
+            raise ValueError(f"Invalid type for {field}")
+
+        if "in" in rules and value not in rules["in"]:
+            raise ValueError(f"Invalid value for {field}")
+
+        if "min" in rules and value < rules["min"]:
+            raise ValueError(f"Invalid value for {field}")
+
+        if "max" in rules and value > rules["max"]:
+            raise ValueError(f"Invalid value for {field}")
 
     return data
 

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -426,3 +426,66 @@ def test_validate_assessment_input_rejects_invalid_gender():
                 "smokingHistory": "never",
             }
         )
+
+
+def test_validate_assessment_input_accepts_complete_valid_payload():
+    from analyze import validate_assessment_input
+
+    payload = {
+        "age": 40,
+        "gender": "Female",
+        "hypertension": False,
+        "heartDisease": 0,
+        "bmi": 25,
+        "hba1cLevel": 5.5,
+        "bloodGlucoseLevel": 100,
+        "smokingHistory": "never",
+    }
+
+    assert validate_assessment_input(payload) == payload
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("hba1cLevel", 16),
+        ("bloodGlucoseLevel", 501),
+        ("smokingHistory", "invalid"),
+        ("hypertension", 2),
+        ("heartDisease", -1),
+    ],
+)
+def test_validate_assessment_input_rejects_invalid_clinical_fields(field, value):
+    from analyze import validate_assessment_input
+
+    payload = {
+        "age": 40,
+        "gender": "Female",
+        "hypertension": False,
+        "heartDisease": False,
+        "bmi": 25,
+        "hba1cLevel": 5.5,
+        "bloodGlucoseLevel": 100,
+        "smokingHistory": "never",
+    }
+    payload[field] = value
+
+    with pytest.raises(ValueError):
+        validate_assessment_input(payload)
+
+
+def test_validate_assessment_input_rejects_missing_clinical_field():
+    from analyze import validate_assessment_input
+
+    payload = {
+        "age": 40,
+        "gender": "Female",
+        "hypertension": False,
+        "heartDisease": False,
+        "bmi": 25,
+        "bloodGlucoseLevel": 100,
+        "smokingHistory": "never",
+    }
+
+    with pytest.raises(ValueError, match="hba1cLevel"):
+        validate_assessment_input(payload)


### PR DESCRIPTION
## Summary
- Extends validate_assessment_input to validate all clinical fields used by the ML prediction path
- Rejects missing/null fields, invalid types, out-of-range numeric values, and invalid enum/binary fields
- Adds focused pytest coverage for valid payloads, missing fields, and invalid clinical field values

## Related Issue
Closes #1510

## Validation
- python -m pytest tests/test_analyze.py -k validate_assessment_input *(9 passed, 13 deselected)*