### PR TITLE
test : added unit tests for loggingAnomaly middleware

### DIFF
--- a/server/middleware/loggingAnomaly.test.ts
+++ b/server/middleware/loggingAnomaly.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { loggingAnomalyMiddleware } from "./loggingAnomaly";
+import type { Request, Response } from "express";
+
+describe("loggingAnomalyMiddleware", () => {
+  it("calls next immediately", () => {
+    const mockReq = { method: "GET", path: "/test", ip: "127.0.0.1" } as unknown as Request;
+    const mockRes = {
+      statusCode: 200,
+      on: vi.fn(),
+    } as unknown as Response;
+    const mockNext = vi.fn();
+
+    loggingAnomalyMiddleware(mockReq, mockRes, mockNext);
+
+    expect(mockNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers finish event listener on response", () => {
+    const mockReq = { method: "GET", path: "/test", ip: "127.0.0.1" } as unknown as Request;
+    const mockRes = {
+      statusCode: 200,
+      on: vi.fn(),
+    } as unknown as Response;
+    const mockNext = vi.fn();
+
+    loggingAnomalyMiddleware(mockReq, mockRes, mockNext);
+
+    expect(mockRes.on).toHaveBeenCalledWith("finish", expect.any(Function));
+  });
+
+  it("does not call next again from the finish listener", async () => {
+    const mockReq = { method: "GET", path: "/test", ip: "127.0.0.1" } as unknown as Request;
+    const mockNext = vi.fn();
+
+    let finishCallback: () => void;
+    const mockRes = {
+      statusCode: 200,
+      on: vi.fn((event: string, cb: () => void) => {
+        if (event === "finish") {
+          finishCallback = cb;
+        }
+      }),
+    } as unknown as Response;
+
+    loggingAnomalyMiddleware(mockReq, mockRes, mockNext);
+
+    expect(mockNext).toHaveBeenCalledTimes(1);
+
+    // Trigger the finish event
+    finishCallback!();
+    // next should still only have been called once (the initial call)
+    expect(mockNext).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #1749.

Summary of What Has Been Done:
Added vitest unit tests for the loggingAnomaly middleware in server/middleware/loggingAnomaly.ts. Tests cover middleware calling next() immediately, registering the response finish event listener, and verifying next is not called again from the finish handler.

Changes Made:
- server/middleware/loggingAnomaly.test.ts: Added 3 test cases for the anomaly logging middleware

Impact it Made:
- Documents expected behavior of anomaly detection middleware
- Ensures finish event listener is properly registered
- 3 tests passing locally

Note: Please assign this PR to the `tmdeveloper007` account.