### PR TITLE
fix: patient registration no longer auto-verifies email (closes #1509)

### DIFF
--- a/server/controllers/patient.controller.test.ts
+++ b/server/controllers/patient.controller.test.ts
@@ -1,0 +1,422 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// ── Hoisted mocks (must be created before vi.mock calls) ───────────────────
+
+const { mockStorage, mockPendingOtps, mockIssueToken, mockSendVerificationEmail, mockBcryptCompare } = vi.hoisted(() => {
+  const map = new Map<string, { otp: string; expiresAt: number; attempts: number }>();
+  return {
+    mockStorage: {
+      getPatientUserByEmail: vi.fn(),
+      getPatientUserByPatientName: vi.fn(),
+      createPatientUser: vi.fn(),
+      getPatientUserById: vi.fn(),
+      updatePatientEmailVerified: vi.fn(),
+      getAssessmentsByPatientName: vi.fn(),
+      getPatientTrends: vi.fn(),
+    },
+    mockPendingOtps: map,
+    mockIssueToken: vi.fn(() => "mock-jwt-token"),
+    mockSendVerificationEmail: vi.fn(async () => true),
+    mockBcryptCompare: vi.fn(() => true),
+  };
+});
+
+vi.mock("../storage", () => ({
+  storage: mockStorage,
+}));
+
+vi.mock("../auth", () => ({
+  pendingOtps: mockPendingOtps,
+}));
+
+vi.mock("../email", () => ({
+  sendVerificationEmail: mockSendVerificationEmail,
+}));
+
+vi.mock("../logger", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("bcrypt", () => ({
+  default: {
+    hashSync: vi.fn(() => "$2b$10$mockedhashstring1234567890123456789012345678901"),
+    compareSync: mockBcryptCompare,
+  },
+}));
+
+vi.mock("../services/auth/tokenValidator", () => ({
+  issueToken: mockIssueToken,
+}));
+
+// ── Subject under test ─────────────────────────────────────────────────────
+
+import {
+  registerPatient,
+  loginPatient,
+  verifyPatientOTP,
+  getMe,
+} from "./patient.controller";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function mockRequest(overrides: Record<string, any> = {}) {
+  return {
+    body: {},
+    jwtUser: { sub: "user-1", email: "test@example.com", role: "PATIENT" },
+    ...overrides,
+  } as any;
+}
+
+function mockResponse() {
+  const res: any = {};
+  res.status = vi.fn(() => res);
+  res.json = vi.fn(() => res);
+  res.cookie = vi.fn(() => res);
+  return res;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("registerPatient", () => {
+  const validBody = {
+    patientName: "TestPatient",
+    email: "patient@example.com",
+    password: "securePass123",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPendingOtps.clear();
+  });
+
+  it("creates a patient with emailVerified: false and returns requiresOTP", async () => {
+    mockStorage.getPatientUserByEmail.mockResolvedValue(undefined);
+    mockStorage.getPatientUserByPatientName.mockResolvedValue(undefined);
+    mockStorage.createPatientUser.mockResolvedValue({
+      id: "patient-1",
+      patientName: "TestPatient",
+      email: "patient@example.com",
+      emailVerified: false,
+    });
+
+    const req = mockRequest({ body: validBody });
+    const res = mockResponse();
+
+    await registerPatient(req, res);
+
+    // Verify user was created with emailVerified: false
+    expect(mockStorage.createPatientUser).toHaveBeenCalledWith(
+      expect.objectContaining({ emailVerified: false }),
+    );
+
+    // Verify OTP was stored
+    expect(mockPendingOtps.size).toBe(1);
+    const pending = mockPendingOtps.get("patient@example.com");
+    expect(pending).toBeDefined();
+    expect(pending!.otp).toMatch(/^\d{6}$/);
+    expect(pending!.expiresAt).toBeGreaterThan(Date.now());
+    expect(pending!.attempts).toBe(0);
+
+    // Verify verification email was sent
+    expect(mockSendVerificationEmail).toHaveBeenCalledWith("patient@example.com", pending!.otp);
+
+    // Verify response
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      requiresOTP: true,
+      pendingEmail: "patient@example.com",
+      message: "OTP sent to email. Verify to complete registration.",
+    });
+
+    // Verify NO JWT was issued yet
+    expect(mockIssueToken).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 if email already exists", async () => {
+    mockStorage.getPatientUserByEmail.mockResolvedValue({ id: "existing", email: "patient@example.com" });
+
+    const req = mockRequest({ body: validBody });
+    const res = mockResponse();
+
+    await registerPatient(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({ message: "An account with this email already exists." });
+    expect(mockStorage.createPatientUser).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 if patient name already exists", async () => {
+    mockStorage.getPatientUserByEmail.mockResolvedValue(undefined);
+    mockStorage.getPatientUserByPatientName.mockResolvedValue({ id: "existing", patientName: "TestPatient" });
+
+    const req = mockRequest({ body: validBody });
+    const res = mockResponse();
+
+    await registerPatient(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({ message: "This patient name is already registered." });
+    expect(mockStorage.createPatientUser).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid input", async () => {
+    const req = mockRequest({ body: { patientName: "", email: "not-an-email", password: "12" } });
+    const res = mockResponse();
+
+    await registerPatient(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("handles email send failure gracefully — still returns 201", async () => {
+    mockStorage.getPatientUserByEmail.mockResolvedValue(undefined);
+    mockStorage.getPatientUserByPatientName.mockResolvedValue(undefined);
+    mockStorage.createPatientUser.mockResolvedValue({
+      id: "patient-1",
+      patientName: "TestPatient",
+      email: "patient@example.com",
+    });
+    mockSendVerificationEmail.mockResolvedValueOnce(false);
+
+    const req = mockRequest({ body: validBody });
+    const res = mockResponse();
+
+    await registerPatient(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true, requiresOTP: true }),
+    );
+  });
+});
+
+describe("loginPatient", () => {
+  const validBody = { email: "patient@example.com", password: "securePass123" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPendingOtps.clear();
+  });
+
+  it("logs in verified patient successfully", async () => {
+    mockStorage.getPatientUserByEmail.mockResolvedValue({
+      id: "patient-1",
+      patientName: "TestPatient",
+      email: "patient@example.com",
+      passwordHash: "$2b$10$hashed",
+      isActive: true,
+      emailVerified: true,
+    });
+
+    const req = mockRequest({ body: validBody });
+    const res = mockResponse();
+
+    await loginPatient(req, res);
+
+    expect(mockIssueToken).toHaveBeenCalledWith("patient-1", "patient@example.com", "PATIENT", "24h");
+    expect(res.cookie).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      user: { id: "patient-1", patientName: "TestPatient", email: "patient@example.com" },
+    });
+  });
+
+  it("blocks login for unverified patient and sends OTP", async () => {
+    mockStorage.getPatientUserByEmail.mockResolvedValue({
+      id: "patient-1",
+      patientName: "TestPatient",
+      email: "patient@example.com",
+      passwordHash: "$2b$10$hashed",
+      isActive: true,
+      emailVerified: false,
+    });
+
+    const req = mockRequest({ body: validBody });
+    const res = mockResponse();
+
+    await loginPatient(req, res);
+
+    expect(mockIssueToken).not.toHaveBeenCalled();
+
+    expect(mockPendingOtps.size).toBe(1);
+    const pending = mockPendingOtps.get("patient@example.com");
+    expect(pending).toBeDefined();
+    expect(pending!.otp).toMatch(/^\d{6}$/);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Email not verified. A verification code has been sent to your email.",
+      requiresOTP: true,
+      pendingEmail: "patient@example.com",
+    });
+  });
+
+  it("returns 401 for invalid credentials", async () => {
+    mockStorage.getPatientUserByEmail.mockResolvedValue(undefined);
+
+    const req = mockRequest({ body: validBody });
+    const res = mockResponse();
+
+    await loginPatient(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it("returns 403 for deactivated account", async () => {
+    mockStorage.getPatientUserByEmail.mockResolvedValue({
+      id: "patient-1",
+      passwordHash: "$2b$10$hash",
+      isActive: false,
+      emailVerified: true,
+    });
+
+    const req = mockRequest({ body: validBody });
+    const res = mockResponse();
+
+    await loginPatient(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ message: "Account is deactivated." });
+  });
+});
+
+describe("verifyPatientOTP", () => {
+  const email = "patient@example.com";
+  const otp = "123456";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPendingOtps.clear();
+  });
+
+  it("verifies OTP and issues JWT", async () => {
+    mockPendingOtps.set(email, { otp, expiresAt: Date.now() + 600000, attempts: 0 });
+    mockStorage.getPatientUserByEmail.mockResolvedValue({
+      id: "patient-1",
+      patientName: "TestPatient",
+      email,
+      emailVerified: false,
+    });
+    mockStorage.updatePatientEmailVerified.mockResolvedValue({
+      id: "patient-1",
+      emailVerified: true,
+    });
+
+    const req = mockRequest({ body: { email, otp } });
+    const res = mockResponse();
+
+    await verifyPatientOTP(req, res);
+
+    expect(mockPendingOtps.has(email)).toBe(false);
+    expect(mockStorage.updatePatientEmailVerified).toHaveBeenCalledWith("patient-1", true);
+    expect(mockIssueToken).toHaveBeenCalledWith("patient-1", email, "PATIENT", "24h");
+    expect(res.cookie).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      user: { id: "patient-1", patientName: "TestPatient", email },
+    });
+  });
+
+  it("rejects invalid OTP", async () => {
+    mockPendingOtps.set(email, { otp, expiresAt: Date.now() + 600000, attempts: 0 });
+
+    const req = mockRequest({ body: { email, otp: "999999" } });
+    const res = mockResponse();
+
+    await verifyPatientOTP(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(mockIssueToken).not.toHaveBeenCalled();
+    expect(mockPendingOtps.get(email)!.attempts).toBe(1);
+  });
+
+  it("locks out after 3 failed attempts", async () => {
+    mockPendingOtps.set(email, { otp, expiresAt: Date.now() + 600000, attempts: 2 });
+
+    const req = mockRequest({ body: { email, otp: "000000" } });
+    const res = mockResponse();
+
+    await verifyPatientOTP(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(mockPendingOtps.has(email)).toBe(false);
+    expect(mockIssueToken).not.toHaveBeenCalled();
+  });
+
+  it("rejects expired OTP", async () => {
+    mockPendingOtps.set(email, { otp, expiresAt: Date.now() - 1000, attempts: 0 });
+
+    const req = mockRequest({ body: { email, otp } });
+    const res = mockResponse();
+
+    await verifyPatientOTP(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "OTP has expired. Please register or sign in again.",
+    });
+    expect(mockPendingOtps.has(email)).toBe(false);
+    expect(mockIssueToken).not.toHaveBeenCalled();
+  });
+
+  it("rejects OTP when no pending verification exists", async () => {
+    const req = mockRequest({ body: { email, otp } });
+    const res = mockResponse();
+
+    await verifyPatientOTP(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "No pending verification found for this email. Please register or sign in again.",
+    });
+  });
+
+  it("returns 400 for invalid input", async () => {
+    const req = mockRequest({ body: { email: "not-email", otp: "12" } });
+    const res = mockResponse();
+
+    await verifyPatientOTP(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});
+
+describe("getMe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns patient user by JWT sub", async () => {
+    mockStorage.getPatientUserById.mockResolvedValue({
+      id: "patient-1",
+      patientName: "TestPatient",
+      email: "patient@example.com",
+    });
+
+    const req = mockRequest();
+    const res = mockResponse();
+
+    await getMe(req, res);
+
+    expect(mockStorage.getPatientUserById).toHaveBeenCalledWith("user-1");
+    expect(res.json).toHaveBeenCalledWith({
+      user: { id: "patient-1", patientName: "TestPatient", email: "patient@example.com" },
+    });
+  });
+
+  it("returns 404 if user not found", async () => {
+    mockStorage.getPatientUserById.mockResolvedValue(undefined);
+
+    const req = mockRequest();
+    const res = mockResponse();
+
+    await getMe(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+});

--- a/server/controllers/patient.controller.ts
+++ b/server/controllers/patient.controller.ts
@@ -1,9 +1,12 @@
 import { type Request, type Response } from "express";
 import bcrypt from "bcrypt";
+import { randomInt } from "crypto";
 import { z } from "zod";
 import { storage } from "../storage";
 import { logger } from "../logger";
 import { issueToken } from "../services/auth/tokenValidator";
+import { pendingOtps } from "../auth";
+import { sendVerificationEmail } from "../email";
 
 const registerSchema = z.object({
   patientName: z.string().trim().min(1, "Patient name is required"),
@@ -15,6 +18,11 @@ const registerSchema = z.object({
 const loginSchema = z.object({
   email: z.string().email("Valid email is required"),
   password: z.string().min(1, "Password is required"),
+});
+
+const verifyOtpSchema = z.object({
+  email: z.string().email("Valid email is required"),
+  otp: z.string().length(6, "OTP must be exactly 6 digits"),
 });
 
 const PATIENT_SESSION_COOKIE = "patient_session";
@@ -56,13 +64,25 @@ export const registerPatient = async (req: Request, res: Response) => {
       passwordHash,
       phone: body.phone ?? null,
       isActive: true,
-      emailVerified: true,
+      emailVerified: false,
     });
-    const token = issueToken(user.id, user.email, "PATIENT", "24h");
-    setPatientSessionCookie(res, token);
+
+    // Generate and store OTP
+    const otp = randomInt(100000, 999999).toString();
+    const expiresAt = Date.now() + 10 * 60 * 1000; // 10 minutes
+    pendingOtps.set(body.email, { otp, expiresAt, attempts: 0 });
+
+    // Send verification email
+    const emailSent = await sendVerificationEmail(body.email, otp);
+    if (!emailSent) {
+      logger.warn({ email: body.email }, "Failed to send patient verification email");
+    }
+
     return res.status(201).json({
       success: true,
-      user: { id: user.id, patientName: user.patientName, email: user.email },
+      requiresOTP: true,
+      pendingEmail: body.email,
+      message: "OTP sent to email. Verify to complete registration.",
     });
   } catch (err) {
     if (err instanceof z.ZodError) {
@@ -83,6 +103,21 @@ export const loginPatient = async (req: Request, res: Response) => {
     if (!user.isActive) {
       return res.status(403).json({ message: "Account is deactivated." });
     }
+    if (!user.emailVerified) {
+      // Resend OTP and direct user to verify
+      const otp = randomInt(100000, 999999).toString();
+      const expiresAt = Date.now() + 10 * 60 * 1000;
+      pendingOtps.set(body.email, { otp, expiresAt, attempts: 0 });
+      const emailSent = await sendVerificationEmail(body.email, otp);
+      if (!emailSent) {
+        logger.warn({ email: body.email }, "Failed to send patient verification email on login");
+      }
+      return res.status(403).json({
+        message: "Email not verified. A verification code has been sent to your email.",
+        requiresOTP: true,
+        pendingEmail: body.email,
+      });
+    }
     const token = issueToken(user.id, user.email, "PATIENT", "24h");
     setPatientSessionCookie(res, token);
     return res.json({
@@ -95,6 +130,61 @@ export const loginPatient = async (req: Request, res: Response) => {
     }
     logger.error({ err }, "Patient login error");
     return res.status(500).json({ message: "Login failed." });
+  }
+};
+
+export const verifyPatientOTP = async (req: Request, res: Response) => {
+  try {
+    const body = verifyOtpSchema.parse(req.body);
+    const pending = pendingOtps.get(body.email);
+
+    if (!pending) {
+      return res.status(400).json({ message: "No pending verification found for this email. Please register or sign in again." });
+    }
+
+    if (Date.now() > pending.expiresAt) {
+      pendingOtps.delete(body.email);
+      return res.status(400).json({ message: "OTP has expired. Please register or sign in again." });
+    }
+
+    if (pending.otp !== body.otp) {
+      pending.attempts = (pending.attempts ?? 0) + 1;
+
+      if (pending.attempts >= 3) {
+        pendingOtps.delete(body.email);
+        return res.status(429).json({
+          message: "Too many failed attempts. Please register or sign in again.",
+        });
+      }
+
+      const remaining = 3 - pending.attempts;
+      return res.status(401).json({
+        message: `Invalid OTP. ${remaining} attempt(s) remaining.`,
+      });
+    }
+
+    // OTP is valid — mark email as verified
+    pendingOtps.delete(body.email);
+    const user = await storage.getPatientUserByEmail(body.email);
+    if (!user) {
+      return res.status(404).json({ message: "User not found." });
+    }
+    await storage.updatePatientEmailVerified(user.id, true);
+
+    // Issue JWT and set cookie
+    const token = issueToken(user.id, user.email, "PATIENT", "24h");
+    setPatientSessionCookie(res, token);
+
+    return res.json({
+      success: true,
+      user: { id: user.id, patientName: user.patientName, email: user.email },
+    });
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json({ message: err.errors[0].message });
+    }
+    logger.error({ err }, "Patient OTP verification error");
+    return res.status(500).json({ message: "Verification failed." });
   }
 };
 

--- a/server/repositories/patient-user.repository.ts
+++ b/server/repositories/patient-user.repository.ts
@@ -38,4 +38,14 @@ export class PatientUserRepository {
     const [result] = await db.insert(patientUsers).values(data).returning();
     return result;
   }
+
+  async updateEmailVerified(id: string, verified: boolean): Promise<PatientUser> {
+    const db = getDb();
+    const [result] = await db
+      .update(patientUsers)
+      .set({ emailVerified: verified, updatedAt: new Date() })
+      .where(eq(patientUsers.id, id))
+      .returning();
+    return result;
+  }
 }

--- a/server/routes/patient.routes.ts
+++ b/server/routes/patient.routes.ts
@@ -4,6 +4,7 @@ import { verifyToken } from "../services/auth/tokenValidator";
 import {
   registerPatient,
   loginPatient,
+  verifyPatientOTP,
   getMe,
   getAssessments,
   getTrends,
@@ -19,6 +20,14 @@ const patientAuthLimiter = rateLimit({
   standardHeaders: "draft-8",
   legacyHeaders: false,
   message: { error: "Too many attempts. Please try again later." },
+});
+
+const verifyOtpLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 10,
+  standardHeaders: "draft-8",
+  legacyHeaders: false,
+  message: { error: "Too many verification attempts. Please try again later." },
 });
 
 function getCookieValue(req: Request, name: string): string | undefined {
@@ -63,6 +72,7 @@ export function requirePatientAuth(req: Request, res: Response, next: NextFuncti
 
 router.post("/auth/register", patientAuthLimiter, registerPatient);
 router.post("/auth/login", patientAuthLimiter, loginPatient);
+router.post("/auth/verify-otp", verifyOtpLimiter, verifyPatientOTP);
 router.post("/auth/logout", (_req: Request, res: Response) => {
   res.clearCookie(PATIENT_SESSION_COOKIE, {
     httpOnly: true,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -92,6 +92,7 @@ export interface IStorage {
   getPatientUserByPatientName(patientName: string): Promise<PatientUser | undefined>;
   getPatientUserById(id: string): Promise<PatientUser | undefined>;
   createPatientUser(data: InsertPatientUser): Promise<PatientUser>;
+  updatePatientEmailVerified(id: string, verified: boolean): Promise<PatientUser>;
   getAssessmentsByPatientName(patientName: string, limit?: number, offset?: number, createdBy?: string, startDate?: string, endDate?: string): Promise<{ data: Assessment[]; total: number }>;
   getPatientTrends(patientName: string, createdBy?: string): Promise<{ date: string; riskScore: number; riskCategory: string }[]>;
   getTrendsDashboardData(patientName: string, startDate?: string, endDate?: string): Promise<{
@@ -286,6 +287,10 @@ export class DatabaseStorage implements IStorage {
 
   async createPatientUser(data: InsertPatientUser): Promise<PatientUser> {
     return this.patientUserRepository.create(data);
+  }
+
+  async updatePatientEmailVerified(id: string, verified: boolean): Promise<PatientUser> {
+    return this.patientUserRepository.updateEmailVerified(id, verified);
   }
 
   async getAssessmentsByPatientName(patientName: string, limit?: number, offset?: number, createdBy?: string, startDate?: string, endDate?: string) {


### PR DESCRIPTION
## Description

Fixed a security vulnerability where patient registration set `emailVerified: true` 
by default, allowing anyone to register using someone else's email and immediately 
receive full access. No verification OTP or confirmation link was sent.

Now patient registration follows the same OTP-based verification pattern as the 
clinician registration flow:
- Accounts are created with `emailVerified: false`
- A 6-digit OTP is sent to the registered email
- JWT is only issued after OTP verification
- Login blocks unverified users and offers OTP resend
- 3-attempt lockout prevents brute-force

## Related Issue

Closes #1509

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Test addition or update

## Changes Made

- **server/controllers/patient.controller.ts** — Registration sets `emailVerified: false`, 
  generates OTP, stores in `pendingOtps` (shared with clinician flow), sends 
  verification email, returns `{ requiresOTP: true }`. Login blocks unverified 
  accounts with OTP resend. Added `verifyPatientOTP` handler with 3-attempt lockout, 
  marks email verified, and issues JWT on success.
- **server/controllers/patient.controller.test.ts** — 17 tests covering all auth paths
- **server/repositories/patient-user.repository.ts** — Added `updateEmailVerified()`
- **server/storage.ts** — Added `updatePatientEmailVerified` to interface + impl
- **server/routes/patient.routes.ts** — Added `POST /auth/verify-otp` with rate limiter

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

Tests: 17/17 new patient controller tests pass, 396 total tests pass 
(6 pre-existing failures from missing dev packages — not related to this change)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors