### PR TITLE
feat: add frontend bounds schema validation and dynamic UI alerts for assessment inputs

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -22,15 +22,28 @@ import { ApiClient } from "@/lib/apiClient";
 const formSchema = insertAssessmentSchema.pick({
   patientName: true,
   gender: true,
-  age: true,
   hypertension: true,
   heartDisease: true,
   smokingHistory: true,
-  bmi: true,
-  hba1cLevel: true,
   bloodGlucoseLevel: true,
   insulin: true,
   skinThickness: true,
+}).extend({
+  // Transform empty inputs to undefined and validate range parameters
+  age: z.preprocess((val) => (val === "" || val === undefined ? undefined : Number(val)), 
+    z.number({ invalid_type_error: "Age must be a number" })
+     .min(0, "Age cannot be negative")
+     .max(125, "Please enter a valid age between 0 and 125")),
+  
+  bmi: z.preprocess((val) => (val === "" || val === undefined ? undefined : Number(val)), 
+    z.number({ invalid_type_error: "BMI must be a number" })
+     .min(10, "BMI is too low (minimum 10)")
+     .max(70, "BMI is too high (maximum 70)")),
+     
+  hba1cLevel: z.preprocess((val) => (val === "" || val === undefined ? undefined : Number(val)), 
+    z.number({ invalid_type_error: "HbA1c must be a number" })
+     .min(2, "HbA1c level is too low (minimum 2%)")
+     .max(20, "HbA1c level is too high (maximum 20%)")),
 });
 
 type AssessmentFormData = z.infer<typeof formSchema>;
@@ -364,8 +377,11 @@ export default function Dashboard() {
                           aria-label="Patient age in years"
                           aria-describedby="age-guidance"
                         />
-                        <p id="age-guidance" className="text-xs text-slate-500 dark:text-slate-400">Use whole years; the model is intended for adult patients.</p>
-                        {errors.age && <p className="text-sm text-red-600 mt-1">{errors.age.message}</p>}
+                        {errors.age ? (
+                          <p className="text-sm font-semibold text-red-500 mt-1 flex items-center gap-1">⚠️ {errors.age.message}</p>
+                        ) : (
+                          <p id="age-guidance" className="text-xs text-slate-500 dark:text-slate-400">Use whole years; the model is intended for adult patients.</p>
+                        )}
                       </div>
 
                       <div className="space-y-2 md:col-span-3">
@@ -456,8 +472,11 @@ export default function Dashboard() {
                             </button>
                           )}
                         </div>
-                        <p id="bmi-guidance" className="text-xs text-slate-500 dark:text-slate-400">Enter BMI in kg/m², typically between 18.5 and 30+.</p>
-                        {errors.bmi && <p className="text-sm text-red-600 mt-1">{errors.bmi.message}</p>}
+                        {errors.bmi ? (
+                          <p className="text-sm font-semibold text-red-500 mt-1 flex items-center gap-1">⚠️ {errors.bmi.message}</p>
+                        ) : (
+                          <p id="bmi-guidance" className="text-xs text-slate-500 dark:text-slate-400">Enter BMI in kg/m², typically between 18.5 and 30+.</p>
+                        )}
                         <BMIClassificationHelper bmi={watchedValues.bmi} />
                       </div>
 
@@ -504,8 +523,11 @@ export default function Dashboard() {
                             </button>
                           )}
                         </div>
-                        <p id="hba1cLevel-guidance" className="text-xs text-slate-500 dark:text-slate-400">Enter the HbA1c percentage from the most recent lab result.</p>
-                        {errors.hba1cLevel && <p className="text-sm text-red-600 mt-1">{errors.hba1cLevel.message}</p>}
+                        {errors.hba1cLevel ? (
+                          <p className="text-sm font-semibold text-red-500 mt-1 flex items-center gap-1">⚠️ {errors.hba1cLevel.message}</p>
+                        ) : (
+                          <p id="hba1cLevel-guidance" className="text-xs text-slate-500 dark:text-slate-400">Enter the HbA1c percentage from the most recent lab result.</p>
+                        )}
                       </div>
 
                       <div className="space-y-2 lg:col-span-2">
@@ -644,7 +666,7 @@ export default function Dashboard() {
                   </button>
                   <button
                     type="submit"
-                    disabled={isPending || result !== null}
+                    disabled={isPending || result !== null || Object.keys(errors).length > 0}
                     className="w-full md:w-auto px-8 py-4 rounded-xl font-black text-lg border border-blue-200 dark:border-blue-800 text-blue-700 dark:text-blue-400 bg-white dark:bg-gray-900 shadow-sm hover:bg-blue-50 dark:hover:bg-blue-950/30 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 flex items-center justify-center gap-2"
                   >
                     {isPending ? (


### PR DESCRIPTION
## Description

This PR introduces strict frontend schema-based form validation for vital clinical metric variables inside the `NewAssessment` workspace. It leverages the existing Zod and react-hook-form architecture to catch negative or out-of-bounds configurations early, protecting downstream ML risk score engines from invalid processing entries.

## Related Issue

Closes #1541 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- Extended `formSchema` inside `client/src/pages/Dashboard.tsx` with preprocessing Zod extensions to safely handle type parsing and enforce strict clinical constraint bounds: Age (0-125), BMI (10-70), and HbA1c (2%-20%).
- Updated the UI input blocks for `age`, `bmi`, and `hba1cLevel` to display real-time interactive error messages when invalid entries are registered, seamlessly substituting static guidelines with error text blocks.
- Modified the main form action button status properties to remain strictly disabled if validation error objects contain any active flags.

## Screenshots (if applicable)

<img width="1917" height="1078" alt="image" src="https://github.com/user-attachments/assets/71eb3371-fc9c-454f-862d-212458777ba3" />

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors