### PR TITLE
[BUG] Inconsistent logging in auth.repository.ts — fix #1788 (also refs #1791)

### DIFF
--- a/server/repositories/auth.repository.ts
+++ b/server/repositories/auth.repository.ts
@@ -217,7 +217,7 @@ await tx
       try {
         await tx.execute(sql`DELETE FROM "session" WHERE (sess->'user'->>'id') = ${userId}`);
       } catch (sessErr) {
-        console.error("Failed to clear user sessions upon password reset", sessErr);
+        logger.error({ err: sessErr }, "Failed to clear user sessions upon password reset");
       }
     });
   }


### PR DESCRIPTION
## Description

Fixes #1788 and addresses the remaining concern from #1791.

## Problem

`consumePasswordResetToken` logged session cleanup failures via `console.error()` at line ~220, while the sibling method `claimPasswordResetToken` used structured `logger.error()`. This caused inconsistent log output (no structured context, no level filtering, no transport integration).

## Changes

| File | Change |
|------|--------|
| `server/repositories/auth.repository.ts` | Replace `console.error(...)` with `logger.error({ err: sessErr }, ...)` in `consumePasswordResetToken` |

## Note on #1791

The primary concern of #1791 (missing `logger` import causing a ReferenceError) was already resolved in commit `a1d6946e` (June 25) which added `import { logger } from "../logger"`. This PR completes the fix by converting the remaining `console.error` call to use the now-available `logger` — resolving both #1788 and the secondary concern of #1791.