### PR TITLE
test : added unit tests for getPythonExecutable in mlService

### DIFF
--- a/server/services/mlService.test.ts
+++ b/server/services/mlService.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockExistsSync = vi.fn();
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    existsSync: mockExistsSync,
+  };
+});
+
+describe("getPythonExecutable", () => {
+  beforeEach(() => {
+    mockExistsSync.mockReset();
+  });
+
+  it("returns .venv/bin/python when it exists on linux", async () => {
+    mockExistsSync.mockImplementation((p: string) => p.includes(".venv"));
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const { getPythonExecutable } = await import("./mlService");
+    const result = getPythonExecutable();
+    expect(result).toContain(".venv");
+    expect(result).toContain("bin");
+    expect(result).toContain("python");
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+  });
+
+  it("falls back to python3 when no venv exists on linux", async () => {
+    mockExistsSync.mockReturnValue(false);
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const { getPythonExecutable } = await import("./mlService");
+    const result = getPythonExecutable();
+    expect(result).toBe("python3");
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+  });
+
+  it("returns .venv/Scripts/python.exe when it exists on windows", async () => {
+    mockExistsSync.mockImplementation((p: string) => p.includes(".venv"));
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    const { getPythonExecutable } = await import("./mlService");
+    const result = getPythonExecutable();
+    expect(result).toContain(".venv");
+    expect(result).toContain("Scripts");
+    expect(result).toContain("python.exe");
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+  });
+
+  it("falls back to python when no venv exists on windows", async () => {
+    mockExistsSync.mockReturnValue(false);
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    const { getPythonExecutable } = await import("./mlService");
+    const result = getPythonExecutable();
+    expect(result).toBe("python");
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+  });
+});


### PR DESCRIPTION
Closes #2119.

Summary of What Has Been Done:
Added vitest tests for the getPythonExecutable function in server/services/mlService.ts. Tests cover Python venv path resolution on Linux (.venv/bin/python) and Windows (.venv/Scripts/python.exe), and the fallback to system python3/python when no virtual environment is found.

Changes Made:
- server/services/mlService.test.ts: 4 new test cases

Impact it Made:
- Guards Python ML subprocess launch path against regression
- 4/4 tests pass locally

Note: Please assign this PR to the `tmdeveloper007` account.