### PR TITLE
test : added unit tests for patient access authorization

### DIFF
--- a/server/middleware/loggingAnomaly.test.ts
+++ b/server/middleware/loggingAnomaly.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { loggingAnomalyMiddleware } from "./loggingAnomaly";
+import { logger } from "../logger";
+
+vi.mock("../logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("loggingAnomalyMiddleware", () => {
+  let nextFn;
+  let mockReq;
+  let mockRes;
+  let finishHandler;
+
+  beforeEach(() => {
+    nextFn = vi.fn();
+    mockReq = {
+      method: "GET",
+      path: "/api/test",
+      ip: "127.0.0.1",
+    };
+    mockRes = {
+      statusCode: 200,
+      on: vi.fn((event, handler) => {
+        if (event === "finish") {
+          finishHandler = handler;
+        }
+      }),
+    };
+    logger.info.mockClear();
+    logger.warn.mockClear();
+  });
+
+  it("calls next to continue the middleware chain", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(nextFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers a finish event handler on the response", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    expect(mockRes.on).toHaveBeenCalledWith("finish", expect.any(Function));
+  });
+
+  it("logs request metadata when the response finishes normally", () => {
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    const logCall = logger.info.mock.calls[0];
+    const logData = logCall[0];
+    const logMsg = logCall[1];
+    expect(logData.method).toBe("GET");
+    expect(logData.path).toBe("/api/test");
+    expect(logData.status).toBe(200);
+    expect(typeof logData.durationMs).toBe("number");
+    expect(logData.ip).toBe("127.0.0.1");
+    expect(logMsg).toBe("Request logged (Anomaly Middleware)");
+  });
+
+  it("logs an anomaly warning for responses with duration > 500ms", () => {
+    const start = Date.now();
+    mockReq.path = "/api/slow";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    // Simulate a slow response by directly calling the finish handler
+    // with a mocked Date.now
+    vi.spyOn(Date, "now").mockReturnValue(start + 600);
+    finishHandler.call(mockRes);
+    Date.now.mockRestore();
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+    expect(warnCall[0].path).toBe("/api/slow");
+  });
+
+  it("logs an anomaly warning for 5xx responses", () => {
+    mockRes.statusCode = 500;
+    mockReq.path = "/api/error";
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = logger.warn.mock.calls[0];
+    expect(warnCall[0].anomaly).toBe(true);
+  });
+
+  it("does not log anomaly warning for normal responses under 500ms with 2xx status", () => {
+    mockRes.statusCode = 200;
+    loggingAnomalyMiddleware(mockReq, mockRes, nextFn);
+
+    finishHandler.call(mockRes);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/services/authz/patient-access.test.ts
+++ b/server/services/authz/patient-access.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { canAccessPatientRecord } from "./patient-access";
+
+describe("canAccessPatientRecord", () => {
+  describe("admin access", () => {
+    it("grants admin global access to any record", () => {
+      const user = { id: "admin-1", email: "admin@test.com", role: "admin" };
+      const record = { createdBy: "doctor@test.com", userId: "patient-1", ownerId: "patient-1" };
+      expect(canAccessPatientRecord(user, record)).toBe(true);
+    });
+
+    it("grants admin access even with no matching fields", () => {
+      const user = { id: "admin-1", email: "admin@test.com", role: "admin" };
+      const record = { createdBy: "other@test.com", userId: "other-patient", ownerId: "other-owner" };
+      expect(canAccessPatientRecord(user, record)).toBe(true);
+    });
+  });
+
+  describe("ownerId matching", () => {
+    it("grants access when ownerId matches user id", () => {
+      const user = { id: "patient-1", email: "patient@test.com", role: "patient" };
+      const record = { createdBy: "doctor@test.com", userId: "other", ownerId: "patient-1" };
+      expect(canAccessPatientRecord(user, record)).toBe(true);
+    });
+
+    it("denies access when ownerId does not match user id", () => {
+      const user = { id: "patient-1", email: "patient@test.com", role: "patient" };
+      const record = { createdBy: "doctor@test.com", userId: "other", ownerId: "different-owner" };
+      expect(canAccessPatientRecord(user, record)).toBe(false);
+    });
+
+    it("denies access when ownerId is undefined", () => {
+      const user = { id: "patient-1", email: "patient@test.com", role: "patient" };
+      const record = { createdBy: "doctor@test.com", userId: "other", ownerId: undefined as any };
+      expect(canAccessPatientRecord(user, record)).toBe(false);
+    });
+  });
+
+  describe("createdBy email matching", () => {
+    it("grants access when createdBy email matches user email", () => {
+      const user = { id: "doctor-1", email: "Doctor@test.com", role: "doctor" };
+      const record = { createdBy: "doctor@test.com", userId: "other", ownerId: undefined as any };
+      expect(canAccessPatientRecord(user, record)).toBe(true);
+    });
+
+    it("grants access with case-insensitive email comparison", () => {
+      const user = { id: "doctor-1", email: "DOCTOR@TEST.COM", role: "doctor" };
+      const record = { createdBy: "doctor@test.com", userId: "other", ownerId: undefined as any };
+      expect(canAccessPatientRecord(user, record)).toBe(true);
+    });
+
+    it("denies access when createdBy email does not match", () => {
+      const user = { id: "doctor-1", email: "other@test.com", role: "doctor" };
+      const record = { createdBy: "doctor@test.com", userId: "other", ownerId: undefined as any };
+      expect(canAccessPatientRecord(user, record)).toBe(false);
+    });
+
+    it("denies access when createdBy is undefined", () => {
+      const user = { id: "doctor-1", email: "doctor@test.com", role: "doctor" };
+      const record = { createdBy: undefined as any, userId: "other", ownerId: undefined as any };
+      expect(canAccessPatientRecord(user, record)).toBe(false);
+    });
+  });
+
+  describe("userId matching", () => {
+    it("grants access when userId matches user id", () => {
+      const user = { id: "patient-1", email: "patient@test.com", role: "patient" };
+      const record = { createdBy: "doctor@test.com", userId: "patient-1", ownerId: undefined as any };
+      expect(canAccessPatientRecord(user, record)).toBe(true);
+    });
+
+    it("denies access when userId does not match user id", () => {
+      const user = { id: "patient-1", email: "patient@test.com", role: "patient" };
+      const record = { createdBy: "doctor@test.com", userId: "different-patient", ownerId: undefined as any };
+      expect(canAccessPatientRecord(user, record)).toBe(false);
+    });
+
+    it("denies access when userId is undefined", () => {
+      const user = { id: "patient-1", email: "patient@test.com", role: "patient" };
+      const record = { createdBy: "doctor@test.com", userId: undefined as any, ownerId: undefined as any };
+      expect(canAccessPatientRecord(user, record)).toBe(false);
+    });
+  });
+
+  describe("default deny", () => {
+    it("denies access when no condition matches", () => {
+      const user = { id: "patient-1", email: "patient@test.com", role: "patient" };
+      const record = {
+        createdBy: "doctor@test.com",
+        userId: "different-patient",
+        ownerId: "different-owner",
+      };
+      expect(canAccessPatientRecord(user, record)).toBe(false);
+    });
+
+    it("denies access for clinician with no matching fields", () => {
+      const user = { id: "clinician-1", email: "clinician@test.com", role: "clinician" };
+      const record = {
+        createdBy: "other@test.com",
+        userId: "other-patient",
+        ownerId: "other-owner",
+      };
+      expect(canAccessPatientRecord(user, record)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #2184.

Summary of What Has Been Done:
Added vitest unit tests for the canAccessPatientRecord authorization function in server/services/authz/patient-access.ts, covering admin global access, ownerId matching, createdBy email matching, and userId matching for all user roles.

Changes Made:
- Created server/services/authz/patient-access.test.ts
- Tested admin users have global access to all records
- Tested doctor/clinician access restricted to records they created
- Tested patient access restricted to their own records via ownerId
- Tested case-insensitivity of email comparison in createdBy check
- Tested default deny for all unmatched scenarios

Impact it Made:
- Guards against IDOR vulnerabilities by validating access control logic
- Ensures admin/doctor/patient role separation is enforced correctly
- Provides regression safety when modifying access rules

Note: Please assign this PR to the `tmdeveloper007` account.