### PR TITLE
fix: AppLayout.tsx uses raw fetch("/api/auth/logout") (#1370)

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { ApiClient } from '../utils/api-client'; // Using the central configured API utility
+
+interface AppLayoutProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Global application viewport wrapper element.
+ * Migrates raw logout fetch trigger to use ApiClient, preserving multi-origin architecture compatibility.
+ */
+export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
+  
+  const handleLogout = async () => {
+    try {
+      // ApiClient naturally appends VITE_API_BASE and safely handles credentials/headers cross-origin
+      const response = await ApiClient.post<{ success: boolean }>('/auth/logout');
+      
+      if (response.data && response.data.success) {
+        // Direct location rewrite or route push context on successful sign-out sync
+        window.location.href = '/login';
+      } else {
+        console.error('Logout request was processed but state confirmation flagged invalid.');
+      }
+    } catch (err: any) {
+      console.error('Failed to dispatch user sign-out session lifecycle action:', err.message);
+    }
+  };
+
+  return (
+    <div className="app-layout-container">
+      <header className="app-navbar">
+        <div className="nav-brand">Clinical Insight Engine</div>
+        <button className="logout-action-btn" onClick={handleLogout}>
+          Sign Out
+        </button>
+      </header>
+      <main className="app-viewport-content">
+        {children}
+      </main>
+    </div>
+  );
+};
+
+export default AppLayout;


### PR DESCRIPTION
## Pull Request Description
This PR resolves a networking boundary flaw within the main viewport header layout component (`AppLayout.tsx`). The logout interactive trigger previously routed transactions via a naked global `fetch("/api/auth/logout")` call, which implicitly assumed the backend ran on the exact same origin as the frontend assets.

This modification drops the unmanaged network call in favor of our central utility wrapper `ApiClient`. This guarantees that user sign-out destruction cycles correctly route to target microservice nodes defined by `VITE_API_BASE` without triggering silent CORS or target resolution failures.

---

## Type of Change
- [x] 🐛 Bug fix (Network Layer Alignment / Cross-Origin Integrity)

---

## Submission Checklist
- [x] Cleaned out raw relative path `fetch()` methods inside view lifecycle states
- [x] Routed logout workflow actions directly via `ApiClient.post`
- [x] Confirmed alignment with cross-origin session and credential state setups

Closes #1370