### PR TITLE
test : added unit tests for asyncHandler utility

### DIFF
--- a/server/utils/asyncHandler.test.ts
+++ b/server/utils/asyncHandler.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { asyncHandler } from "./asyncHandler";
+import type { Request, Response, NextFunction } from "express";
+
+describe("asyncHandler", () => {
+  it("does not call next when the wrapped async function resolves", async () => {
+    const mockReq = {} as Request;
+    const mockRes = {} as Response;
+    const mockNext: NextFunction = vi.fn();
+    const handler = asyncHandler(async (req, res, next) => {
+      return "success";
+    });
+
+    handler(mockReq, mockRes, mockNext);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(mockNext).not.toHaveBeenCalled();
+  });
+
+  it("forwards rejected promises to next", async () => {
+    const mockReq = {} as Request;
+    const mockRes = {} as Response;
+    const mockNext = vi.fn();
+    const testError = new Error("async error");
+    const handler = asyncHandler(async (req, res, next) => {
+      throw testError;
+    });
+
+    handler(mockReq, mockRes, mockNext);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(mockNext).toHaveBeenCalledTimes(1);
+    expect(mockNext).toHaveBeenCalledWith(testError);
+  });
+
+  it("passes req, res, and next to the wrapped function", async () => {
+    const mockReq = { custom: "value" } as unknown as Request;
+    const mockRes = { customRes: "res" } as unknown as Response;
+    const mockNext = vi.fn();
+    let receivedReq: any;
+    let receivedRes: any;
+    let receivedNext: any;
+
+    const handler = asyncHandler(async (req, res, next) => {
+      receivedReq = req;
+      receivedRes = res;
+      receivedNext = next;
+    });
+
+    handler(mockReq, mockRes, mockNext);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(receivedReq).toBe(mockReq);
+    expect(receivedRes).toBe(mockRes);
+    expect(receivedNext).toBe(mockNext);
+  });
+
+  it("does not call next if the wrapped function resolves normally", async () => {
+    const mockReq = {} as Request;
+    const mockRes = {} as Response;
+    const mockNext = vi.fn();
+
+    const handler = asyncHandler(async (req, res, next) => {
+      // do nothing, resolve normally
+    });
+
+    handler(mockReq, mockRes, mockNext);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(mockNext).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #1747.

Summary of What Has Been Done:
Added vitest unit tests for the asyncHandler utility function in server/utils/asyncHandler.ts. The test suite covers promise rejection forwarding, context preservation for req/res/next, and normal async resolution without spurious next() calls.

Changes Made:
- server/utils/asyncHandler.test.ts: Added 4 test cases for the asyncHandler wrapper function

Impact it Made:
- Prevents silent failures in async Express route handlers
- Ensures asyncHandler reliably delegates errors to the global error handler
- 4 tests passing locally

Note: Please assign this PR to the `tmdeveloper007` account.