### PR TITLE
test : added unit tests for ml bulk prediction route

### DIFF
--- a/server/middleware/loggingAnomaly.test.ts
+++ b/server/middleware/loggingAnomaly.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { loggingAnomalyMiddleware } from "./loggingAnomaly";
+import { logger } from "../logger";
+
+vi.mock("../logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("loggingAnomalyMiddleware", () => {
+  let nextFn;
+  let mockReq;
+  let mockRes;
+  let finishHandler;
+
+  beforeEach(() => {
+    nextFn = vi.fn();
+    mockReq = {
+      method: "GET",
+      path: "/api/test",
+      ip: "127.0.0.1",
+    };
+    mockRes = {
+      statusCode: 200,
+      on: vi.fn((event, handler) => {
+        if (event === "finish") {
+          finishHandler = handler;
+        }
+      }),
+    };
+    logger.info.mockClear();
+    logger.warn.mockClear();
+  });
+
+  it("calls next to continue the middleware chain", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(nextFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers a finish event handler on the response", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(mockRes.on).toHaveBeenCalledWith("finish", expect.any(Function));
+  });
+
+  it("logs request metadata when the response finishes normally", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    const logCall = logger.info.mock.calls[0];
+    const logData = logCall[0];
+    const logMsg = logCall[1];
+    expect(logData.method).toBe("GET");
+    expect(logData.path).toBe("/api/test");
+    expect(logData.status).toBe(200);
+    expect(typeof logData.durationMs).toBe("number");
+    expect(logData.ip).toBe("127.0.0.1");
+    expect(logMsg).toBe("Request logged (Anomaly Middleware)");
+  });
+
+  it("logs an anomaly warning for responses with duration > 500ms", () => {
+    const start = Date.now();
+    mockReq.path = "/api/slow";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    // Simulate a slow response by directly calling the finish handler
+    // with a mocked Date.now
+    vi.spyOn(Date, "now").mockReturnValue(start + 600);
+    finishHandler.call(mockRes);
+    Date.now.mockRestore();
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+    expect(warnCall[0].path).toBe("/api/slow");
+  });
+
+  it("logs an anomaly warning for 5xx responses", () => {
+    mockRes.statusCode = 500;
+    mockReq.path = "/api/error";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+  });
+
+  it("does not log anomaly warning for normal responses under 500ms with 2xx status", () => {
+    mockRes.statusCode = 200;
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/routes/ml.routes.test.ts
+++ b/server/routes/ml.routes.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+import mlRouter from "./ml.routes";
+
+const { mockRunBatch, mockFallback, mockFingerprint, mockCreateBatch, mockActiveRequests } = vi.hoisted(() => ({
+  mockRunBatch: vi.fn(),
+  mockFallback: vi.fn(),
+  mockFingerprint: vi.fn(() => "mock-fingerprint"),
+  mockCreateBatch: vi.fn(),
+  mockActiveRequests: new Set<string>(),
+}));
+
+vi.mock("express-rate-limit", () => {
+  const rateLimit = () => (_req: any, _res: any, next: any) => next();
+  return { rateLimit, default: rateLimit };
+});
+
+vi.mock("../services/mlService", () => ({
+  MLService: {
+    runAssessmentInferenceBatch: mockRunBatch,
+    generateRequestFingerprint: mockFingerprint,
+    get activeInferenceRequests() {
+      return mockActiveRequests;
+    },
+  },
+  calculateClinicalFallback: mockFallback,
+}));
+
+vi.mock("../storage", () => ({
+  storage: {
+    createAssessmentsBatch: mockCreateBatch,
+  },
+}));
+
+vi.mock("../middleware/validateDTO", () => ({
+  validateDTO: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+const validAssessment = {
+  patientName: "John Doe",
+  gender: "Male",
+  age: 45,
+  hypertension: false,
+  heartDisease: false,
+  smokingHistory: "never",
+  bmi: 24.5,
+  hba1cLevel: 5.2,
+  bloodGlucoseLevel: 95,
+};
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req.session = { user: { id: "test-user-id", email: "test@example.com", role: "provider", emailVerified: true } };
+    next();
+  });
+  app.use("/ml", mlRouter);
+  return app;
+}
+
+describe("POST /ml/bulk", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveRequests.clear();
+  });
+
+  it("returns 201 with created assessments on successful batch processing", async () => {
+    mockRunBatch.mockResolvedValue({
+      predictions: [
+        { riskScore: 15.0, riskCategory: "LOW", factors: [], confidenceInterval: "10-20", modelConfidence: 0.9 },
+        { riskScore: 65.0, riskCategory: "HIGH", factors: [], confidenceInterval: "55-75", modelConfidence: 0.8 },
+      ],
+    });
+    mockFingerprint.mockReturnValue("unique-fingerprint-123");
+    mockCreateBatch.mockResolvedValue([{ id: 1 }, { id: 2 }]);
+
+    const response = await request(createApp())
+      .post("/ml/bulk")
+      .send({ assessments: [validAssessment, { ...validAssessment, age: 55 }] })
+      .expect(201);
+
+    expect(response.body.count).toBe(2);
+    expect(response.body.batchId).toBeDefined();
+    expect(mockRunBatch).toHaveBeenCalled();
+    expect(mockCreateBatch).toHaveBeenCalled();
+  });
+
+  it("returns 400 when assessments array is empty", async () => {
+    const response = await request(createApp())
+      .post("/ml/bulk")
+      .send({ assessments: [] })
+      .expect(400);
+
+    expect(response.body.message).toMatch(/empty/i);
+  });
+
+  it("returns 409 when the same fingerprint is already processing", async () => {
+    mockFingerprint.mockReturnValue("duplicate-fingerprint");
+    mockActiveRequests.add("duplicate-fingerprint");
+
+    const response = await request(createApp())
+      .post("/ml/bulk")
+      .send({ assessments: [validAssessment] })
+      .expect(409);
+
+    expect(response.body.message).toMatch(/already processing/i);
+  });
+
+  it("returns 201 with fallback predictions when ML service throws", async () => {
+    mockFingerprint.mockReturnValue("fallback-fingerprint");
+    mockRunBatch.mockRejectedValue(new Error("Python daemon unavailable"));
+    mockFallback.mockReturnValue([
+      { riskScore: 20.0, riskCategory: "LOW", factors: [], confidenceInterval: null, modelConfidence: null },
+    ]);
+    mockCreateBatch.mockResolvedValue([{ id: 3 }]);
+
+    const response = await request(createApp())
+      .post("/ml/bulk")
+      .send({ assessments: [validAssessment] })
+      .expect(201);
+
+    expect(response.body.count).toBe(1);
+    expect(mockFallback).toHaveBeenCalled();
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    const unauthApp = express();
+    unauthApp.use(express.json());
+    unauthApp.use("/ml", mlRouter);
+
+    const response = await request(unauthApp)
+      .post("/ml/bulk")
+      .send({ assessments: [validAssessment] })
+      .expect(401);
+
+    expect(response.body.message).toMatch(/auth/i);
+  });
+});


### PR DESCRIPTION
Closes #1779.

Summary of What Has Been Done:
Added vitest integration tests for the POST /ml/bulk batch assessment prediction route in server/routes/ml.routes.ts, covering successful batch creation, empty array validation, duplicate fingerprint detection (409), ML service fallback to clinical rules, and unauthenticated access.

Changes Made:
- server/routes/ml.routes.test.ts: 5 tests covering batch success (201), empty input (400), duplicate fingerprint (409), fallback prediction (201), and unauthenticated access (401)

Impact it Made:
- 5 tests pass locally covering the ML bulk inference endpoint
- Tests the ML-to-clinical-fallback code path

Note: Please assign this PR to the `tmdeveloper007` account.