### PR TITLE
fix : added ignoreDeprecations 6.0 to tsconfig.json for TypeScript 6 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "moduleResolution": "bundler",
 
     "types": ["node", "vite/client", "vitest/globals", "@testing-library/jest-dom"],
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
 
     "paths": {


### PR DESCRIPTION
Closes #1803.

Summary of What Has Been Done:
TypeScript was upgraded to 6.0.3 in upstream PR #1739. TypeScript 6.0 deprecated the baseUrl compiler option, causing the CI quality gate to fail with TS5101 on every fork pull request. Added ignoreDeprecations: "6.0" to tsconfig.json compilerOptions to suppress this deprecation error.

Changes Made:
- tsconfig.json: added "ignoreDeprecations": "6.0" above the existing baseUrl option

Impact it Made:
- Unblocks all open fork PRs that are stuck in CI due to this pre-existing TS5101 error
- Allows the Continuous Integration Pipeline / quality gate to pass for all contributors

Note: Please assign this PR to the `tmdeveloper007` account.