### PR TITLE
test : added vitest unit tests for asyncHandler utility

### DIFF
--- a/server/utils/asyncHandler.test.ts
+++ b/server/utils/asyncHandler.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { asyncHandler } from "./asyncHandler";
+import type { Request, Response, NextFunction } from "express";
+
+describe("asyncHandler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not call next when async function resolves successfully", async () => {
+    const next = vi.fn<Parameters<NextFunction>>();
+    const req = {} as Request;
+    const res = { json: vi.fn() } as unknown as Response;
+    const handler = asyncHandler(async (_req, _res, _next) => {
+      return;
+    });
+
+    const promise = handler(req, res, next);
+    await vi.advanceTimersByTimeAsync(0);
+    await promise;
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next with the error when async function rejects", async () => {
+    const next = vi.fn<Parameters<NextFunction>>();
+    const req = {} as Request;
+    const res = {} as Response;
+    const testError = new Error("async rejection");
+    const handler = asyncHandler(async (_req, _res, _next) => {
+      throw testError;
+    });
+
+    const promise = handler(req, res, next);
+    await vi.advanceTimersByTimeAsync(0);
+    await promise;
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(testError);
+  });
+
+  it("returns a function that is a valid request handler", () => {
+    const handler = asyncHandler(async (_req, _res, _next) => {});
+    expect(typeof handler).toBe("function");
+    expect(handler.length).toBe(3);
+  });
+
+  it("passes request and response objects through to the wrapped function", async () => {
+    const next = vi.fn<Parameters<NextFunction>>();
+    const req = { method: "POST", path: "/test" } as Request;
+    const res = {} as Response;
+    let receivedReq: Request | undefined;
+    let receivedRes: Response | undefined;
+
+    const handler = asyncHandler(async (r, resArg, _next) => {
+      receivedReq = r;
+      receivedRes = resArg;
+    });
+
+    const promise = handler(req, res, next);
+    await vi.advanceTimersByTimeAsync(0);
+    await promise;
+    expect(receivedReq).toBe(req);
+    expect(receivedRes).toBe(res);
+  });
+});


### PR DESCRIPTION
Closes #1680.

Summary of What Has Been Done:
Added vitest unit tests for the asyncHandler utility in server/utils/asyncHandler.ts. Tests cover: success path (next not called), error path (next called with error), returned function arity, and request/response passthrough.

Changes Made:
- server/utils/asyncHandler.test.ts — 4 tests using vi.useFakeTimers to properly flush microtasks

Impact it Made:
- Covers error handling in async route handlers
- Increases server/utils test coverage
- All 4 tests pass locally (vitest --project=server)

Note: Please assign this PR to the `tmdeveloper007` account.