### PR TITLE
test : added unit tests for extractBearerToken in jwtVerification middleware

### DIFF
--- a/server/middleware/jwtVerification.test.ts
+++ b/server/middleware/jwtVerification.test.ts
@@ -1,0 +1,89 @@
+import { expect, test, describe } from "vitest";
+import { extractBearerToken } from "./jwtVerification";
+
+// Minimal mock for Request type (Express lowercases header keys to lowercase)
+function mockReq(headers: Record<string, string | string[] | undefined>): any {
+  return { headers };
+}
+
+describe("extractBearerToken", () => {
+  test("returns token string for valid Bearer header", () => {
+    const req = mockReq({ authorization: "Bearer eyJhbGciOiJIUzI1NiJ9.test.signature" });
+    const result = extractBearerToken(req);
+    expect(result).toBe("eyJhbGciOiJIUzI1NiJ9.test.signature");
+  });
+
+  test("handles Bearer in lowercase", () => {
+    const req = mockReq({ authorization: "bearer some.token.here" });
+    const result = extractBearerToken(req);
+    expect(result).toBe("some.token.here");
+  });
+
+  test("returns null when scheme is not lowercase bearer", () => {
+    // Only "bearer" (case-insensitive) is accepted
+    const req = mockReq({ authorization: "BeArEr token123" });
+    const result = extractBearerToken(req);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when Authorization header is missing", () => {
+    const req = mockReq({});
+    const result = extractBearerToken(req);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when Authorization header is undefined", () => {
+    const req = mockReq({ authorization: undefined });
+    const result = extractBearerToken(req);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when Authorization header is empty string", () => {
+    const req = mockReq({ authorization: "" });
+    const result = extractBearerToken(req);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when scheme is not Bearer", () => {
+    const req = mockReq({ authorization: "Basic dXNlcjpwYXNz" });
+    const result = extractBearerToken(req);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when header has only Bearer without token", () => {
+    const req = mockReq({ authorization: "Bearer" });
+    const result = extractBearerToken(req);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when header has Bearer and empty token", () => {
+    const req = mockReq({ authorization: "Bearer " });
+    const result = extractBearerToken(req);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when header has extra parts (more than 2)", () => {
+    const req = mockReq({ authorization: "Bearer token extra" });
+    const result = extractBearerToken(req);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when token has no dot", () => {
+    const req = mockReq({ authorization: "Bearer noDotToken" });
+    const result = extractBearerToken(req);
+    expect(result).toBeNull();
+  });
+
+  test("returns token when token has multiple dots", () => {
+    const req = mockReq({ authorization: "Bearer a.b.c.d" });
+    const result = extractBearerToken(req);
+    expect(result).toBe("a.b.c.d");
+  });
+
+  test("returns null for Bearer with token containing whitespace", () => {
+    const req = mockReq({ authorization: "Bearer token with space" });
+    const result = extractBearerToken(req);
+    // parts = ["Bearer", "token", "with", "space"]; length !== 2 => null
+    expect(result).toBeNull();
+  });
+});

--- a/server/middleware/jwtVerification.ts
+++ b/server/middleware/jwtVerification.ts
@@ -36,7 +36,7 @@ declare global {
  * Extracts the raw token string from the Authorization header.
  * Returns null if the header is missing or malformed.
  */
-function extractBearerToken(req: Request): string | null {
+export function extractBearerToken(req: Request): string | null {
   const authHeader = req.headers.authorization;
 
   if (!authHeader) {


### PR DESCRIPTION
Closes #2246.

Summary of What Has Been Done:
Added server/middleware/jwtVerification.test.ts with 13 unit tests covering the extractBearerToken helper function. Tests cover: valid Bearer token extraction, missing/malformed headers, case-insensitive scheme matching (lowercase only), token dot validation, empty strings, extra header parts. Also added minimal export for extractBearerToken to enable testing. 

Changes Made:
- server/middleware/jwtVerification.test.ts: new test file with 13 tests 
- server/middleware/jwtVerification.ts: export extractBearerToken (1-line change)

Impact it Made:
- Covers previously untested authentication helper
- All 13 tests pass; lint clean; no new TypeScript errors introduced

Note: Please assign this PR to the tmdeveloper007 account.