### PR TITLE
fix: sanitize error responses to prevent information disclosure (#1991)

### DIFF
--- a/server/controllers/assessments.controller.ts
+++ b/server/controllers/assessments.controller.ts
@@ -11,6 +11,7 @@ import { searchQuerySchema, assessmentsQuerySchema, cohortQuerySchema } from "..
 import { canAccessPatientRecord } from "../services/authz/patient-access";
 import { logAccessAttempt } from "../security/access-audit";
 import { validateDTO } from "../middleware/validateDTO";
+import { getSafeServerErrorMessage } from "../security/errorSanitizer";
 import { existsSync } from "fs";
 import { execFile } from "child_process";
 import { fileURLToPath } from "url";
@@ -51,7 +52,8 @@ export const previewAssessment = async (req: Request, res: Response) => {
     if ((err as Error).message === "Clinical assessment timed out." || (err as Error).message.includes("timed out")) {
       return res.status(503).json({ message: "Clinical assessment preview timed out." });
     }
-    return res.status(500).json({ message: (err as Error).message || "Internal server error" });
+    logger.error({ err, endpoint: "previewAssessment" }, "Error in preview assessment");
+    return res.status(500).json({ message: getSafeServerErrorMessage(err) });
   }
 };
 
@@ -74,7 +76,8 @@ export const simulateWhatIf = async (req: Request, res: Response) => {
     if ((err as Error).message === "Clinical assessment timed out." || (err as Error).message.includes("timed out")) {
       return res.status(503).json({ message: "What-if assessment timed out." });
     }
-    return res.status(500).json({ message: (err as Error).message || "Internal server error" });
+    logger.error({ err, endpoint: "simulateWhatIf" }, "Error in what-if simulation");
+    return res.status(500).json({ message: getSafeServerErrorMessage(err) });
   }
 };
 

--- a/server/middleware/errorHandler.ts
+++ b/server/middleware/errorHandler.ts
@@ -4,6 +4,7 @@ import { logAuditEvent, generateRequestId } from "../services/security/auditLogg
 import { createErrorResponse } from "../../shared/schemas/errorResponse";
 import { logger } from "../logger";
 import { AppError } from "../utils/AppError";
