### PR TITLE
test : added unit tests for RBAC role helpers

### DIFF
--- a/server/middleware/loggingAnomaly.test.ts
+++ b/server/middleware/loggingAnomaly.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { loggingAnomalyMiddleware } from "./loggingAnomaly";
+import { logger } from "../logger";
+
+vi.mock("../logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("loggingAnomalyMiddleware", () => {
+  let nextFn;
+  let mockReq;
+  let mockRes;
+  let finishHandler;
+
+  beforeEach(() => {
+    nextFn = vi.fn();
+    mockReq = {
+      method: "GET",
+      path: "/api/test",
+      ip: "127.0.0.1",
+    };
+    mockRes = {
+      statusCode: 200,
+      on: vi.fn((event, handler) => {
+        if (event === "finish") {
+          finishHandler = handler;
+        }
+      }),
+    };
+    logger.info.mockClear();
+    logger.warn.mockClear();
+  });
+
+  it("calls next to continue the middleware chain", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(nextFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers a finish event handler on the response", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(mockRes.on).toHaveBeenCalledWith("finish", expect.any(Function));
+  });
+
+  it("logs request metadata when the response finishes normally", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    const logCall = logger.info.mock.calls[0];
+    const logData = logCall[0];
+    const logMsg = logCall[1];
+    expect(logData.method).toBe("GET");
+    expect(logData.path).toBe("/api/test");
+    expect(logData.status).toBe(200);
+    expect(typeof logData.durationMs).toBe("number");
+    expect(logData.ip).toBe("127.0.0.1");
+    expect(logMsg).toBe("Request logged (Anomaly Middleware)");
+  });
+
+  it("logs an anomaly warning for responses with duration > 500ms", () => {
+    const start = Date.now();
+    mockReq.path = "/api/slow";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    // Simulate a slow response by directly calling the finish handler
+    // with a mocked Date.now
+    vi.spyOn(Date, "now").mockReturnValue(start + 600);
+    finishHandler.call(mockRes);
+    Date.now.mockRestore();
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+    expect(warnCall[0].path).toBe("/api/slow");
+  });
+
+  it("logs an anomaly warning for 5xx responses", () => {
+    mockRes.statusCode = 500;
+    mockReq.path = "/api/error";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+  });
+
+  it("does not log anomaly warning for normal responses under 500ms with 2xx status", () => {
+    mockRes.statusCode = 200;
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/services/authz/rbac.test.ts
+++ b/server/services/authz/rbac.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { hasRole, isAdmin, ROLES } from "./rbac";
+
+describe("ROLES", () => {
+  it("exports ADMIN role", () => {
+    expect(ROLES.ADMIN).toBe("ADMIN");
+  });
+
+  it("exports DOCTOR role", () => {
+    expect(ROLES.DOCTOR).toBe("DOCTOR");
+  });
+
+  it("exports CLINICIAN role", () => {
+    expect(ROLES.CLINICIAN).toBe("CLINICIAN");
+  });
+
+  it("exports STAFF role", () => {
+    expect(ROLES.STAFF).toBe("STAFF");
+  });
+
+  it("exports PATIENT role", () => {
+    expect(ROLES.PATIENT).toBe("PATIENT");
+  });
+
+  it("exports PROVIDER legacy role", () => {
+    expect(ROLES.PROVIDER).toBe("provider");
+  });
+});
+
+describe("hasRole", () => {
+  it("returns true when user has the specified role (uppercase)", () => {
+    const user = { role: "DOCTOR" };
+    expect(hasRole(user, ROLES.DOCTOR)).toBe(true);
+  });
+
+  it("returns false when user lacks the specified role", () => {
+    const user = { role: "PATIENT" };
+    expect(hasRole(user, ROLES.DOCTOR)).toBe(false);
+  });
+
+  it("returns true for ADMIN matching ADMIN role", () => {
+    const user = { role: "ADMIN" };
+    expect(hasRole(user, ROLES.ADMIN)).toBe(true);
+  });
+
+  it("returns false for non-admin role", () => {
+    const user = { role: "ADMIN" };
+    expect(hasRole(user, ROLES.DOCTOR)).toBe(false);
+  });
+
+  it("handles CLINICIAN role correctly", () => {
+    const user = { role: "CLINICIAN" };
+    expect(hasRole(user, ROLES.CLINICIAN)).toBe(true);
+    expect(hasRole(user, ROLES.DOCTOR)).toBe(false);
+  });
+
+  it("is case-insensitive for user role (uppercases internally)", () => {
+    const user = { role: "doctor" };
+    expect(hasRole(user, ROLES.DOCTOR)).toBe(true);
+  });
+
+  it("treats DOCTOR and provider as equivalent (legacy support)", () => {
+    const doctor = { role: "DOCTOR" };
+    const provider = { role: "provider" };
+    expect(hasRole(doctor, ROLES.PROVIDER)).toBe(true);
+    expect(hasRole(provider, ROLES.DOCTOR)).toBe(true);
+  });
+});
+
+describe("isAdmin", () => {
+  it("returns true for ADMIN user", () => {
+    const user = { role: "ADMIN" };
+    expect(isAdmin(user)).toBe(true);
+  });
+
+  it("returns false for DOCTOR", () => {
+    const user = { role: "DOCTOR" };
+    expect(isAdmin(user)).toBe(false);
+  });
+
+  it("returns false for CLINICIAN", () => {
+    const user = { role: "CLINICIAN" };
+    expect(isAdmin(user)).toBe(false);
+  });
+
+  it("returns false for PATIENT", () => {
+    const user = { role: "PATIENT" };
+    expect(isAdmin(user)).toBe(false);
+  });
+
+  it("returns true for admin (case-insensitive)", () => {
+    const user = { role: "admin" };
+    expect(isAdmin(user)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #2182.

Summary of What Has Been Done:
Added vitest unit tests for the RBAC role system in server/services/authz/rbac.ts, covering ROLES constants, hasRole function, and isAdmin helper.

Changes Made:
- Created server/services/authz/rbac.test.ts
- Tested ROLES constant values (admin, doctor, clinician, patient)
- Tested hasRole with valid role membership
- Tested hasRole with invalid role membership
- Tested isAdmin shortcut function for all roles

Impact it Made:
- Guards against role enum changes breaking authorization checks
- Documents expected role strings for future developers

Note: Please assign this PR to the `tmdeveloper007` account.