### PR TITLE
fix(queue): persist permanently failed BullMQ jobs to dead letter queue

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
     "email_verification_tokens",
     "model_versions",
     "patient_users",
-    "patient_access_audit_logs"
+    "patient_access_audit_logs",
+    "dead_letter_jobs"
   ],
 });

--- a/migrations/0005_flawless_lockheed.sql
+++ b/migrations/0005_flawless_lockheed.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "dead_letter_jobs" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"original_job_id" text,
+	"payload" jsonb NOT NULL,
+	"error_reason" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);

--- a/migrations/meta/0005_snapshot.json
+++ b/migrations/meta/0005_snapshot.json
@@ -1,0 +1,996 @@
+{
+  "id": "825f77e6-6ce7-4727-b434-0fd7139fbc7f",
+  "prevId": "d9289f6f-98b7-4445-b6b3-102f4a3cc8a0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.assessment_notes": {
+      "name": "assessment_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assessment_id": {
+          "name": "assessment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section": {
+          "name": "section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "assessment_notes_assessment_id_assessments_id_fk": {
+          "name": "assessment_notes_assessment_id_assessments_id_fk",
+          "tableFrom": "assessment_notes",
+          "tableTo": "assessments",
+          "columnsFrom": [
+            "assessment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assessment_notes_user_id_users_id_fk": {
+          "name": "assessment_notes_user_id_users_id_fk",
+          "tableFrom": "assessment_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assessments": {
+      "name": "assessments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "patient_name": {
+          "name": "patient_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hypertension": {
+          "name": "hypertension",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heart_disease": {
+          "name": "heart_disease",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "smoking_history": {
+          "name": "smoking_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bmi": {
+          "name": "bmi",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hba1c_level": {
+          "name": "hba1c_level",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blood_glucose_level": {
+          "name": "blood_glucose_level",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "insulin": {
+          "name": "insulin",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skin_thickness": {
+          "name": "skin_thickness",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "risk_category": {
+          "name": "risk_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "factors": {
+          "name": "factors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence_interval": {
+          "name": "confidence_interval",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_confidence": {
+          "name": "model_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_note": {
+          "name": "clinical_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explainable_insights": {
+          "name": "explainable_insights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "created_by_id_idx": {
+          "name": "created_by_id_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "owner_id_idx": {
+          "name": "owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assessments_owner_id_users_id_fk": {
+          "name": "assessments_owner_id_users_id_fk",
+          "tableFrom": "assessments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dead_letter_jobs": {
+      "name": "dead_letter_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "original_job_id": {
+          "name": "original_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_reason": {
+          "name": "error_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_code": {
+          "name": "verification_code",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_verification_tokens_user_id_users_id_fk": {
+          "name": "email_verification_tokens_user_id_users_id_fk",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.login_audit_logs": {
+      "name": "login_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_status": {
+          "name": "login_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "login_audit_logs_user_id_users_id_fk": {
+          "name": "login_audit_logs_user_id_users_id_fk",
+          "tableFrom": "login_audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_versions": {
+      "name": "model_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy": {
+          "name": "accuracy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "precision": {
+          "name": "precision",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recall": {
+          "name": "recall",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "f1_score": {
+          "name": "f1_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auc_roc": {
+          "name": "auc_roc",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataset_hash": {
+          "name": "dataset_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_samples": {
+          "name": "num_samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_features": {
+          "name": "num_features",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_balance": {
+          "name": "class_balance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_distributions": {
+          "name": "feature_distributions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "training_duration_ms": {
+          "name": "training_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'completed'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_access_audit_logs": {
+      "name": "patient_access_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted": {
+          "name": "granted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "patient_access_audit_logs_user_id_users_id_fk": {
+          "name": "patient_access_audit_logs_user_id_users_id_fk",
+          "tableFrom": "patient_access_audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_users": {
+      "name": "patient_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_name": {
+          "name": "patient_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "patient_users_patient_name_unique": {
+          "name": "patient_users_patient_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "patient_name"
+          ]
+        },
+        "patient_users_email_unique": {
+          "name": "patient_users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_terms_acceptance": {
+      "name": "user_terms_acceptance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted": {
+          "name": "accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "terms_version": {
+          "name": "terms_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_terms_acceptance_user_id_users_id_fk": {
+          "name": "user_terms_acceptance_user_id_users_id_fk",
+          "tableFrom": "user_terms_acceptance",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "medical_license_number": {
+          "name": "medical_license_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'provider'"
+        },
+        "report_frequency": {
+          "name": "report_frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_medical_license_number_unique": {
+          "name": "users_medical_license_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "medical_license_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1783170278253,
       "tag": "0004_outgoing_vampiro",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1783351717489,
+      "tag": "0005_flawless_lockheed",
+      "breakpoints": true
     }
   ]
 }

--- a/server/queue.test.ts
+++ b/server/queue.test.ts
@@ -42,6 +42,13 @@ vi.mock("ioredis", () => {
   };
 });
 
+vi.mock("./db", () => {
+  return {
+    getPool: vi.fn(),
+    withRetry: vi.fn(async (name, fn) => fn()),
+  };
+});
+
 import {
   isQueueAvailable,
   getAssessmentQueue,
@@ -113,5 +120,75 @@ describe("queue module", () => {
     const conn1 = getRedisConnection();
     const conn2 = getRedisConnection();
     expect(conn1).toBe(conn2);
+  });
+});
+
+describe("worker DLQ handling", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { closeQueue } = await import("./queue");
+    await closeQueue();
+  });
+
+  it("inserts failed job into DLQ when retries are exhausted", async () => {
+    const mockQuery = vi.fn().mockResolvedValue({ rowCount: 1 });
+    const mockRelease = vi.fn();
+    const mockConnect = vi.fn().mockResolvedValue({ query: mockQuery, release: mockRelease });
+    
+    const dbModule = await import("./db");
+    vi.mocked(dbModule.getPool).mockReturnValue({ connect: mockConnect } as any);
+
+    const { startAssessmentWorker, verifyRedisConnection } = await import("./queue");
+    await verifyRedisConnection();
+    startAssessmentWorker();
+
+    const { Worker } = await import("bullmq");
+    const workerMock = vi.mocked(Worker).mock.results[0].value;
+    
+    // Find the 'failed' event handler
+    const failedHandlerCall = workerMock.on.mock.calls.find((call: any[]) => call[0] === "failed");
+    expect(failedHandlerCall).toBeDefined();
+    
+    const failedHandler = failedHandlerCall[1];
+    
+    // Trigger the handler with max retries
+    const mockJob = { id: "test-job-123", data: { foo: "bar" }, attemptsMade: 5 };
+    await failedHandler(mockJob, new Error("ML crashed"));
+    
+    expect(mockConnect).toHaveBeenCalled();
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO dead_letter_jobs"),
+      expect.arrayContaining(["test-job-123", JSON.stringify({ foo: "bar" }), expect.any(String)])
+    );
+    expect(mockRelease).toHaveBeenCalled();
+  });
+
+  it("does NOT insert into DLQ when retries are less than max", async () => {
+    const mockQuery = vi.fn();
+    const mockRelease = vi.fn();
+    const mockConnect = vi.fn().mockResolvedValue({ query: mockQuery, release: mockRelease });
+    
+    const dbModule = await import("./db");
+    vi.mocked(dbModule.getPool).mockReturnValue({ connect: mockConnect } as any);
+
+    const { startAssessmentWorker, verifyRedisConnection } = await import("./queue");
+    await verifyRedisConnection();
+    startAssessmentWorker();
+
+    const { Worker } = await import("bullmq");
+    const workerMock = vi.mocked(Worker).mock.results[0].value;
+    
+    const failedHandlerCall = workerMock.on.mock.calls.find((call: any[]) => call[0] === "failed");
+    expect(failedHandlerCall).toBeDefined();
+    
+    const failedHandler = failedHandlerCall[1];
+    
+    // Trigger with 3 attempts (less than QUEUE_MAX_RETRIES which is 5)
+    const mockJob = { id: "test-job-early-fail", data: {}, attemptsMade: 3 };
+    await failedHandler(mockJob, new Error("Transient network error"));
+    
+    // DB connect/query should NOT be called
+    expect(mockConnect).not.toHaveBeenCalled();
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 });

--- a/server/queue.ts
+++ b/server/queue.ts
@@ -373,12 +373,32 @@ export function startAssessmentWorker(): void {
     }
   );
 
-  assessmentWorkerInstance.on("failed", (job: Job | undefined, err: Error) => {
+  assessmentWorkerInstance.on("failed", async (job: Job | undefined, err: Error) => {
     const attempt = job?.attemptsMade ?? 0;
     logger.error(
       { jobId: job?.id, requestId: job?.data?.requestId, attempt, err },
       `Assessment queue job failed (attempt ${attempt}/${QUEUE_MAX_RETRIES})`,
     );
+
+    if (job && attempt >= QUEUE_MAX_RETRIES) {
+      try {
+        await withRetry("worker.insertDLQ", async () => {
+          const pool = getPool();
+          const client = await pool.connect();
+          try {
+            await client.query(
+              `INSERT INTO dead_letter_jobs (original_job_id, payload, error_reason) VALUES ($1, $2, $3)`,
+              [job.id ?? null, JSON.stringify(job.data), err.stack || err.message]
+            );
+          } finally {
+            client.release();
+          }
+        }, 3, 500, 2);
+        logger.info({ jobId: job.id }, "Moved failed job to dead_letter_jobs (DLQ)");
+      } catch (dlqErr) {
+        logger.error({ err: dlqErr, jobId: job.id }, "Failed to write to dead letter queue");
+      }
+    }
   });
 
   assessmentWorkerInstance.on("completed", (job: Job | undefined) => {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -225,3 +225,14 @@ export const insertUserSchema = z.object({
 
 export type User = typeof users.$inferSelect;
 export type InsertUser = z.infer<typeof insertUserSchema>;
+
+export const deadLetterJobs = pgTable("dead_letter_jobs", {
+  id: serial("id").primaryKey(),
+  originalJobId: text("original_job_id"),
+  payload: jsonb("payload").notNull(),
+  errorReason: text("error_reason"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+export type DeadLetterJob = typeof deadLetterJobs.$inferSelect;
+export type InsertDeadLetterJob = typeof deadLetterJobs.$inferInsert;


### PR DESCRIPTION
## Description

This PR fixes Issue #1897 by introducing a durable **Dead Letter Queue (DLQ)** mechanism for BullMQ assessment jobs.

Previously, jobs that exhausted all retry attempts were only logged and retained temporarily in BullMQ's failed set before being automatically removed according to the configured `removeOnFail` policy. This made it difficult to inspect or recover permanently failed assessment jobs. 

This implementation persists permanently failed jobs to a dedicated PostgreSQL table, allowing failures to be retained for debugging and future recovery while leaving the normal processing path unchanged.

## Related Issue

Closes #1897

## Type of Change

* [x] 🐛 Bug fix (non-breaking change that fixes an issue)
* [x] 🧪 Test addition or update

## Changes Made

* Added a new `dead_letter_jobs` table using Drizzle ORM to persist permanently failed jobs.
* Added the corresponding database migration and updated Drizzle migration metadata.
* Updated the BullMQ worker to persist jobs only after all retry attempts have been exhausted.
* Preserved the existing retry behavior and successful job processing flow.
* Added unit tests covering:

  * DLQ insertion after maximum retries are exhausted.
  * No DLQ insertion for transient failures before the retry limit.

## Screenshots (if applicable)

N/A

## Testing

* [x] I have tested these changes locally
* [x] I have added/updated tests where applicable
* [x] All existing tests pass

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my own code
* [x] I have commented my code where necessary
* [x] I have updated the documentation if needed
* [x] My changes generate no new warnings or errors
