### PR TITLE
test : added unit tests for sanitize utility

### DIFF
--- a/server/utils/sanitize.test.ts
+++ b/server/utils/sanitize.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeHtml } from "./sanitize";
+
+describe("sanitizeHtml", () => {
+  it("removes simple HTML tags", () => {
+    expect(sanitizeHtml("<script>alert('xss')</script>")).toBe("alert('xss')");
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(sanitizeHtml("Hello, World!")).toBe("Hello, World!");
+  });
+
+  it("removes anchor tags and preserves link text", () => {
+    expect(sanitizeHtml('<a href="http://evil.com">Click here</a>')).toBe("Click here");
+  });
+
+  it("removes img tags", () => {
+    expect(sanitizeHtml('<img src="x" onerror="alert(1)">')).toBe("");
+  });
+
+  it("handles nested HTML tags", () => {
+    expect(sanitizeHtml("<div><p>Paragraph <strong>text</strong></p></div>")).toBe(
+      "Paragraph text"
+    );
+  });
+
+  it("handles empty string", () => {
+    expect(sanitizeHtml("")).toBe("");
+  });
+
+  it("handles self-closing tags", () => {
+    expect(sanitizeHtml("Line 1<br/>Line 2<hr/>")).toBe("Line 1Line 2");
+  });
+
+  it("handles XSS event handlers", () => {
+    expect(sanitizeHtml('<img onload="alert(document.cookie)">')).toBe("");
+    expect(sanitizeHtml('<div onmouseover="alert(1)">Hover me</div>')).toBe("Hover me");
+  });
+
+  it("handles unclosed tags", () => {
+    expect(sanitizeHtml("<p>Unclosed")).toBe("Unclosed");
+  });
+});


### PR DESCRIPTION
Closes #1805.

Summary of What Has Been Done:
Added 9 vitest unit tests for server/utils/sanitize.ts covering: basic HTML tag removal, plain text passthrough, anchor tag stripping, event handler removal (onload, onmouseover), self-closing tags, nested HTML, empty string, and unclosed tags.

Changes Made:
- server/utils/sanitize.test.ts: new test file with 9 test cases

Impact it Made:
- All 9 tests pass (6ms, 1 test file)
- npm run lint passes
- No new TypeScript errors introduced

Note: Please assign this PR to the `tmdeveloper007` account.