### PR TITLE
[BUG] Bulk ML endpoint stores UUID in createdBy instead of email — fix #1792

### DIFF
--- a/server/queue.ts
+++ b/server/queue.ts
@@ -163,7 +163,7 @@ export function startAssessmentWorker(): void {
     "assessmentQueue",
     async (job: Job) => {
       if (job.name === "predictBatch") {
-        const { assessments, userId } = job.data;
+        const { assessments, userId, userEmail } = job.data;
         const startedAt = Date.now();
         const requestId = (job.data as any).requestFingerprint ?? job.id;
         
@@ -213,7 +213,7 @@ export function startAssessmentWorker(): void {
                       JSON.stringify(prediction.factors || []),
                       prediction.confidenceInterval ?? null,
                       prediction.modelConfidence == null ? null : Number(prediction.modelConfidence),
-                      userId,
+                      userEmail || userId,
                       userId,
                     ]
                   );

--- a/server/routes/ml.routes.ts
+++ b/server/routes/ml.routes.ts
@@ -47,6 +47,7 @@ mlRouter.post(
       const job = await assessmentQueue.add("predictBatch", {
         assessments: input,
         userId,
+        userEmail,
         batchId
       });
 


### PR DESCRIPTION
## Description

Fixes #1792 — Bulk ML endpoint stores UUID in `createdBy` instead of email, inconsistent with all other assessment creation paths.

## Root Cause

The `predictBatch` handler in `queue.ts` received only `userId` (a UUID) from the job data and stored it directly in `createdBy`. Every other assessment creation path stores the user's email.

## Changes

| File | Change |
|------|--------|
| `server/routes/ml.routes.ts` | Pass `userEmail` alongside `userId` in `predictBatch` job data |
| `server/queue.ts` | Use `userEmail || userId` for `createdBy` in the `predictBatch` INSERT, matching the single-assessment worker pattern |

## Impact

- Fixes broken `createdBy`-by-email queries for bulk assessments
- Consistent data model: `createdBy` always contains an email (or falls back to UUID)
- Affects only the bulk ML path; single-assessment path was already correct

## Verification

- [x] `predictBatch` INSERT uses `userEmail || userId` (same pattern as single-assessment worker at line ~226)
- [x] `ml.routes.ts` already extracts `userEmail` from session — no new session access needed