+import { getSafeServerErrorMessage } from "../security/errorSanitizer";
 
 /**
  * Global Exception Handler
@@ -61,7 +62,7 @@ export function globalErrorHandler(
   if (err instanceof AppError) {
     safeMessage = err.message;
   } else if (finalStatus === 500) {
-    safeMessage = "An internal server error occurred";
+    safeMessage = getSafeServerErrorMessage(err);
   }
 
   // 5. Record security audit event

--- a/server/security/errorSanitizer.test.ts
+++ b/server/security/errorSanitizer.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import {
+  sanitizeErrorMessage,
+  getSafeServerErrorMessage,
+  getSafeClientErrorMessage,
+} from "./errorSanitizer";
+
+describe("errorSanitizer", () => {
+  describe("sanitizeErrorMessage", () => {
+    it("removes stack traces from error messages", () => {
+      const error = new Error("Database error at /home/user/app/db.ts (line 42:15)");
+      const result = sanitizeErrorMessage(error);
+      expect(result).not.toContain("/home/user");
+      expect(result).toBe("An error occurred");
+    });
+
+    it("removes file paths from error messages", () => {
+      const error = new Error("Failed to read /var/lib/app/config.json");
+      const result = sanitizeErrorMessage(error);
+      expect(result).not.toContain("/var/lib/app");
+      expect(result).toBe("An error occurred");
+    });
+
+    it("removes Windows file paths", () => {
+      const error = new Error("Failed at C:\\Users\\admin\\app\\server.js line 100");
+      const result = sanitizeErrorMessage(error);
+      expect(result).not.toContain("C:\\");
+      expect(result).toBe("An error occurred");
+    });
+
+    it("removes SQL error details", () => {
+      const error = new Error("database error: relation 'users' does not exist");
+      const result = sanitizeErrorMessage(error);
+      expect(result).toBe("An error occurred");
+    });
+
+    it("removes credential references", () => {
+      const error = new Error("Authentication failed: API key mismatch");
+      const result = sanitizeErrorMessage(error);
+      expect(result).toBe("An error occurred");
+    });
+
+    it("removes password references", () => {
+      const error = new Error("Database password validation failed");
+      const result = sanitizeErrorMessage(error);
+      expect(result).toBe("An error occurred");
+    });
+
+    it("removes IP addresses", () => {
+      const error = new Error("Connection refused from 192.168.1.100");
+      const result = sanitizeErrorMessage(error);
+      expect(result).not.toContain("192.168.1.100");
+      expect(result).toBe("An error occurred");
+    });
+
+    it("allows generic numbers in messages", () => {
+      const error = new Error("Process 5432 crashed");
+      const result = sanitizeErrorMessage(error);
+      // Generic numbers are allowed; only sensitive patterns are blocked
+      expect(result).toBe("Process 5432 crashed");
+    });
+
+    it("returns default message for null or undefined", () => {
+      expect(sanitizeErrorMessage(null)).toBe("An error occurred");
+      expect(sanitizeErrorMessage(undefined)).toBe("An error occurred");
+    });
+
+    it("accepts custom default message", () => {
+      const error = new Error("Stack trace at /var/app/error.ts");
+      const result = sanitizeErrorMessage(error, "Custom error occurred");
+      expect(result).toBe("Custom error occurred");
+    });
+
+    it("handles ENOENT error code", () => {
+      const error = new Error("ENOENT: no such file or directory");
+      (error as any).code = "ENOENT";
+      const result = sanitizeErrorMessage(error);
+      expect(result).toBe("Resource not found");
+    });
+
+    it("handles EACCES error code", () => {
+      const error = new Error("EACCES: permission denied");
+      (error as any).code = "EACCES";
+      const result = sanitizeErrorMessage(error);
+      expect(result).toBe("Access denied");
+    });
+
+    it("handles ETIMEDOUT error code", () => {
+      const error = new Error("ETIMEDOUT: operation timed out");
+      (error as any).code = "ETIMEDOUT";
+      const result = sanitizeErrorMessage(error);
+      expect(result).toBe("Request timed out");
+    });
+
+    it("removes messages with 'Internal' keyword", () => {
+      const error = new Error("Internal system error occurred");
+      const result = sanitizeErrorMessage(error);
+      expect(result).toBe("An error occurred");
+    });
+
+    it("removes messages with 'Uncaught' keyword", () => {
+      const error = new Error("Uncaught exception in main thread");
+      const result = sanitizeErrorMessage(error);
+      expect(result).toBe("An error occurred");
+    });
+
+    it("handles string error messages", () => {
+      const result = sanitizeErrorMessage("Database error at /var/app/db.ts");
+      expect(result).toBe("An error occurred");
+    });
+
+    it("handles object with message property", () => {
+      const error = { message: "Failed at /home/user/app.ts line 50" };
+      const result = sanitizeErrorMessage(error);
+      expect(result).toBe("An error occurred");
+    });
+
+    it("preserves safe error messages", () => {
+      const error = new Error("Validation failed: email is required");
+      const result = sanitizeErrorMessage(error);
+      // This should be preserved as it doesn't match sensitive patterns
+      expect(result).toBe("Validation failed: email is required");
+    });
+
+    it("preserves safe timeout message", () => {
+      const error = new Error("Request timed out after 30 seconds");
+      const result = sanitizeErrorMessage(error);
+      expect(result).toContain("timed out");
+    });
+  });
+
+  describe("getSafeServerErrorMessage", () => {
+    it("always returns generic message for server errors", () => {
+      const error = new Error("Sensitive DB error at /var/database/backup.sql");
+      const result = getSafeServerErrorMessage(error);
+      expect(result).toBe("An internal server error occurred");
+    });
+
+    it("returns generic message even for undefined errors", () => {
+      const result = getSafeServerErrorMessage();
+      expect(result).toBe("An internal server error occurred");
+    });
+
+    it("never exposes file paths in server error message", () => {
+      const error = new Error("/var/sensitive/path/exposed.ts");
+      const result = getSafeServerErrorMessage(error);
+      expect(result).not.toContain("/var");
+    });
+  });
+
+  describe("getSafeClientErrorMessage", () => {
+    it("returns safe validation error messages", () => {
+      const error = new Error("Email format is invalid");
+      const result = getSafeClientErrorMessage(error);
+      expect(result).toContain("invalid");
+    });
+
+    it("removes file paths from client errors", () => {
+      const error = new Error("Parse error at /app/parser.js:42");
+      const result = getSafeClientErrorMessage(error);
+      expect(result).not.toContain("/app/parser");
+    });
+
+    it("returns default message for sensitive client errors", () => {
+      const error = new Error("Database connection at 192.168.1.1 failed");
+      const result = getSafeClientErrorMessage(error, "Connection error");
+      expect(result).toBe("Connection error");
+    });
+
+    it("preserves safe validation messages", () => {
+      const error = new Error("Password must be at least 8 characters");
+      const result = getSafeClientErrorMessage(error);
+      expect(result).toContain("8 characters");
+    });
+  });
+});

--- a/server/security/errorSanitizer.ts
+++ b/server/security/errorSanitizer.ts
@@ -1,0 +1,106 @@
+/**
+ * errorSanitizer.ts
+ *
+ * Sanitizes error messages to prevent exposure of sensitive information
+ * such as stack traces, file paths, SQL details, and internal system details.
+ */
+
+/**
+ * Patterns that indicate sensitive information in error messages.
+ * These are stripped from client-facing error responses.
+ */
+const SENSITIVE_PATTERNS = [
+  /at\s+\S+\s+\(\S+\/\S+\)/gi, // Stack trace frames (at file path)
+  /\/[\w\-./]+\.(ts|js|py|java|rb)/gi, // File paths with extensions
+  /\/(?:home|Users|root|var|etc|tmp|app|srv)\/[\w\-./]+/gi, // Absolute system paths
+  /C:\\[\w\\]+/gi, // Windows paths
+  /(?:database|relation|table|column|schema).*(?:error|failed|missing|does not exist)/gi, // Database error details
+  /(?:database|secret|credential|api.?key|token)\s*(?:error|validation|mismatch|failed)/gi, // Credential/auth errors
+  /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/g, // IP addresses
+];
+
+/**
+ * Messages that should never be exposed to clients.
+ * Maps error types to safe messages.
+ */
+const ERROR_MESSAGE_MAPPING: Record<string, string> = {
+  "ENOENT": "Resource not found",
+  "EACCES": "Access denied",
+  "ETIMEDOUT": "Request timed out",
+  "ECONNREFUSED": "Service unavailable",
+  "ECONNRESET": "Connection reset",
+};
+
+/**
+ * Check if an error message contains sensitive information.
+ */
+function containsSensitiveInfo(message: string): boolean {
+  return SENSITIVE_PATTERNS.some(pattern => pattern.test(message));
+}
+
+/**
+ * Sanitize an error message by removing sensitive information.
+ * Returns a safe message suitable for client exposure.
+ *
+ * @param error The error object or message
+ * @param defaultMessage Fallback message if sanitization results in empty string
+ * @returns A safe error message for client response
+ */
+export function sanitizeErrorMessage(
+  error: unknown,
+  defaultMessage = "An error occurred"
+): string {
+  if (!error) {
+    return defaultMessage;
+  }
+
+  // Extract message from Error object
+  let message = "";
+  if (error instanceof Error) {
+    message = error.message;
+  } else if (typeof error === "string") {
+    message = error;
+  } else if (typeof error === "object" && "message" in error) {
+    message = String((error as any).message);
+  } else {
+    return defaultMessage;
+  }
+
+  // Check for known safe error codes
+  if ((error as any)?.code && ERROR_MESSAGE_MAPPING[(error as any).code]) {
+    return ERROR_MESSAGE_MAPPING[(error as any).code];
+  }
+
+  // Return default if message contains sensitive info
+  if (containsSensitiveInfo(message)) {
+    return defaultMessage;
+  }
+
+  // Only return message if it doesn't contain "Error" suffix or system keywords
+  if (message.toLowerCase().includes("internal") ||
+      message.toLowerCase().includes("system") ||
+      message.toLowerCase().includes("uncaught")) {
+    return defaultMessage;
+  }
+
+  return message || defaultMessage;
+}
+
+/**
+ * Safe error response wrapper for 5xx errors.
+ * Always returns a generic message to the client.
+ */
+export function getSafeServerErrorMessage(error?: unknown): string {
+  return "An internal server error occurred";
+}
+
+/**
+ * Safe error response wrapper for 4xx validation errors.
+ * Returns message only if it doesn't expose sensitive paths or internal details.
+ */
+export function getSafeClientErrorMessage(
+  error: unknown,
+  defaultMessage = "Invalid request"
+): string {
+  return sanitizeErrorMessage(error, defaultMessage);
+}


