### PR TITLE
fix(#1994): Add caching layer for clinical document analysis results

### DIFF
--- a/server/services/analysisCache.test.ts
+++ b/server/services/analysisCache.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { AnalysisCache } from "./analysisCache";
+
+vi.mock("../logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+describe("AnalysisCache", () => {
+  let cache: AnalysisCache;
+
+  beforeEach(() => {
+    cache = new AnalysisCache(60); // 60 minute TTL
+  });
+
+  it("returns null for uncached content", () => {
+    const result = cache.get("uncached document");
+    expect(result).toBeNull();
+  });
+
+  it("stores and retrieves cached analysis result", () => {
+    const content = "Clinical document with diagnosis";
+    const analysis = {
+      diagnosis: "Hypertension",
+      confidence: 0.95,
+      entities: ["BP", "medication"],
+    };
+
+    cache.set(content, analysis);
+    const retrieved = cache.get(content);
+
+    expect(retrieved).toEqual(analysis);
+  });
+
+  it("returns same cached result for identical content", () => {
+    const content = "Same clinical note";
+    const analysis = { findings: ["fever", "cough"] };
+
+    cache.set(content, analysis);
+    const result1 = cache.get(content);
+    const result2 = cache.get(content);
+
+    expect(result1).toEqual(result2);
+    expect(result1).toEqual(analysis);
+  });
+
+  it("returns different cached results for different content", () => {
+    const content1 = "Patient A clinical note";
+    const content2 = "Patient B clinical note";
+    const analysis1 = { condition: "Diabetes" };
+    const analysis2 = { condition: "Hypertension" };
+
+    cache.set(content1, analysis1);
+    cache.set(content2, analysis2);
+
+    expect(cache.get(content1)).toEqual(analysis1);
+    expect(cache.get(content2)).toEqual(analysis2);
+  });
+
+  it("returns null for expired cache entries", () => {
+    vi.useFakeTimers();
+    const cache = new AnalysisCache(1); // 1 minute TTL
+    const content = "document to expire";
+    const analysis = { data: "analysis" };
+
+    cache.set(content, analysis);
+    expect(cache.get(content)).toEqual(analysis);
+
+    // Advance time past expiration
+    vi.advanceTimersByTime(61 * 1000);
+    expect(cache.get(content)).toBeNull();
+
+    vi.useRealTimers();
+  });
+
+  it("clears all cache entries", () => {
+    cache.set("doc1", { result: 1 });
+    cache.set("doc2", { result: 2 });
+
+    cache.clear();
+
+    expect(cache.get("doc1")).toBeNull();
+    expect(cache.get("doc2")).toBeNull();
+  });
+
+  it("provides cache statistics", () => {
+    cache.set("doc1", { result: 1 });
+    cache.set("doc2", { result: 2 });
+
+    const stats = cache.getStats();
+
+    expect(stats.size).toBe(2);
+    expect(stats.entries).toBeGreaterThan(0);
+  });
+
+  it("uses content hash for cache key (identical content, different whitespace)", () => {
+    const content1 = "Clinical diagnosis: hypertension";
+    const content2 = "Clinical diagnosis: hypertension"; // Exactly same
+    const analysis = { condition: "Hypertension" };
+
+    cache.set(content1, analysis);
+    expect(cache.get(content2)).toEqual(analysis);
+  });
+
+  it("handles complex analysis results", () => {
+    const content = "comprehensive clinical document";
+    const complexResult = {
+      diagnoses: [
+        { code: "I10", condition: "Hypertension", confidence: 0.98 },
+        { code: "E11", condition: "Type 2 Diabetes", confidence: 0.92 },
+      ],
+      medications: ["Lisinopril", "Metformin"],
+      entities: {
+        symptoms: ["fatigue", "headache"],
+        vitals: { BP: "150/90", HR: 78 },
+      },
+      timestamp: new Date().toISOString(),
+    };
+
+    cache.set(content, complexResult);
+    const retrieved = cache.get(content);
+
+    expect(retrieved).toEqual(complexResult);
+  });
+});

--- a/server/services/analysisCache.ts
+++ b/server/services/analysisCache.ts
@@ -1,0 +1,108 @@
+/**
+ * analysisCache.ts
+ *
+ * Caching layer for clinical document analysis results.
+ * Prevents redundant LLM API calls for duplicate document content.
+ * Improves performance and reduces API costs for repeated analyses.
+ */
+
+import { createHash } from "crypto";
+import { logger } from "../logger";
+
+export interface CachedAnalysisResult {
+  documentHash: string;
+  result: any;
+  timestamp: number;
+  expiresAt: number;
+}
+
+/**
+ * In-memory cache for document analysis results.
+ * Configurable TTL to balance freshness vs. performance.
+ */
+export class AnalysisCache {
+  private cache = new Map<string, CachedAnalysisResult>();
+  private readonly defaultTTL: number; // milliseconds
+
+  constructor(ttlMinutes: number = 60) {
+    this.defaultTTL = ttlMinutes * 60 * 1000;
+  }
+
+  /**
+   * Compute content hash for cache key
+   */
+  private computeHash(content: string): string {
+    return createHash("sha256").update(content).digest("hex");
+  }
+
+  /**
+   * Get cached analysis result if available and not expired
+   */
+  get(documentContent: string): any | null {
+    const hash = this.computeHash(documentContent);
+    const cached = this.cache.get(hash);
+
+    if (!cached) {
+      return null;
+    }
+
+    // Check if cache entry has expired
+    if (Date.now() > cached.expiresAt) {
+      this.cache.delete(hash);
+      logger.debug({ hash }, "Removed expired cache entry");
+      return null;
+    }
+
+    logger.info({ hash }, "Document analysis cache hit");
+    return cached.result;
+  }
+
+  /**
+   * Store analysis result in cache
+   */
+  set(documentContent: string, result: any): void {
+    const hash = this.computeHash(documentContent);
+    const now = Date.now();
+
+    this.cache.set(hash, {
+      documentHash: hash,
+      result,
+      timestamp: now,
+      expiresAt: now + this.defaultTTL,
+    });
+
+    logger.info(
+      { hash, resultSize: JSON.stringify(result).length },
+      "Cached document analysis result"
+    );
+  }
+
+  /**
+   * Clear cache for testing or manual invalidation
+   */
+  clear(): void {
+    const size = this.cache.size;
+    this.cache.clear();
+    logger.info({ size }, "Cleared analysis cache");
+  }
+
+  /**
+   * Get cache statistics
+   */
+  getStats(): { size: number; entries: number } {
+    let validEntries = 0;
+    for (const cached of this.cache.values()) {
+      if (Date.now() <= cached.expiresAt) {
+        validEntries++;
+      }
+    }
+
+    return {
+      size: this.cache.size,
+      entries: validEntries,
+    };
+  }
+}
+
+// Global cache instance (60 minute TTL)
+export const analysisCache = new AnalysisCache(60);


### PR DESCRIPTION
## Summary
Implement in-memory cache for document analysis results to prevent redundant LLM API calls.

## Changes
- Add AnalysisCache service with content-hash based caching 
- Configurable TTL (default 60 minutes)
- Automatic expiration and cleanup
- 9 comprehensive test cases

## Performance Impact
- Eliminates redundant LLM calls for duplicate documents
- Reduces API latency and costs
- Configurable freshness/performance tradeoff

Suggested labels: performance, bug, test, GSSoC 2026