### PR TITLE
feat(server): add RLS client tracking, pool metrics, and drain on shutdown

### DIFF
--- a/server/db-rls.ts
+++ b/server/db-rls.ts
@@ -2,6 +2,7 @@ import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import pg from "pg";
 import * as schema from "@shared/schema";
 import { getPool, dbRlsStorage } from "./db";
+import { logger } from "./logger";
 
 export interface RlsUserContext {
   userId: string;
@@ -12,8 +13,81 @@ export interface RlsUserContext {
 
 const rlsStorage = dbRlsStorage;
 
+// ── Active RLS client tracking ───────────────────────
+// Tracks every checked-out client so they can be drained during shutdown.
+const activeRlsClients = new Set<pg.PoolClient>();
+
 export function getRlsDb(): NodePgDatabase<typeof schema> | undefined {
   return dbRlsStorage.getStore();
+}
+
+/**
+ * Register an RLS client for tracking. Called by createRlsClient.
+ */
+export function registerRlsClient(client: pg.PoolClient): void {
+  activeRlsClients.add(client);
+}
+
+/**
+ * Unregister an RLS client. Called when the client is released.
+ */
+export function unregisterRlsClient(client: pg.PoolClient): void {
+  activeRlsClients.delete(client);
+}
+
+/**
+ * Return the number of currently active (checked-out) RLS clients.
+ */
+export function getActiveRlsCount(): number {
+  return activeRlsClients.size;
+}
+
+/**
+ * Return pool utilisation metrics for observability and health checks.
+ */
+export function getPoolMetrics(): {
+  activeRlsClients: number;
+  totalConnections: number;
+  idleConnections: number;
+  waitingClients: number;
+} {
+  const pool = getPool();
+  return {
+    activeRlsClients: activeRlsClients.size,
+    totalConnections: pool.totalCount,
+    idleConnections: pool.idleCount,
+    waitingClients: pool.waitingCount,
+  };
+}
+
+/**
+ * Gracefully release all tracked RLS clients. Called during shutdown
+ * before the pool itself is closed.
+ */
+export async function drainRlsClients(): Promise<void> {
+  const count = activeRlsClients.size;
+  if (count === 0) return;
+
+  logger.info({ activeRlsClients: count }, "Draining RLS clients…");
+
+  const timeout = 10_000;
+  const drainStart = Date.now();
+
+  for (const client of activeRlsClients) {
+    try {
+      client.release();
+    } catch (err) {
+      logger.error({ err }, "Error releasing RLS client during drain");
+    }
+  }
+  activeRlsClients.clear();
+
+  const elapsed = Date.now() - drainStart;
+  if (elapsed >= timeout) {
+    logger.warn({ elapsedMs: elapsed }, "RLS client drain may have timed out");
+  } else {
+    logger.info({ count, elapsedMs: elapsed }, "RLS clients drained");
+  }
 }
 
 export async function createRlsClient(context: RlsUserContext): Promise<{
@@ -46,6 +120,9 @@ export async function createRlsClient(context: RlsUserContext): Promise<{
     client.release();
     throw err;
   }
+
+  // Track this client so it can be drained on shutdown
+  registerRlsClient(client);
 
   const db = drizzle(client, { schema });
   return { db, client };

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,6 +33,7 @@ import { generalLimiter } from "./middleware/rateLimit";
 import { registerOpenApiDocs } from "./openapi";
 import { initAssessmentSocket } from "./socket/assessmentSocket";
 import { rlsContextMiddleware } from "./middleware/rlsContext";
+import { drainRlsClients, getPoolMetrics } from "./db-rls";
 
 import compression from "compression";
 
@@ -309,8 +310,10 @@ registerOpenApiDocs(app);
 
     httpServer.close(async () => {
       logger.info({ source: "express" }, "HTTP server closed");
+      logger.info({ source: "express", metrics: getPoolMetrics() }, "Pool metrics before drain");
       await closeQueue();
       logger.info({ source: "express" }, "Assessment queue closed");
+      await drainRlsClients();
       await closePool();
       logger.info({ source: "express" }, "Database pool closed");
       process.exit(0);

--- a/server/middleware/rlsContext.ts
+++ b/server/middleware/rlsContext.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from "express";
-import { createRlsClient, runWithRlsDb, type RlsUserContext } from "../db-rls";
+import { createRlsClient, runWithRlsDb, unregisterRlsClient, type RlsUserContext } from "../db-rls";
 import { getDb } from "../db";
 import { patientUsers } from "@shared/schema";
 import { eq } from "drizzle-orm";
@@ -111,6 +111,7 @@ export async function rlsContextMiddleware(
       if (client) {
         try {
           client.release();
+          unregisterRlsClient(client);
         } catch (err) {
           logger.error({ err }, "Failed to release RLS database client");
         }
@@ -139,7 +140,10 @@ export async function rlsContextMiddleware(
     }
   } catch (err) {
     if (client) {
-      try { client.release(); } catch { /* ignore */ }
+      try {
+        client.release();
+        unregisterRlsClient(client);
+      } catch { /* ignore */ }
     }
     logger.error({ err }, "Failed to set up RLS context");
     next(err);


### PR DESCRIPTION
## Summary

Adds active RLS database client tracking with a `Set<pg.PoolClient>`, pool utilization metrics, and graceful draining during shutdown. Prevents connection leaks and provides observability into pool health.

## Changes

- `server/db-rls.ts`: Added `activeRlsClients` set, `registerRlsClient`, `unregisterRlsClient`, `getActiveRlsCount`, `getPoolMetrics`, `drainRlsClients`
- `server/middleware/rlsContext.ts`: Calls `unregisterRlsClient` on client release/error
- `server/index.ts`: Logs pool metrics and calls `drainRlsClients()` before `closePool()` in shutdown handler

Closes #1657