### PR TITLE
test : added unit tests for sanitizeHtml utility

### DIFF
--- a/server/utils/sanitize.test.ts
+++ b/server/utils/sanitize.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeHtml } from "./sanitize";
+
+describe("sanitizeHtml", () => {
+  it("returns empty string for empty input", () => {
+    expect(sanitizeHtml("")).toBe("");
+  });
+
+  it("returns string unchanged when no HTML tags present", () => {
+    expect(sanitizeHtml("Hello, this is plain text.")).toBe(
+      "Hello, this is plain text."
+    );
+  });
+
+  it("removes a simple open tag", () => {
+    expect(sanitizeHtml("Hello <b>world</b>")).toBe("Hello world");
+  });
+
+  it("removes nested HTML tags", () => {
+    expect(sanitizeHtml("<p>Paragraph with <strong>nested</strong> text</p>")).toBe(
+      "Paragraph with nested text"
+    );
+  });
+
+  it("removes script tags", () => {
+    expect(sanitizeHtml("<script>alert('xss')</script>")).toBe("alert('xss')");
+  });
+
+  it("removes img tags with attributes", () => {
+    expect(sanitizeHtml('Text before <img src="x" onerror="alert(1)"> text after')).toBe(
+      "Text before  text after"
+    );
+  });
+
+  it("removes multiple HTML-like patterns on same line", () => {
+    expect(sanitizeHtml("<b>bold</b> and <i>italic</i> and <u>underline</u>")).toBe(
+      "bold and italic and underline"
+    );
+  });
+
+  it("handles string with only HTML tags", () => {
+    expect(sanitizeHtml("<div></div>")).toBe("");
+  });
+
+  it("removes tag with special characters inside", () => {
+    expect(sanitizeHtml("<span class='test' data-val='1'>content</span>")).toBe(
+      "content"
+    );
+  });
+
+  it("removes tags and keeps surrounding whitespace", () => {
+    expect(sanitizeHtml("  <p>  spaced  </p>  ")).toBe("    spaced    ");
+  });
+
+  it("removes malformed unclosed tags", () => {
+    expect(sanitizeHtml("Text <span>content")).toBe("Text content");
+  });
+
+  it("removes tags with no angle brackets inside", () => {
+    expect(sanitizeHtml("Email: test@example.com and <b>bold</b>")).toBe(
+      "Email: test@example.com and bold"
+    );
+  });
+});


### PR DESCRIPTION
Closes #2049.

Summary of What Has Been Done:
Added vitest unit tests for the sanitizeHtml function which strips HTML tags from user input to prevent XSS. 12 test cases cover empty input, no tags, simple tags, nested tags, script tags, attributes, multiple tags, edge cases, and malformed tags.

Changes Made:
- server/utils/sanitize.test.ts: Added 12 unit tests covering all common and edge cases for HTML tag stripping

Impact it Made:
- 12 passing tests covering sanitizeHtml security utility
- Tests run via npx vitest run server/utils/sanitize.test.ts

Note: Please assign this PR to the `tmdeveloper007` account.