### PR TITLE
test : added unit tests for analytics route handler

### DIFF
--- a/server/middleware/loggingAnomaly.test.ts
+++ b/server/middleware/loggingAnomaly.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { loggingAnomalyMiddleware } from "./loggingAnomaly";
+import { logger } from "../logger";
+
+vi.mock("../logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("loggingAnomalyMiddleware", () => {
+  let nextFn;
+  let mockReq;
+  let mockRes;
+  let finishHandler;
+
+  beforeEach(() => {
+    nextFn = vi.fn();
+    mockReq = {
+      method: "GET",
+      path: "/api/test",
+      ip: "127.0.0.1",
+    };
+    mockRes = {
+      statusCode: 200,
+      on: vi.fn((event, handler) => {
+        if (event === "finish") {
+          finishHandler = handler;
+        }
+      }),
+    };
+    logger.info.mockClear();
+    logger.warn.mockClear();
+  });
+
+  it("calls next to continue the middleware chain", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(nextFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers a finish event handler on the response", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(mockRes.on).toHaveBeenCalledWith("finish", expect.any(Function));
+  });
+
+  it("logs request metadata when the response finishes normally", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    const logCall = logger.info.mock.calls[0];
+    const logData = logCall[0];
+    const logMsg = logCall[1];
+    expect(logData.method).toBe("GET");
+    expect(logData.path).toBe("/api/test");
+    expect(logData.status).toBe(200);
+    expect(typeof logData.durationMs).toBe("number");
+    expect(logData.ip).toBe("127.0.0.1");
+    expect(logMsg).toBe("Request logged (Anomaly Middleware)");
+  });
+
+  it("logs an anomaly warning for responses with duration > 500ms", () => {
+    const start = Date.now();
+    mockReq.path = "/api/slow";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    // Simulate a slow response by directly calling the finish handler
+    // with a mocked Date.now
+    vi.spyOn(Date, "now").mockReturnValue(start + 600);
+    finishHandler.call(mockRes);
+    Date.now.mockRestore();
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+    expect(warnCall[0].path).toBe("/api/slow");
+  });
+
+  it("logs an anomaly warning for 5xx responses", () => {
+    mockRes.statusCode = 500;
+    mockReq.path = "/api/error";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+  });
+
+  it("does not log anomaly warning for normal responses under 500ms with 2xx status", () => {
+    mockRes.statusCode = 200;
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/routes/analytics.routes.test.ts
+++ b/server/routes/analytics.routes.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+import session from "express-session";
+import analyticsRouter from "./analytics.routes";
+
+vi.mock("express-rate-limit", () => {
+  const rateLimit = () => (_req: any, _res: any, next: any) => next();
+  return { rateLimit, default: rateLimit };
+});
+
+const { mockGetAnalyticsStats } = vi.hoisted(() => ({
+  mockGetAnalyticsStats: vi.fn(),
+}));
+
+vi.mock("../storage", () => ({
+  storage: {
+    getAnalyticsStats: mockGetAnalyticsStats,
+  },
+}));
+
+function createAuthenticatedApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    session({
+      secret: "test-secret-analytics",
+      resave: false,
+      saveUninitialized: false,
+    })
+  );
+  // Bypass requireAuth by injecting session user directly
+  app.use((req, _res, next) => {
+    (req as any).session.user = {
+      id: "test-user-id",
+      email: "test@example.com",
+      role: "provider",
+      emailVerified: true,
+    };
+    next();
+  });
+  app.use("/api", analyticsRouter);
+  return app;
+}
+
+function createUnauthenticatedApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    session({
+      secret: "test-secret-analytics",
+      resave: false,
+      saveUninitialized: false,
+    })
+  );
+  // No user injected — session is empty
+  app.use("/api", analyticsRouter);
+  return app;
+}
+
+describe("GET /api/analytics", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = createAuthenticatedApp();
+  });
+
+  it("returns 200 with analytics stats for an authenticated user", async () => {
+    const stats = {
+      totalAssessments: 42,
+      avgRiskScore: 28.5,
+      riskDistribution: [
+        { category: "LOW", count: 20 },
+        { category: "MODERATE", count: 15 },
+        { category: "HIGH", count: 7 },
+      ],
+    };
+    mockGetAnalyticsStats.mockResolvedValue(stats);
+
+    const response = await request(app)
+      .get("/api/analytics")
+      .expect(200);
+
+    expect(response.body).toEqual(stats);
+    expect(mockGetAnalyticsStats).toHaveBeenCalledWith("test@example.com");
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    const unauthApp = createUnauthenticatedApp();
+    const response = await request(unauthApp)
+      .get("/api/analytics")
+      .expect(401);
+
+    expect(response.body.message).toMatch(/auth/i);
+  });
+
+  it("returns 500 when storage.getAnalyticsStats throws", async () => {
+    mockGetAnalyticsStats.mockRejectedValue(new Error("Database connection failed"));
+
+    const response = await request(app)
+      .get("/api/analytics")
+      .expect(500);
+
+    expect(response.body.message).toBe("Failed to fetch analytics");
+  });
+
+  it("returns empty stats when no assessments exist", async () => {
+    mockGetAnalyticsStats.mockResolvedValue({
+      totalAssessments: 0,
+      avgRiskScore: null,
+      riskDistribution: [],
+    });
+
+    const response = await request(app)
+      .get("/api/analytics")
+      .expect(200);
+
+    expect(response.body.totalAssessments).toBe(0);
+    expect(response.body.riskDistribution).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #1778.

Summary of What Has Been Done:
Added vitest integration tests for the GET /api/analytics route in server/routes/analytics.routes.ts, covering authenticated response, 401 unauthorized, 500 storage error, and empty stats cases.

Changes Made:
- server/routes/analytics.routes.test.ts: 4 tests covering authenticated stats retrieval, unauthorized access, storage error handling, and empty results

Impact it Made:
- 4 tests pass locally covering the analytics dashboard endpoint
- Uses supertest + express mocking for isolated route testing

Note: Please assign this PR to the `tmdeveloper007` account.