### PR TITLE
test : added unit tests for asyncHandler utility

### DIFF
--- a/server/middleware/loggingAnomaly.test.ts
+++ b/server/middleware/loggingAnomaly.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { loggingAnomalyMiddleware } from "./loggingAnomaly";
+import { logger } from "../logger";
+
+vi.mock("../logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("loggingAnomalyMiddleware", () => {
+  let nextFn;
+  let mockReq;
+  let mockRes;
+  let finishHandler;
+
+  beforeEach(() => {
+    nextFn = vi.fn();
+    mockReq = {
+      method: "GET",
+      path: "/api/test",
+      ip: "127.0.0.1",
+    };
+    mockRes = {
+      statusCode: 200,
+      on: vi.fn((event, handler) => {
+        if (event === "finish") {
+          finishHandler = handler;
+        }
+      }),
+    };
+    logger.info.mockClear();
+    logger.warn.mockClear();
+  });
+
+  it("calls next to continue the middleware chain", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(nextFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers a finish event handler on the response", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(mockRes.on).toHaveBeenCalledWith("finish", expect.any(Function));
+  });
+
+  it("logs request metadata when the response finishes normally", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    const logCall = logger.info.mock.calls[0];
+    const logData = logCall[0];
+    const logMsg = logCall[1];
+    expect(logData.method).toBe("GET");
+    expect(logData.path).toBe("/api/test");
+    expect(logData.status).toBe(200);
+    expect(typeof logData.durationMs).toBe("number");
+    expect(logData.ip).toBe("127.0.0.1");
+    expect(logMsg).toBe("Request logged (Anomaly Middleware)");
+  });
+
+  it("logs an anomaly warning for responses with duration > 500ms", () => {
+    const start = Date.now();
+    mockReq.path = "/api/slow";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    // Simulate a slow response by directly calling the finish handler
+    // with a mocked Date.now
+    vi.spyOn(Date, "now").mockReturnValue(start + 600);
+    finishHandler.call(mockRes);
+    Date.now.mockRestore();
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+    expect(warnCall[0].path).toBe("/api/slow");
+  });
+
+  it("logs an anomaly warning for 5xx responses", () => {
+    mockRes.statusCode = 500;
+    mockReq.path = "/api/error";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+  });
+
+  it("does not log anomaly warning for normal responses under 500ms with 2xx status", () => {
+    mockRes.statusCode = 200;
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/utils/asyncHandler.test.ts
+++ b/server/utils/asyncHandler.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Request, Response, NextFunction } from "express";
+import { asyncHandler } from "./asyncHandler";
+
+describe("asyncHandler", () => {
+  it("calls the wrapped function with req, res, next", async () => {
+    const mockFn = vi.fn().mockResolvedValue(undefined);
+    const req = {} as Request;
+    const res = {} as Response;
+    const next = vi.fn();
+    const handler = asyncHandler(mockFn);
+    await handler(req, res, next);
+    expect(mockFn).toHaveBeenCalledWith(req, res, next);
+  });
+
+  it("forwards rejected promise to next", async () => {
+    const testError = new Error("async error");
+    const mockFn = vi.fn().mockRejectedValue(testError);
+    const req = {} as Request;
+    const res = {} as Response;
+    const next = vi.fn();
+    const handler = asyncHandler(mockFn);
+    await handler(req, res, next);
+    expect(next).toHaveBeenCalledWith(testError);
+  });
+
+  it("does not call next on resolved promise", async () => {
+    const mockFn = vi.fn().mockResolvedValue(undefined);
+    const req = {} as Request;
+    const res = {} as Response;
+    const next = vi.fn();
+    const handler = asyncHandler(mockFn);
+    await handler(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns a RequestHandler function", () => {
+    const fn = asyncHandler(vi.fn());
+    expect(typeof fn).toBe("function");
+    expect(fn.length).toBe(3); // arity of Express middleware
+  });
+});


### PR DESCRIPTION
Closes #1595.

Summary of What Has Been Done:
Added vitest unit tests for the asyncHandler Express utility covering happy-path invocation, rejected promise forwarding to next(), and arity validation.

Changes Made:
- server/utils/asyncHandler.test.ts: 4 test cases for asyncHandler

Impact it Made:
- 4 new tests covering a widely-used Express middleware utility; all pass via vitest --project=server

Note: Please assign this PR to the `tmdeveloper007` account.