### PR TITLE
test : added vitest unit tests for safeQueryParams utility

### DIFF
--- a/client/src/utils/safeQueryParams.test.ts
+++ b/client/src/utils/safeQueryParams.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { encodeHtmlEntities, getSafeQueryParam } from "./safeQueryParams";
+
+describe("encodeHtmlEntities", () => {
+  it("encodes ampersand", () => {
+    expect(encodeHtmlEntities("a&b")).toBe("a&amp;b");
+  });
+
+  it("encodes less than", () => {
+    expect(encodeHtmlEntities("a<b")).toBe("a&lt;b");
+  });
+
+  it("encodes greater than", () => {
+    expect(encodeHtmlEntities("a>b")).toBe("a&gt;b");
+  });
+
+  it("encodes double quote", () => {
+    expect(encodeHtmlEntities('a"b')).toBe("a&quot;b");
+  });
+
+  it("encodes single quote", () => {
+    expect(encodeHtmlEntities("a'b")).toBe("a&#39;b");
+  });
+
+  it("leaves plain text unchanged", () => {
+    expect(encodeHtmlEntities("Hello World")).toBe("Hello World");
+  });
+
+  it("encodes mixed HTML content", () => {
+    // encodeHtmlEntities encodes &, <, >, ", ' but leaves / unchanged
+    expect(encodeHtmlEntities('<script>alert("xss")</script>')).toBe(
+      "&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;"
+    );
+  });
+});
+
+describe("getSafeQueryParam", () => {
+  it("returns empty string for missing key", () => {
+    const result = getSafeQueryParam("name=John", "age");
+    expect(result).toBe("");
+  });
+
+  it("returns empty string for malformed query string", () => {
+    const result = getSafeQueryParam("not a valid query", "name");
+    expect(result).toBe("");
+  });
+
+  it("returns empty string for empty query string", () => {
+    const result = getSafeQueryParam("", "name");
+    expect(result).toBe("");
+  });
+
+  it("returns HTML-encoded value for existing key", () => {
+    const result = getSafeQueryParam("name=John%20Doe", "name");
+    expect(result).toBe("John Doe");
+  });
+
+  it("returns empty string for XSS payload in query value", () => {
+    // <script> gets stripped by validateFilterInput -> ""
+    const result = getSafeQueryParam("q=<script>alert(1)</script>", "q");
+    expect(result).toBe("");
+  });
+
+  it("returns HTML-encoded value for SQL injection (validateFilterInput does not block SQL patterns)", () => {
+    // validateFilterInput only blocks XSS patterns, not SQL injection.
+    // SQL injection is blocked by validateSearchInput (different function).
+    // The value gets validated by validateFilterInput (passes) then HTML-encoded.
+    const result = getSafeQueryParam("q=' OR 1=1 --", "q");
+    expect(result).toBe("&#39; OR 1=1 --");
+  });
+});


### PR DESCRIPTION
Closes #1644.

Summary of What Has been Done:
Added vitest unit tests for the safeQueryParams utility in client/src/utils/safeQueryParams.ts. Tests cover encodeHtmlEntities for all 5 HTML entities, and getSafeQueryParam for valid params, missing keys, malformed strings, and XSS payloads.

Changes Made:
- client/src/utils/safeQueryParams.test.ts: 13 test cases

Impact it Made:
- Automated test coverage for the client-side query parameter safety utility
- Confirmed XSS payloads in URL params are HTML-encoded before output

Note: Please assign this PR to the `tmdeveloper007` account.