### PR TITLE
test : added unit tests for patient auth and assessment routes

### DIFF
--- a/server/middleware/loggingAnomaly.test.ts
+++ b/server/middleware/loggingAnomaly.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { loggingAnomalyMiddleware } from "./loggingAnomaly";
+import { logger } from "../logger";
+
+vi.mock("../logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("loggingAnomalyMiddleware", () => {
+  let nextFn;
+  let mockReq;
+  let mockRes;
+  let finishHandler;
+
+  beforeEach(() => {
+    nextFn = vi.fn();
+    mockReq = {
+      method: "GET",
+      path: "/api/test",
+      ip: "127.0.0.1",
+    };
+    mockRes = {
+      statusCode: 200,
+      on: vi.fn((event, handler) => {
+        if (event === "finish") {
+          finishHandler = handler;
+        }
+      }),
+    };
+    logger.info.mockClear();
+    logger.warn.mockClear();
+  });
+
+  it("calls next to continue the middleware chain", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(nextFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers a finish event handler on the response", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(mockRes.on).toHaveBeenCalledWith("finish", expect.any(Function));
+  });
+
+  it("logs request metadata when the response finishes normally", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    const logCall = logger.info.mock.calls[0];
+    const logData = logCall[0];
+    const logMsg = logCall[1];
+    expect(logData.method).toBe("GET");
+    expect(logData.path).toBe("/api/test");
+    expect(logData.status).toBe(200);
+    expect(typeof logData.durationMs).toBe("number");
+    expect(logData.ip).toBe("127.0.0.1");
+    expect(logMsg).toBe("Request logged (Anomaly Middleware)");
+  });
+
+  it("logs an anomaly warning for responses with duration > 500ms", () => {
+    const start = Date.now();
+    mockReq.path = "/api/slow";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    // Simulate a slow response by directly calling the finish handler
+    // with a mocked Date.now
+    vi.spyOn(Date, "now").mockReturnValue(start + 600);
+    finishHandler.call(mockRes);
+    Date.now.mockRestore();
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+    expect(warnCall[0].path).toBe("/api/slow");
+  });
+
+  it("logs an anomaly warning for 5xx responses", () => {
+    mockRes.statusCode = 500;
+    mockReq.path = "/api/error";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+  });
+
+  it("does not log anomaly warning for normal responses under 500ms with 2xx status", () => {
+    mockRes.statusCode = 200;
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/routes/patient.routes.test.ts
+++ b/server/routes/patient.routes.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+import patientRouter from "./patient.routes";
+
+// ALL mock functions must be defined via vi.hoisted before vi.mock calls
+const {
+  mockGetPatientUserByEmail,
+  mockGetPatientUserByPatientName,
+  mockCreatePatientUser,
+  mockGetPatientUserById,
+  mockGetAssessmentsByPatientName,
+  mockGetPatientTrends,
+  mockIssueToken,
+  mockVerifyToken,
+  mockHashSync,
+  mockCompareSync,
+} = vi.hoisted(() => ({
+  mockGetPatientUserByEmail: vi.fn(),
+  mockGetPatientUserByPatientName: vi.fn(),
+  mockCreatePatientUser: vi.fn(),
+  mockGetPatientUserById: vi.fn(),
+  mockGetAssessmentsByPatientName: vi.fn(),
+  mockGetPatientTrends: vi.fn(),
+  mockIssueToken: vi.fn(() => "mock-jwt-token"),
+  mockVerifyToken: vi.fn(() => ({ valid: true, payload: { sub: "patient-1", email: "test@test.com", role: "PATIENT" } })),
+  mockHashSync: vi.fn(() => "hashed_password"),
+  mockCompareSync: vi.fn(() => true),
+}));
+
+vi.mock("express-rate-limit", () => {
+  const rateLimit = () => (_req: any, _res: any, next: any) => next();
+  return { rateLimit, default: rateLimit };
+});
+
+vi.mock("../storage", () => ({
+  storage: {
+    getPatientUserByEmail: mockGetPatientUserByEmail,
+    getPatientUserByPatientName: mockGetPatientUserByPatientName,
+    createPatientUser: mockCreatePatientUser,
+    getPatientUserById: mockGetPatientUserById,
+    getAssessmentsByPatientName: mockGetAssessmentsByPatientName,
+    getPatientTrends: mockGetPatientTrends,
+  },
+}));
+
+vi.mock("bcrypt", () => ({
+  default: { hashSync: mockHashSync, compareSync: mockCompareSync },
+  hashSync: mockHashSync,
+  compareSync: mockCompareSync,
+}));
+
+vi.mock("../services/auth/tokenValidator", () => ({
+  issueToken: mockIssueToken,
+  verifyToken: mockVerifyToken,
+}));
+
+function makeApp(authHeader?: string) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res, next) => {
+    if (authHeader) {
+      req.headers.authorization = authHeader;
+    }
+    next();
+  });
+  app.use("/patient-portal", patientRouter);
+  return app;
+}
+
+describe("POST /patient-portal/auth/register", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("returns 201 with token on valid registration", async () => {
+    mockGetPatientUserByEmail.mockResolvedValue(null);
+    mockGetPatientUserByPatientName.mockResolvedValue(null);
+    mockCreatePatientUser.mockResolvedValue({
+      id: "patient-1", patientName: "John Doe", email: "john@example.com", isActive: true, emailVerified: true,
+    });
+
+    const res = await request(makeApp())
+      .post("/patient-portal/auth/register")
+      .send({ patientName: "John Doe", email: "john@example.com", password: "secret123" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.token).toBe("mock-jwt-token");
+  });
+
+  it("returns 409 when email already exists", async () => {
+    mockGetPatientUserByEmail.mockResolvedValue({ id: "existing", email: "john@example.com" });
+
+    const res = await request(makeApp())
+      .post("/patient-portal/auth/register")
+      .send({ patientName: "John Doe", email: "john@example.com", password: "secret123" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.message).toMatch(/email/i);
+  });
+
+  it("returns 400 for invalid email", async () => {
+    const res = await request(makeApp())
+      .post("/patient-portal/auth/register")
+      .send({ patientName: "John", email: "not-an-email", password: "secret123" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for short password", async () => {
+    const res = await request(makeApp())
+      .post("/patient-portal/auth/register")
+      .send({ patientName: "John", email: "john@example.com", password: "12345" });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /patient-portal/auth/login", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("returns 200 with token on valid credentials", async () => {
+    mockGetPatientUserByEmail.mockResolvedValue({
+      id: "patient-1", patientName: "Jane Doe", email: "jane@example.com", passwordHash: "hashed", isActive: true,
+    });
+
+    const res = await request(makeApp())
+      .post("/patient-portal/auth/login")
+      .send({ email: "jane@example.com", password: "correctpassword" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it("returns 401 on invalid credentials", async () => {
+    mockGetPatientUserByEmail.mockResolvedValue(null);
+
+    const res = await request(makeApp())
+      .post("/patient-portal/auth/login")
+      .send({ email: "nobody@example.com", password: "wrongpassword" });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for deactivated account", async () => {
+    mockGetPatientUserByEmail.mockResolvedValue({ id: "patient-1", isActive: false });
+
+    const res = await request(makeApp())
+      .post("/patient-portal/auth/login")
+      .send({ email: "deactivated@example.com", password: "password" });
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("GET /patient-portal/auth/me", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("returns 200 with user info for authenticated patient", async () => {
+    mockGetPatientUserById.mockResolvedValue({ id: "patient-1", patientName: "John Doe", email: "john@example.com" });
+
+    const res = await request(makeApp("Bearer patient-token"))
+      .get("/patient-portal/auth/me");
+
+    expect(res.status).toBe(200);
+    expect(res.body.user).toBeDefined();
+  });
+
+  it("returns 404 when user not found", async () => {
+    mockGetPatientUserById.mockResolvedValue(null);
+
+    const res = await request(makeApp("Bearer patient-token"))
+      .get("/patient-portal/auth/me");
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const res = await request(makeApp())
+      .get("/patient-portal/auth/me");
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /patient-portal/assessments", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("returns 200 with assessments for authenticated patient", async () => {
+    mockGetPatientUserById.mockResolvedValue({ id: "patient-1", patientName: "John" });
+    mockGetAssessmentsByPatientName.mockResolvedValue([{ id: 1, riskScore: 25 }]);
+
+    const res = await request(makeApp("Bearer patient-token"))
+      .get("/patient-portal/assessments");
+
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 404 when patient not found", async () => {
+    mockGetPatientUserById.mockResolvedValue(null);
+
+    const res = await request(makeApp("Bearer patient-token"))
+      .get("/patient-portal/assessments");
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /patient-portal/trends", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("returns 200 with patient trends", async () => {
+    mockGetPatientUserById.mockResolvedValue({ id: "patient-1", patientName: "John" });
+    mockGetPatientTrends.mockResolvedValue({ hba1cTrend: "stable" });
+
+    const res = await request(makeApp("Bearer patient-token"))
+      .get("/patient-portal/trends");
+
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 404 when patient not found", async () => {
+    mockGetPatientUserById.mockResolvedValue(null);
+
+    const res = await request(makeApp("Bearer patient-token"))
+      .get("/patient-portal/trends");
+
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
Closes #1780.

Summary of What Has Been Done:
Added vitest integration tests for patient-facing routes in server/routes/patient.routes.ts covering registration, login, /auth/me, /assessments, and /trends endpoints.

Changes Made:
- server/routes/patient.routes.test.ts: 14 tests covering registration (201/409/400), login (200/401/403), authenticated me endpoint (200/404/401), assessments listing (200/404), and trends endpoint (200/404)

Impact it Made:
- 14 tests pass locally covering the complete patient portal API surface
- Tests use supertest + express mocking for isolated route testing

Note: Please assign this PR to the `tmdeveloper007` account.