### PR TITLE
[BUG] console.error used instead of logger.error in OAuth callback (oauth2.ts:280) — fix #1790

### DIFF
--- a/server/auth/oauth2.ts
+++ b/server/auth/oauth2.ts
@@ -38,6 +38,7 @@ import { Router, type Request, type Response } from "express";
 import crypto from "crypto";
 import bcrypt from "bcrypt";
 import { getDb } from "../db";
+import { logger } from "../logger";
 import { users } from "@shared/schema";
 import { eq } from "drizzle-orm";
 
@@ -278,7 +279,7 @@ export function createOAuth2Router(): Router {
         });
       });
     } catch (err: any) {
-      console.error("OAuth callback error:", err);
+      logger.error({ err }, "OAuth callback error");
       res.status(500).json({
         message: "OAuth2 authentication failed. Please try again.",
       });


### PR DESCRIPTION
## Description

Fixes #1790 — OAuth2 callback error handler uses `console.error()` instead of the project's structured `logger.error()`.

## Changes

| File | Change |
|------|--------|
| `server/auth/oauth2.ts` | Add `import { logger } from "../logger"`; replace `console.error("OAuth callback error:", err)` with `logger.error({ err }, "OAuth callback error")` |

## Impact

- Structured error logging with object context instead of raw string interpolation
- Consistent with the rest of the codebase
- Allows log filtering, routing, and level-based suppression in production