### PR DESCRIPTION
## Summary
Prevents exposure of sensitive information in API error responses by sanitizing errors before sending to clients:
- Removes stack traces, file paths, and absolute system paths
- Filters database error details, internal keywords, and credential references  
- Blocks IP addresses from error messages
- Ensures all 500 errors return generic messages
 
## Implementation Details
Introduces `errorSanitizer` module that:
- Patterns-matches sensitive information in error messages
- Maps known error codes to safe user-facing messages
- Provides utility functions for different error contexts (server vs client)
- Integrates with global error handler and controller responses

Updated error handlers in:
- `server/middleware/errorHandler.ts` — Global exception handler
- `server/controllers/assessments.controller.ts` — Controller error responses

All 5xx errors now return "An internal server error occurred" while full error details are logged server-side with requestId for debugging.

## Test Coverage
- 26 comprehensive tests for error sanitization:
  - ✓ Removes stack traces from error messages
  - ✓ Strips file paths and system paths
  - ✓ Filters database and SQL error details
  - ✓ Removes credential and password references
  - ✓ Blocks IP addresses
  - ✓ Handles known error codes (ENOENT, EACCES, ETIMEDOUT)
  - ✓ Preserves safe validation messages
  - ✓ Returns generic server error messages

## Suggested GSSoC Labels
- 🔒 **security:information-disclosure** — Information disclosure prevention
- 🛡️ **security:error-handling** — Security error handling improvements
- 🔐 **security:defense-in-depth** — Defense-in-depth security measure