### PR TITLE
fix: AuthFlow.tsx handleResendOtp uses raw fetch("/api/auth/resend-otp") (#1367)

### DIFF
--- a/src/components/AuthFlow.tsx
+++ b/src/components/AuthFlow.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { ApiClient } from '../utils/api-client'; // Using the central configured API utility
+
+interface AuthFlowProps {
+  email: string;
+}
+
+/**
+ * AuthFlow Component managing authentication registration and verification loops.
+ * Refactored to utilize ApiClient for OTP resend triggers, preventing multi-origin network drops.
+ */
+export const AuthFlow: React.FC<AuthFlowProps> = ({ email }) => {
+  const [resending, setResending] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const handleResendOtp = async () => {
+    if (!email) return;
+    
+    setResending(true);
+    setMessage('');
+    
+    try {
+      // ApiClient naturally prefixes VITE_API_BASE and satisfies cross-origin pipeline configurations
+      const response = await ApiClient.post<{ success: boolean; message?: string }>('/auth/resend-otp', {
+        email
+      });
+
+      if (response.data && response.data.success) {
+        setMessage('A fresh verification token has been routed to your inbox.');
+      } else {
+        setMessage(response.data.message || 'Verification token transmission rejected by identity gateway.');
+      }
+    } catch (err: any) {
+      setMessage(err.message || 'Network infrastructure exception encountered during OTP transmission.');
+    } finally {
+      setResending(false);
+    }
+  };
+
+  return (
+    <div className="auth-flow-container">
+      <h2>Verify Your Clinical Identity</h2>
+      <p>An authentication credential frame has been dispatched to {email}.</p>
+      
+      <div className="action-row">
+        <button 
+          onClick={handleResendOtp} 
+          disabled={resending}
+          className="resend-action-btn"
+        >
+          {resending ? 'Transmitting Token...' : 'Resend OTP Token'}
+        </button>
+      </div>
+
+      {message && <div className="status-feedback-msg">{message}</div>}
+    </div>
+  );
+};
+
+export default AuthFlow;


### PR DESCRIPTION
## Pull Request Description
This PR addresses an API integration bypass inside our verification management flow (`AuthFlow.tsx`). The component's OTP re-dispatch trigger previously bypassed global interceptors by utilizing a loose `fetch("/api/auth/resend-otp")` operation. This logic defaults target parameters strictly to the frontend static server's host domain, dropping network transactions when the ecosystem architecture is configured with decoupled API endpoints (`VITE_API_BASE`).

Migrating this module over to our central `ApiClient` tool resolves origin matching challenges and secures request transmission tracking.

---

## Type of Change
- [x] 🐛 Bug fix (Network Layer Alignment / Cross-Origin Integrity)

---

## Submission Checklist
- [x] Stripped out unmanaged global `fetch()` statements inside auth identity handlers
- [x] Configured the resend pipeline routine to route via standard `ApiClient.post` actions
- [x] Verified target prefix routing behaviors align dynamically against active microservice environment bounds

Closes #1367