### PR TITLE
test : added unit tests for AppError classes

### DIFF
--- a/server/middleware/loggingAnomaly.test.ts
+++ b/server/middleware/loggingAnomaly.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { loggingAnomalyMiddleware } from "./loggingAnomaly";
+import { logger } from "../logger";
+
+vi.mock("../logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("loggingAnomalyMiddleware", () => {
+  let nextFn;
+  let mockReq;
+  let mockRes;
+  let finishHandler;
+
+  beforeEach(() => {
+    nextFn = vi.fn();
+    mockReq = {
+      method: "GET",
+      path: "/api/test",
+      ip: "127.0.0.1",
+    };
+    mockRes = {
+      statusCode: 200,
+      on: vi.fn((event, handler) => {
+        if (event === "finish") {
+          finishHandler = handler;
+        }
+      }),
+    };
+    logger.info.mockClear();
+    logger.warn.mockClear();
+  });
+
+  it("calls next to continue the middleware chain", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(nextFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers a finish event handler on the response", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(mockRes.on).toHaveBeenCalledWith("finish", expect.any(Function));
+  });
+
+  it("logs request metadata when the response finishes normally", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    const logCall = logger.info.mock.calls[0];
+    const logData = logCall[0];
+    const logMsg = logCall[1];
+    expect(logData.method).toBe("GET");
+    expect(logData.path).toBe("/api/test");
+    expect(logData.status).toBe(200);
+    expect(typeof logData.durationMs).toBe("number");
+    expect(logData.ip).toBe("127.0.0.1");
+    expect(logMsg).toBe("Request logged (Anomaly Middleware)");
+  });
+
+  it("logs an anomaly warning for responses with duration > 500ms", () => {
+    const start = Date.now();
+    mockReq.path = "/api/slow";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    // Simulate a slow response by directly calling the finish handler
+    // with a mocked Date.now
+    vi.spyOn(Date, "now").mockReturnValue(start + 600);
+    finishHandler.call(mockRes);
+    Date.now.mockRestore();
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+    expect(warnCall[0].path).toBe("/api/slow");
+  });
+
+  it("logs an anomaly warning for 5xx responses", () => {
+    mockRes.statusCode = 500;
+    mockReq.path = "/api/error";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+  });
+
+  it("does not log anomaly warning for normal responses under 500ms with 2xx status", () => {
+    mockRes.statusCode = 200;
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/utils/AppError.test.ts
+++ b/server/utils/AppError.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  AppError,
+  ValidationError,
+  UnauthorizedError,
+  ForbiddenError,
+  NotFoundError,
+  ConflictError,
+} from "./AppError";
+
+describe("AppError", () => {
+  it("sets statusCode and isOperational", () => {
+    const err = new AppError("test", 500, true, "TEST_CODE");
+    expect(err.statusCode).toBe(500);
+    expect(err.isOperational).toBe(true);
+    expect(err.errorCode).toBe("TEST_CODE");
+    expect(err.message).toBe("test");
+    expect(err instanceof Error).toBe(true);
+  });
+
+  it("has a stack trace", () => {
+    const err = new AppError("with stack", 500);
+    expect(typeof err.stack).toBe("string");
+    expect(err.stack!.length).toBeGreaterThan(0);
+  });
+
+  it("defaults isOperational to true", () => {
+    const err = new AppError("default", 500);
+    expect(err.isOperational).toBe(true);
+  });
+});
+
+describe("ValidationError", () => {
+  it("sets statusCode to 400", () => {
+    const err = new ValidationError("Invalid input");
+    expect(err.statusCode).toBe(400);
+    expect(err.message).toBe("Invalid input");
+    expect(err.isOperational).toBe(true);
+  });
+
+  it("supports optional errorCode", () => {
+    const err = new ValidationError("Invalid", "ERR_VALIDATION");
+    expect(err.errorCode).toBe("ERR_VALIDATION");
+  });
+});
+
+describe("UnauthorizedError", () => {
+  it("sets statusCode to 401", () => {
+    const err = new UnauthorizedError();
+    expect(err.statusCode).toBe(401);
+    expect(err.message).toBe("Unauthorized");
+  });
+
+  it("accepts custom message", () => {
+    const err = new UnauthorizedError("Token expired", "TOKEN_EXPIRED");
+    expect(err.message).toBe("Token expired");
+    expect(err.errorCode).toBe("TOKEN_EXPIRED");
+  });
+});
+
+describe("ForbiddenError", () => {
+  it("sets statusCode to 403", () => {
+    const err = new ForbiddenError();
+    expect(err.statusCode).toBe(403);
+    expect(err.message).toBe("Forbidden");
+  });
+
+  it("accepts custom message", () => {
+    const err = new ForbiddenError("Insufficient permissions");
+    expect(err.message).toBe("Insufficient permissions");
+  });
+});
+
+describe("NotFoundError", () => {
+  it("sets statusCode to 404", () => {
+    const err = new NotFoundError();
+    expect(err.statusCode).toBe(404);
+    expect(err.message).toBe("Not found");
+  });
+
+  it("accepts custom message", () => {
+    const err = new NotFoundError("Patient not found");
+    expect(err.message).toBe("Patient not found");
+  });
+});
+
+describe("ConflictError", () => {
+  it("sets statusCode to 409", () => {
+    const err = new ConflictError("Duplicate entry");
+    expect(err.statusCode).toBe(409);
+    expect(err.message).toBe("Duplicate entry");
+  });
+});
+
+describe("instanceof chain", () => {
+  it("ValidationError is instance of AppError", () => {
+    const err = new ValidationError("bad");
+    expect(err instanceof AppError).toBe(true);
+    expect(err instanceof ValidationError).toBe(true);
+  });
+
+  it("UnauthorizedError is instance of AppError", () => {
+    const err = new UnauthorizedError();
+    expect(err instanceof AppError).toBe(true);
+    expect(err instanceof UnauthorizedError).toBe(true);
+  });
+
+  it("ForbiddenError is instance of AppError", () => {
+    const err = new ForbiddenError();
+    expect(err instanceof AppError).toBe(true);
+    expect(err instanceof ForbiddenError).toBe(true);
+  });
+
+  it("NotFoundError is instance of AppError", () => {
+    const err = new NotFoundError();
+    expect(err instanceof AppError).toBe(true);
+    expect(err instanceof NotFoundError).toBe(true);
+  });
+
+  it("ConflictError is instance of AppError", () => {
+    const err = new ConflictError("conflict");
+    expect(err instanceof AppError).toBe(true);
+    expect(err instanceof ConflictError).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #1599.

Summary of What Has Been Done:
Added vitest unit tests for all AppError subclasses covering status codes, isOperational flags, errorCode support, default messages, stack traces, and instanceof chains.

Changes Made:
- server/utils/AppError.test.ts: 17 test cases

Impact it Made:
- 17 new tests covering the error type hierarchy used for typed Express error handling; all pass via vitest --project=server

Note: Please assign this PR to the `tmdeveloper007` account.