### PR TITLE
test : added unit tests for seedDatabase function

### DIFF
--- a/server/middleware/loggingAnomaly.test.ts
+++ b/server/middleware/loggingAnomaly.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { loggingAnomalyMiddleware } from "./loggingAnomaly";
+import { logger } from "../logger";
+
+vi.mock("../logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("loggingAnomalyMiddleware", () => {
+  let nextFn;
+  let mockReq;
+  let mockRes;
+  let finishHandler;
+
+  beforeEach(() => {
+    nextFn = vi.fn();
+    mockReq = {
+      method: "GET",
+      path: "/api/test",
+      ip: "127.0.0.1",
+    };
+    mockRes = {
+      statusCode: 200,
+      on: vi.fn((event, handler) => {
+        if (event === "finish") {
+          finishHandler = handler;
+        }
+      }),
+    };
+    logger.info.mockClear();
+    logger.warn.mockClear();
+  });
+
+  it("calls next to continue the middleware chain", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(nextFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers a finish event handler on the response", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(mockRes.on).toHaveBeenCalledWith("finish", expect.any(Function));
+  });
+
+  it("logs request metadata when the response finishes normally", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    const logCall = logger.info.mock.calls[0];
+    const logData = logCall[0];
+    const logMsg = logCall[1];
+    expect(logData.method).toBe("GET");
+    expect(logData.path).toBe("/api/test");
+    expect(logData.status).toBe(200);
+    expect(typeof logData.durationMs).toBe("number");
+    expect(logData.ip).toBe("127.0.0.1");
+    expect(logMsg).toBe("Request logged (Anomaly Middleware)");
+  });
+
+  it("logs an anomaly warning for responses with duration > 500ms", () => {
+    const start = Date.now();
+    mockReq.path = "/api/slow";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    // Simulate a slow response by directly calling the finish handler
+    // with a mocked Date.now
+    vi.spyOn(Date, "now").mockReturnValue(start + 600);
+    finishHandler.call(mockRes);
+    Date.now.mockRestore();
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+    expect(warnCall[0].path).toBe("/api/slow");
+  });
+
+  it("logs an anomaly warning for 5xx responses", () => {
+    mockRes.statusCode = 500;
+    mockReq.path = "/api/error";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+  });
+
+  it("does not log anomaly warning for normal responses under 500ms with 2xx status", () => {
+    mockRes.statusCode = 200;
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/utils/seed.test.ts
+++ b/server/utils/seed.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { seedDatabase } from "./seed";
+
+const { mockGetAssessments, mockCreateAssessment, mockLoggerInfo } = vi.hoisted(() => ({
+  mockGetAssessments: vi.fn(),
+  mockCreateAssessment: vi.fn(),
+  mockLoggerInfo: vi.fn(),
+}));
+
+vi.mock("../storage", () => ({
+  storage: {
+    getAssessments: mockGetAssessments,
+    createAssessment: mockCreateAssessment,
+  },
+}));
+
+vi.mock("../logger", () => ({
+  logger: {
+    info: mockLoggerInfo,
+  },
+}));
+
+describe("seedDatabase", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips seeding when assessments already exist", async () => {
+    mockGetAssessments.mockResolvedValue({ data: [{ id: 1 }] });
+
+    await seedDatabase();
+
+    expect(mockCreateAssessment).not.toHaveBeenCalled();
+    expect(mockGetAssessments).toHaveBeenCalledWith(1);
+  });
+
+  it("seeds when storage returns { data: [] } (empty object)", async () => {
+    // { data: [] } means no existing records, seed should run
+    mockGetAssessments.mockResolvedValue({ data: [] });
+    mockCreateAssessment.mockResolvedValue({ id: 1 });
+
+    await seedDatabase();
+
+    expect(mockCreateAssessment).toHaveBeenCalledTimes(2);
+  });
+
+  it("seeds when storage returns null (falls back to empty)", async () => {
+    // null: .data is undefined, Array.isArray(null) is false, so existingData = []
+    mockGetAssessments.mockResolvedValue(null);
+    mockCreateAssessment.mockResolvedValue({ id: 1 });
+
+    await seedDatabase();
+
+    expect(mockCreateAssessment).toHaveBeenCalledTimes(2);
+  });
+
+  it("creates two seed assessments when no assessments exist", async () => {
+    mockGetAssessments.mockResolvedValue({ data: [] });
+    mockCreateAssessment.mockResolvedValue({ id: 1 });
+
+    await seedDatabase();
+
+    expect(mockCreateAssessment).toHaveBeenCalledTimes(2);
+    expect(mockGetAssessments).toHaveBeenCalledWith(1);
+  });
+
+  it("creates seed assessments with correct properties", async () => {
+    mockGetAssessments.mockResolvedValue({ data: [] });
+    mockCreateAssessment.mockResolvedValue({ id: 1 });
+
+    await seedDatabase();
+
+    const firstCall = mockCreateAssessment.mock.calls[0][0];
+    expect(firstCall.patientName).toBe("John Doe");
+    expect(firstCall.gender).toBe("Male");
+    expect(firstCall.riskCategory).toBe("LOW");
+    expect(firstCall.confidenceInterval).toBe("8.5% - 16.1%");
+    expect(firstCall.modelConfidence).toBeCloseTo(0.877);
+
+    const secondCall = mockCreateAssessment.mock.calls[1][0];
+    expect(secondCall.patientName).toBe("Mary Johnson");
+    expect(secondCall.gender).toBe("Female");
+    expect(secondCall.riskCategory).toBe("MODERATE");
+  });
+
+  it("logs seeding start and completion messages", async () => {
+    mockGetAssessments.mockResolvedValue({ data: [] });
+    mockCreateAssessment.mockResolvedValue({ id: 1 });
+
+    await seedDatabase();
+
+    expect(mockLoggerInfo).toHaveBeenCalledWith("Seeding database with sample assessments...");
+    expect(mockLoggerInfo).toHaveBeenCalledWith("Seeding complete!");
+  });
+
+  it("seeds with the correct seed user email", async () => {
+    mockGetAssessments.mockResolvedValue({ data: [] });
+    mockCreateAssessment.mockResolvedValue({ id: 1 });
+
+    await seedDatabase();
+
+    const firstCall = mockCreateAssessment.mock.calls[0][0];
+    expect(firstCall.createdBy).toBe("seed@clinical-insight-engine.dev");
+  });
+
+  it("seeds when storage returns plain empty array", async () => {
+    // Plain []: existingData = [] (Array.isArray is true, but .data is undefined so falls through to [])
+    mockGetAssessments.mockResolvedValue([]);
+    mockCreateAssessment.mockResolvedValue({ id: 1 });
+
+    await seedDatabase();
+
+    expect(mockCreateAssessment).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Closes #1781.

Summary of What Has Been Done:
Added vitest unit tests for the seedDatabase async function in server/utils/seed.ts, covering idempotency checks (skips when assessments exist), correct seeding behavior for empty/null/plain-array storage responses, seed data properties, logging, and the seed user email.

Changes Made:
- server/utils/seed.test.ts: 8 tests covering idempotency, empty storage responses, seed data validation, logging, and edge cases

Impact it Made:
- 8 tests pass locally covering database seeding logic

Note: Please assign this PR to the `tmdeveloper007` account.