### PR TITLE
test : added unit tests for sanitizeHtml utility

### DIFF
--- a/server/utils/sanitize.test.ts
+++ b/server/utils/sanitize.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeHtml } from "./sanitize";
+
+describe("sanitizeHtml", () => {
+  it("strips basic HTML tags", () => {
+    expect(sanitizeHtml("<script>alert('xss')</script>")).toBe("alert('xss')");
+  });
+
+  it("returns string unchanged when no tags present", () => {
+    expect(sanitizeHtml("Hello World")).toBe("Hello World");
+    expect(sanitizeHtml("No tags here")).toBe("No tags here");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(sanitizeHtml("")).toBe("");
+  });
+
+  it("handles nested tags", () => {
+    expect(sanitizeHtml("<div><p>Nested</p></div>")).toBe("Nested");
+  });
+
+  it("handles unclosed tags", () => {
+    expect(sanitizeHtml("Text <b>bold")).toBe("Text bold");
+  });
+
+  it("handles special characters in HTML entities", () => {
+    expect(sanitizeHtml("A &amp; B")).toBe("A &amp; B");
+    expect(sanitizeHtml("5 > 3")).toBe("5 > 3");
+    expect(sanitizeHtml("3 < 5")).toBe("3 < 5");
+  });
+
+  it("handles mixed content", () => {
+    expect(sanitizeHtml("Hello <strong>World</strong>!")).toBe("Hello World!");
+  });
+
+  it("handles self-closing tags", () => {
+    expect(sanitizeHtml("Line1<br/>Line2")).toBe("Line1Line2");
+    expect(sanitizeHtml("HR<hr>below")).toBe("HRbelow");
+  });
+});


### PR DESCRIPTION
Closes #2145.

Summary of What Has Been Done:
Added vitest unit tests for the sanitizeHtml function in server/utils/sanitize.ts. Tests cover HTML tag stripping, empty strings, nested tags, unclosed tags, and special characters.

Changes Made:
- server/utils/sanitize.test.ts: Added 8 test cases for sanitizeHtml

Impact it Made:
Increases server-side test coverage for the HTML sanitization utility, covering basic tags, empty input, nested tags, unclosed tags, and special characters.

Note: Please assign this PR to the `tmdeveloper007` account.