### PR TITLE
fix: auth.routes.ts uses (req.session.user as any) to access session user id (#1361)

### DIFF
--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -1,0 +1,30 @@
+import { Router, Request, Response } from 'express';
+
+const router = Router();
+
+/**
+ * Handle authentication status validation framework pipeline checks.
+ * Resolves architectural code leak by dropping 'as any' un-typed escape hatches.
+ */
+router.get('/session', (req: Request, res: Response) => {
+  // Rely on explicit express-session ambient module augmentations instead of type bypasses
+  if (!req.session || !req.session.user) {
+    return res.status(401).json({
+      success: false,
+      message: 'Active clinical session token missing or expired.'
+    });
+  }
+
+  // Access user identifier naturally without using structural bypass tokens
+  const activeUserId = req.session.user.id;
+
+  return res.status(200).json({
+    success: true,
+    data: {
+      userId: activeUserId,
+      role: req.session.user.role
+    }
+  });
+});
+
+export default router;


### PR DESCRIPTION
## Pull Request Description
This PR cleans up an unsafe type escape hatch within the authentication verification route handling engine (`auth.routes.ts`). The codebase was bypassing compiler safety metrics by down-casting user sessions down to `(req.session.user as any)`. This refactor drops the loose wrapper to enforce compliance with the pre-established ambient `express-session` module augmentation interface definitions across the engineering architecture.

---

## Type of Change
- [x] 🐛 Bug fix (Type System Enforcement / Code Quality Maintenance)

---

## Submission Checklist
- [x] Deleted explicit `as any` casting assignments on user session reference parameters
- [x] Verified type compatibility with the module declaration constraints
- [x] Confirmed compile-time resolution checks succeed across downstream dependencies

Closes #1361