### PR TITLE
fix(auth): hash reset token before database comparison

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -716,6 +716,7 @@ out
     try {
       const db = getDb();
 
+      const tokenHash = createHash("sha256").update(token).digest("hex");
       const passwordHash = hashPassword(newPassword);
 
       await db.transaction(async (tx: any) => {
@@ -724,7 +725,7 @@ out
           .set({ used: true })
           .where(
             and(
-              eq(passwordResetTokens.token, token),
+              eq(passwordResetTokens.token, tokenHash),
               eq(passwordResetTokens.used, false),
               gte(passwordResetTokens.expiresAt, new Date()),
             ),


### PR DESCRIPTION
The forgot-password flow hashes the reset token with SHA-256 before storing it in the database, but the reset-password endpoint compared the raw token from the request body directly against the stored hash. This mismatch caused every valid password reset to fail.

Hash the incoming token with the same SHA-256 algorithm before the database lookup so the comparison succeeds. 

## Description

This PR fixes the password reset flow by ensuring the incoming reset token is hashed using SHA-256 before it is compared with the token stored in the database. The change keeps the verification logic consistent with the token generation process and restores successful password resets for valid reset links.

## Related Issue

Closes #2109

## Type of Change

* [x] 🐛 Bug fix (non-breaking change that fixes an issue)
* [ ] ✨ New feature (non-breaking change that adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] 📝 Documentation update
* [ ] 🎨 Style / UI improvement
* [ ] ♻️ Refactor (no functional changes)
* [ ] ⚡ Performance improvement
* [ ] 🧪 Test addition or update
* [ ] 🔧 Chore / Tooling / Config

## Changes Made

* Hash the incoming password reset token using SHA-256 before database lookup.
* Replace raw token comparison with hashed token comparison during password reset validation.
* Preserve the existing password reset flow, token expiration checks, and API responses without introducing breaking changes.

## Screenshots (if applicable)

N/A (Backend authentication fix)

## Testing

* [x] I have tested these changes locally
* [ ] I have added/updated tests where applicable
* [x] All existing tests pass

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my own code
* [x] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings or errors
