### PR TITLE
test : added unit tests for sanitize utility

### DIFF
--- a/server/utils/sanitize.test.ts
+++ b/server/utils/sanitize.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeHtml } from "./sanitize";
+
+describe("sanitizeHtml", () => {
+  it("returns plain text unchanged", () => {
+    expect(sanitizeHtml("Hello world")).toBe("Hello world");
+  });
+
+  it("strips opening and closing tags", () => {
+    expect(sanitizeHtml("Hello <b>world</b>")).toBe("Hello world");
+  });
+
+  it("strips self-closing tags", () => {
+    expect(sanitizeHtml("line1<br/>line2")).toBe("line1line2");
+  });
+
+  it("strips hr tags", () => {
+    expect(sanitizeHtml("text<hr>more")).toBe("textmore");
+  });
+
+  it("strips nested tags", () => {
+    expect(sanitizeHtml("<div><p>paragraph</p></div>")).toBe("paragraph");
+  });
+
+  it("strips tags with attributes", () => {
+    expect(sanitizeHtml("<a href='https://evil.com'>link</a>")).toBe("link");
+  });
+
+  it("strips script tags content remains but tag removed", () => {
+    expect(sanitizeHtml("<script>alert(1)</script>")).toBe("alert(1)");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(sanitizeHtml("")).toBe("");
+  });
+
+  it("returns empty string when input is only tags", () => {
+    expect(sanitizeHtml("<><>")).toBe("");
+  });
+
+  it("handles mixed text and multiple tag types", () => {
+    const input = "<p>Hello</p> <br/> <span style='color:red'>world</span>";
+    // regex strips tags but whitespace between them is preserved
+    expect(sanitizeHtml(input)).toBe("Hello  world");
+  });
+
+  it("handles unclosed tags", () => {
+    expect(sanitizeHtml("text<strong>bold")).toBe("textbold");
+  });
+
+  it("handles img tag with src", () => {
+    expect(sanitizeHtml("<img src='x' onerror='alert(1)'>")).toBe("");
+  });
+});


### PR DESCRIPTION
Closes #2233.

Summary of What Has Been Done:
Added vitest unit tests for the sanitizeHtml function in server/utils/sanitize.ts. The test suite covers 12 cases including plain text passthrough, tag stripping, nested tags, attributes, script content exposure after tag removal, empty string, tag-only input, and mixed content edge cases.

Changes Made:
- Created server/utils/sanitize.test.ts with 12 test cases

Impact it Made:
All 12 tests pass locally. Tests guard the HTML sanitization utility and document behavior around whitespace preservation between stripped tags.

Note: Please assign this PR to the `tmdeveloper007` account.