### PR TITLE
test : added unit tests for asyncHandler middleware

### DIFF
--- a/server/utils/asyncHandler.test.ts
+++ b/server/utils/asyncHandler.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { asyncHandler } from "./asyncHandler";
+
+describe("asyncHandler", () => {
+  it("calls the wrapped function with req, res, next", async () => {
+    const mockFn = vi.fn().mockResolvedValue(undefined);
+    const mockReq = {};
+    const mockRes = {};
+    const mockNext = vi.fn();
+
+    const handler = asyncHandler(mockFn);
+    await handler(mockReq, mockRes, mockNext);
+
+    expect(mockFn).toHaveBeenCalledWith(mockReq, mockRes, mockNext);
+  });
+
+  it("does not call next when the wrapped function resolves", async () => {
+    const mockFn = vi.fn().mockResolvedValue(undefined);
+    const mockNext = vi.fn();
+
+    const handler = asyncHandler(mockFn);
+    await handler({}, {}, mockNext);
+
+    expect(mockNext).not.toHaveBeenCalled();
+  });
+
+  it("forwards rejection to next", async () => {
+    const testError = new Error("async error");
+    const mockFn = vi.fn().mockRejectedValue(testError);
+    const mockNext = vi.fn();
+
+    const handler = asyncHandler(mockFn);
+    await handler({}, {}, mockNext);
+
+    expect(mockNext).toHaveBeenCalledWith(testError);
+  });
+
+  it("handles non-Error rejections", async () => {
+    const mockFn = vi.fn().mockRejectedValue("string error");
+    const mockNext = vi.fn();
+
+    const handler = asyncHandler(mockFn);
+    await handler({}, {}, mockNext);
+
+    expect(mockNext).toHaveBeenCalledWith("string error");
+  });
+});


### PR DESCRIPTION
Closes #1806.

Summary of What Has Been Done:
Added 4 vitest unit tests for server/utils/asyncHandler.ts covering: function invocation with req/res/next, no-op on resolved promise, async rejection forwarding to next(), and non-Error rejection handling.

Changes Made:
- server/utils/asyncHandler.test.ts: new test file with 4 test cases

Impact it Made:
- All 4 tests pass (8ms)
- npm run lint passes
- No new TypeScript errors introduced

Note: Please assign this PR to the `tmdeveloper007` account.