### PR TITLE
fix: AssessmentSearchBar.tsx uses raw fetch("/api/assessments/autocomplete") (#1368)

### DIFF
--- a/src/components/AssessmentSearchBar.tsx
+++ b/src/components/AssessmentSearchBar.tsx
@@ -1,0 +1,58 @@
+import React, { useState, useEffect } from 'react';
+import { ApiClient } from '../utils/api-client'; // Using the central configured API utility
+
+/**
+ * Assessment Search Bar component featuring real-time autocomplete suggestions.
+ * Fixed to route requests through ApiClient, enabling robust multi-origin capabilities.
+ */
+export const AssessmentSearchBar: React.FC = () => {
+  const [query, setQuery] = useState('');
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (query.trim().length < 2) {
+      setSuggestions([]);
+      return;
+    }
+
+    const delayDebounce = setTimeout(async () => {
+      try {
+        // ApiClient prefixes VITE_API_BASE and handles credentials/headers for cross-origin setups
+        const response = await ApiClient.get<{ success: boolean; data: string[] }>(
+          `/assessments/autocomplete?q=${encodeURIComponent(query)}`
+        );
+
+        if (response.data && response.data.success) {
+          setSuggestions(response.data.data);
+        }
+      } catch (err: any) {
+        console.error('Failed to fetch autocomplete suggestions:', err.message);
+      }
+    }, 300); // 300ms debounce interval
+
+    return () => clearTimeout(delayDebounce);
+  }, [query]);
+
+  return (
+    <div className="search-bar-container">
+      <input
+        type="text"
+        placeholder="Search clinical assessments..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        className="search-input"
+      />
+      {suggestions.length > 0 && (
+        <ul className="suggestions-dropdown">
+          {suggestions.map((item, idx) => (
+            <li key={idx} className="suggestion-item">
+              {item}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default AssessmentSearchBar;


### PR DESCRIPTION
## Pull Request Description
This PR addresses an infrastructure bypass within the assessment autocomplete search module (`AssessmentSearchBar.tsx`). The input suggestion handler previously relied on an absolute/relative path query using the global `fetch()` API, causing connection breakages when the application is deployed across decoupled origins or when `VITE_API_BASE` points to a standalone service tier.

Migrating this endpoint query to the shared `ApiClient` layer ensures proper cross-origin configurations, request header propagation, and uniform endpoint handling.

---

## Type of Change
- [x] 🐛 Bug fix (Network Layer Alignment / Cross-Origin Integrity)

---

## Submission Checklist
- [x] Eliminated unconfigured global `fetch()` requests inside input event loops
- [x] Routed autocomplete telemetry checks entirely via standard `ApiClient.get` methods
- [x] Ensured network stream targets resolve cleanly relative to environmental base URL configurations

Closes #1368