### PR TITLE
test : added unit tests for FHIR bundle extraction and explainable insights

### DIFF
--- a/server/middleware/loggingAnomaly.test.ts
+++ b/server/middleware/loggingAnomaly.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { loggingAnomalyMiddleware } from "./loggingAnomaly";
+import { logger } from "../logger";
+
+vi.mock("../logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("loggingAnomalyMiddleware", () => {
+  let nextFn;
+  let mockReq;
+  let mockRes;
+  let finishHandler;
+
+  beforeEach(() => {
+    nextFn = vi.fn();
+    mockReq = {
+      method: "GET",
+      path: "/api/test",
+      ip: "127.0.0.1",
+    };
+    mockRes = {
+      statusCode: 200,
+      on: vi.fn((event, handler) => {
+        if (event === "finish") {
+          finishHandler = handler;
+        }
+      }),
+    };
+    logger.info.mockClear();
+    logger.warn.mockClear();
+  });
+
+  it("calls next to continue the middleware chain", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(nextFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers a finish event handler on the response", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(mockRes.on).toHaveBeenCalledWith("finish", expect.any(Function));
+  });
+
+  it("logs request metadata when the response finishes normally", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    const logCall = logger.info.mock.calls[0];
+    const logData = logCall[0];
+    const logMsg = logCall[1];
+    expect(logData.method).toBe("GET");
+    expect(logData.path).toBe("/api/test");
+    expect(logData.status).toBe(200);
+    expect(typeof logData.durationMs).toBe("number");
+    expect(logData.ip).toBe("127.0.0.1");
+    expect(logMsg).toBe("Request logged (Anomaly Middleware)");
+  });
+
+  it("logs an anomaly warning for responses with duration > 500ms", () => {
+    const start = Date.now();
+    mockReq.path = "/api/slow";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    // Simulate a slow response by directly calling the finish handler
+    // with a mocked Date.now
+    vi.spyOn(Date, "now").mockReturnValue(start + 600);
+    finishHandler.call(mockRes);
+    Date.now.mockRestore();
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+    expect(warnCall[0].path).toBe("/api/slow");
+  });
+
+  it("logs an anomaly warning for 5xx responses", () => {
+    mockRes.statusCode = 500;
+    mockReq.path = "/api/error";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+  });
+
+  it("does not log anomaly warning for normal responses under 500ms with 2xx status", () => {
+    mockRes.statusCode = 200;
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/services/fhirParser.test.ts
+++ b/server/services/fhirParser.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateFhirBundle,
+  parseFhirBundle,
+  extractExplainableInsights,
+  convertToInternalSchema,
+} from "./fhirParser";
+
+describe("validateFhirBundle", () => {
+  it("accepts a valid FHIR R4 Bundle", () => {
+    const bundle = {
+      resourceType: "Bundle",
+      type: "collection",
+      entry: [{ resource: { resourceType: "Patient" } }],
+    };
+    expect(() => validateFhirBundle(bundle)).not.toThrow();
+  });
+
+  it("throws for null payload", () => {
+    expect(() => validateFhirBundle(null)).toThrow("Invalid FHIR payload");
+  });
+
+  it("throws for non-object payload", () => {
+    expect(() => validateFhirBundle("string")).toThrow("Invalid FHIR payload");
+    expect(() => validateFhirBundle(123)).toThrow("Invalid FHIR payload");
+  });
+
+  it("throws when resourceType is missing", () => {
+    expect(() => validateFhirBundle({ type: "collection" })).toThrow("Invalid FHIR payload");
+  });
+
+  it("throws for non-Bundle resourceType", () => {
+    const bundle = {
+      resourceType: "Patient",
+      type: "collection",
+      entry: [],
+    };
+    expect(() => validateFhirBundle(bundle)).toThrow("Unsupported FHIR structure");
+  });
+
+  it("throws when type is missing", () => {
+    const bundle = {
+      resourceType: "Bundle",
+      entry: [],
+    };
+    expect(() => validateFhirBundle(bundle)).toThrow("Unsupported FHIR structure");
+  });
+
+  it("throws when entry is missing", () => {
+    const bundle = {
+      resourceType: "Bundle",
+      type: "collection",
+    };
+    expect(() => validateFhirBundle(bundle)).toThrow("Missing Bundle entries");
+  });
+
+  it("throws when entry is not an array", () => {
+    const bundle = {
+      resourceType: "Bundle",
+      type: "collection",
+      entry: "not-an-array",
+    };
+    expect(() => validateFhirBundle(bundle)).toThrow("Missing Bundle entries");
+  });
+
+  it("throws when entry is empty array", () => {
+    const bundle = {
+      resourceType: "Bundle",
+      type: "collection",
+      entry: [],
+    };
+    expect(() => validateFhirBundle(bundle)).toThrow("Missing Bundle entries");
+  });
+});
+
+describe("parseFhirBundle", () => {
+  it("parses a bundle with a Patient resource", () => {
+    const bundle = {
+      resourceType: "Bundle",
+      type: "collection",
+      entry: [
+        {
+          resource: {
+            resourceType: "Patient",
+            name: [{ given: ["John"], family: "Doe" }],
+            gender: "male",
+          },
+        },
+      ],
+    };
+    const result = parseFhirBundle(bundle);
+    expect(result.patient).toBeDefined();
+    expect(result.observations).toBeDefined();
+    expect(Array.isArray(result.observations)).toBe(true);
+    expect(result.documents).toBeDefined();
+  });
+
+  it("parses a bundle with an Observation resource", () => {
+    const bundle = {
+      resourceType: "Bundle",
+      type: "collection",
+      entry: [
+        {
+          resource: {
+            resourceType: "Observation",
+            code: { text: "HbA1c" },
+            valueQuantity: { value: 7.5, unit: "%" },
+          },
+        },
+      ],
+    };
+    const result = parseFhirBundle(bundle);
+    expect(result.observations.length).toBeGreaterThan(0);
+  });
+
+  it("returns empty arrays for bundle with no parseable entries", () => {
+    const bundle = {
+      resourceType: "Bundle",
+      type: "collection",
+      entry: [
+        {
+          resource: {
+            resourceType: "UnknownType",
+          },
+        },
+      ],
+    };
+    const result = parseFhirBundle(bundle);
+    expect(result.observations).toEqual([]);
+    expect(result.documents).toEqual([]);
+  });
+});
+
+describe("extractExplainableInsights", () => {
+  it("extracts insights from clinical note text", () => {
+    const text = "Patient has elevated blood glucose levels. HbA1c is 8.5.";
+    const insights = extractExplainableInsights(text);
+    expect(Array.isArray(insights)).toBe(true);
+  });
+
+  it("handles empty string", () => {
+    const insights = extractExplainableInsights("");
+    expect(Array.isArray(insights)).toBe(true);
+  });
+
+  it("handles null or undefined text", () => {
+    expect(() => extractExplainableInsights(null as any)).not.toThrow();
+    expect(() => extractExplainableInsights(undefined as any)).not.toThrow();
+  });
+
+  it("returns insight objects with expected shape", () => {
+    const insights = extractExplainableInsights(
+      "Patient presents with high blood pressure and elevated HbA1c"
+    );
+    insights.forEach((insight) => {
+      expect(typeof insight).toBe("object");
+    });
+  });
+});
+
+describe("convertToInternalSchema", () => {
+  function makeObservation(code: string, value: number, display = "") {
+    return {
+      code,
+      codeDisplay: display,
+      valueQuantity: { value, unit: "%" },
+    };
+  }
+
+  it("converts valid normalized FHIR structure to InsertAssessment", () => {
+    const normalized = {
+      patient: { name: "Jane Doe", gender: "Female" as const, birthDate: "1985-06-15" },
+      observations: [
+        makeObservation("BMI", 25.5, "Body Mass Index"),
+        makeObservation("HbA1c", 6.5, "Hemoglobin A1c"),
+        makeObservation("Glucose", 120, "Blood Glucose"),
+      ],
+      documents: [],
+    };
+    expect(() => convertToInternalSchema(normalized)).not.toThrow();
+  });
+
+  it("throws when patient is missing", () => {
+    const normalized = { observations: [], documents: [] } as any;
+    expect(() => convertToInternalSchema(normalized)).toThrow("Missing required field: Patient Name");
+  });
+
+  it("throws when patient name is missing", () => {
+    const normalized = {
+      patient: { gender: "Female" as const, birthDate: "1985-06-15" },
+      observations: [],
+      documents: [],
+    } as any;
+    expect(() => convertToInternalSchema(normalized)).toThrow("Missing required field: Patient Name");
+  });
+
+  it("throws when gender is not Male or Female", () => {
+    const normalized = {
+      patient: { name: "Test", gender: "Unknown" as any, birthDate: "1985-06-15" },
+      observations: [],
+      documents: [],
+    };
+    expect(() => convertToInternalSchema(normalized)).toThrow("Gender must be 'Male' or 'Female'");
+  });
+
+  it("throws when birthDate is missing", () => {
+    const normalized = {
+      patient: { name: "Test", gender: "Male" as const },
+      observations: [],
+      documents: [],
+    } as any;
+    expect(() => convertToInternalSchema(normalized)).toThrow("Missing required field: Age");
+  });
+
+  it("throws for invalid birth date format", () => {
+    const normalized = {
+      patient: { name: "Test", gender: "Male" as const, birthDate: "invalid-date" },
+      observations: [],
+      documents: [],
+    };
+    expect(() => convertToInternalSchema(normalized)).toThrow("Invalid birth date format");
+  });
+
+  it("throws when BMI is missing from observations", () => {
+    const normalized = {
+      patient: { name: "Test Patient", gender: "Female" as const, birthDate: "1985-06-15" },
+      observations: [
+        makeObservation("HbA1c", 6.5, "Hemoglobin A1c"),
+        makeObservation("Glucose", 120, "Blood Glucose"),
+      ],
+      documents: [],
+    };
+    expect(() => convertToInternalSchema(normalized)).toThrow("Missing required field: BMI");
+  });
+
+  it("throws when HbA1c is missing from observations", () => {
+    const normalized = {
+      patient: { name: "Test Patient", gender: "Female" as const, birthDate: "1985-06-15" },
+      observations: [
+        makeObservation("BMI", 25.5, "Body Mass Index"),
+        makeObservation("Glucose", 120, "Blood Glucose"),
+      ],
+      documents: [],
+    };
+    expect(() => convertToInternalSchema(normalized)).toThrow("Missing required field: HbA1c Level");
+  });
+
+  it("throws when Blood Glucose is missing from observations", () => {
+    const normalized = {
+      patient: { name: "Test Patient", gender: "Female" as const, birthDate: "1985-06-15" },
+      observations: [
+        makeObservation("BMI", 25.5, "Body Mass Index"),
+        makeObservation("HbA1c", 6.5, "Hemoglobin A1c"),
+      ],
+      documents: [],
+    };
+    expect(() => convertToInternalSchema(normalized)).toThrow("Missing required field: Blood Glucose Level");
+  });
+});


### PR DESCRIPTION
Closes #2183.

Summary of What Has Been Done:
Added vitest unit tests for the FHIR bundle parser in server/services/fhirParser.ts, covering validateFhirBundle, parseFhirBundle, extractExplainableInsights, and convertToInternalSchema.

Changes Made:
- Created server/services/fhirParser.test.ts
- Tested validateFhirBundle: valid bundle, null/non-object, missing resourceType, wrong resourceType, missing type, missing/empty entry
- Tested parseFhirBundle: Patient resource, Observation resource, unknown resource type
- Tested extractExplainableInsights: clinical text, empty string, null/undefined, insight shape
- Tested convertToInternalSchema: valid normalized structure, missing patient, empty arrays

Impact it Made:
- Ensures FHIR interoperability functions correctly for healthcare data exchange
- Catches regressions when updating FHIR parsing logic
- Documents expected FHIR bundle formats and validation rules

Note: Please assign this PR to the `tmdeveloper007` account.