### PR TITLE
test : added vitest unit tests for rlsContext middleware

### DIFF
--- a/server/middleware/rlsContext.test.ts
+++ b/server/middleware/rlsContext.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { Request, Response } from "express";
+import { rlsContextMiddleware } from "./rlsContext";
+
+vi.mock("../db-rls", () => ({
+  createRlsClient: vi.fn().mockResolvedValue({
+    client: {
+      release: vi.fn(),
+    },
+    db: {},
+  }),
+  runWithRlsDb: vi.fn((_db, next) => next()),
+}));
+
+vi.mock("../db", () => ({
+  getDb: vi.fn().mockReturnValue({
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ patientName: "Test Patient" }]),
+        }),
+      }),
+    }),
+  }),
+}));
+
+vi.mock("@shared/schema", () => ({
+  patientUsers: {},
+}));
+
+vi.mock("../services/auth/tokenValidator", () => ({
+  verifyToken: vi.fn().mockReturnValue({ valid: false, payload: null }),
+}));
+
+import { createRlsClient, runWithRlsDb } from "../db-rls";
+import { verifyToken } from "../services/auth/tokenValidator";
+
+describe("rlsContextMiddleware", () => {
+  let mockReq: Partial<Request>;
+  let finishListeners: Array<() => void>;
+  let closeListeners: Array<() => void>;
+  let mockRes: Partial<Response>;
+  let nextFn: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    finishListeners = [];
+    closeListeners = [];
+    nextFn = vi.fn();
+
+    mockReq = {
+      session: undefined,
+      jwtUser: undefined,
+      headers: {},
+      authenticatedUser: undefined,
+    };
+
+    mockRes = {
+      on: vi.fn((event: string, listener: () => void) => {
+        if (event === "finish") finishListeners.push(listener);
+        if (event === "close") closeListeners.push(listener);
+        return mockRes as Response;
+      }),
+      onAll: vi.fn(),
+      removeListener: vi.fn(),
+    };
+
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useFakeTimers();
+    vi.runAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("resolves context from session user", async () => {
+    mockReq.session = {
+      user: { id: "user-1", email: "doc@hospital.org", role: "provider" },
+    } as any;
+
+    await rlsContextMiddleware(mockReq as Request, mockRes as Response, nextFn);
+
+    expect(createRlsClient).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-1", email: "doc@hospital.org" })
+    );
+    expect(runWithRlsDb).toHaveBeenCalled();
+    expect(nextFn).toHaveBeenCalled();
+  });
+
+  it("resolves context from jwtUser on request", async () => {
+    mockReq.jwtUser = {
+      sub: "jwt-user-2",
+      email: "nurse@hospital.org",
+      role: "provider",
+    };
+
+    await rlsContextMiddleware(mockReq as Request, mockRes as Response, nextFn);
+
+    expect(createRlsClient).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "jwt-user-2" })
+    );
+    expect(runWithRlsDb).toHaveBeenCalled();
+    expect(nextFn).toHaveBeenCalled();
+  });
+
+  it("resolves context from Bearer token in Authorization header", async () => {
+    mockReq.headers = { authorization: "Bearer valid.jwt.token" };
+    (verifyToken as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      valid: true,
+      payload: { sub: "token-user-3", email: "tech@hospital.org", role: "admin" },
+    });
+
+    await rlsContextMiddleware(mockReq as Request, mockRes as Response, nextFn);
+
+    expect(verifyToken).toHaveBeenCalledWith("valid.jwt.token");
+    expect(createRlsClient).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "token-user-3", email: "tech@hospital.org" })
+    );
+    expect(runWithRlsDb).toHaveBeenCalled();
+    expect(nextFn).toHaveBeenCalled();
+  });
+
+  it("does not call createRlsClient for unauthenticated request", async () => {
+    // No session, no jwtUser, no Authorization header, no authenticatedUser
+    await rlsContextMiddleware(mockReq as Request, mockRes as Response, nextFn);
+
+    expect(createRlsClient).not.toHaveBeenCalled();
+    expect(nextFn).toHaveBeenCalledWith();
+  });
+
+  it("skips invalid Bearer token without throwing", async () => {
+    mockReq.headers = { authorization: "Bearer invalid.token" };
+    (verifyToken as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      valid: false,
+      payload: null,
+    });
+
+    await rlsContextMiddleware(mockReq as Request, mockRes as Response, nextFn);
+
+    expect(createRlsClient).not.toHaveBeenCalled();
+    expect(nextFn).toHaveBeenCalled();
+  });
+
+  it("attaches cleanup handlers to res.on finish and close", async () => {
+    mockReq.session = {
+      user: { id: "user-1", email: "doc@hospital.org" },
+    } as any;
+
+    await rlsContextMiddleware(mockReq as Request, mockRes as Response, nextFn);
+
+    expect(mockRes.on).toHaveBeenCalledWith("finish", expect.any(Function));
+    expect(mockRes.on).toHaveBeenCalledWith("close", expect.any(Function));
+  });
+});


### PR DESCRIPTION
Closes #1867.

Summary of What Has Been Done:
Added vitest tests for server/middleware/rlsContext.ts covering the RLS context resolution chain. Tests verify context is correctly resolved from Express session, jwtUser on request, Bearer token in Authorization header, and that unauthenticated requests pass through without creating an RLS context. Cleanup handlers attached to res.on(finish) and res.on(close) are also verified. All 6 tests pass.

Changes Made:
- server/middleware/rlsContext.test.ts (new file): 154 lines

Impact it Made:
- Guards Row-Level Security context setup for cross-user data protection
- Increases server test coverage for critical RLS security middleware
- Verified: ./node_modules/.bin/vitest run server/middleware/rlsContext.test.ts (6 passed)

Note: Please assign this PR to the `tmdeveloper007` account.