### PR TITLE
Fix: PHIRedactor.redact_patient_data no longer skips redaction of numeric patient IDs

### DIFF
--- a/app/services/phi_redactor.py
+++ b/app/services/phi_redactor.py
@@ -189,7 +189,7 @@ class PHIRedactor:
                     redacted_dict[k] = "[PHONE]"
                 elif k in ["dob", "dateOfBirth", "date"] and isinstance(v, str):
                     redacted_dict[k] = "[DATE]"
-                elif k in ["patientId", "mrn", "id"] and isinstance(v, str) and not v.isdigit():
+                elif k in ["patientId", "mrn", "id"] and isinstance(v, str) and not (v.isdigit() and len(v) <= 3):
                     redacted_dict[k] = "[PATIENT_ID]"
                 elif k in ["address"] and isinstance(v, str):
                     redacted_dict[k] = "[ADDRESS]"

--- a/tests/test_phi_redactor.py
+++ b/tests/test_phi_redactor.py
@@ -125,6 +125,56 @@ class TestPHIRedactor(unittest.TestCase):
         self.assertEqual(self.redactor.redact_patient_data(None), None)
         self.assertEqual(self.redactor.redact_patient_data([]), [])
 
+    def test_numeric_patient_id_redaction(self):
+        """Verify numeric-string patient IDs/MRNs are redacted, while short
+        digit strings that plausibly represent internal PKs (<=3 digits)
+        are left untouched."""
+        # Short digit-only strings are treated as internal PKs, not MRNs.
+        self.assertEqual(
+            self.redactor.redact_patient_data({"id": "1"}),
+            {"id": "1"}
+        )
+        self.assertEqual(
+            self.redactor.redact_patient_data({"id": "42"}),
+            {"id": "42"}
+        )
+        self.assertEqual(
+            self.redactor.redact_patient_data({"id": "999"}),
+            {"id": "999"}
+        )
+
+        # 4+ digit numeric-string IDs are real MRN-style identifiers and
+        # must be redacted regardless of key (id, patientId, mrn).
+        self.assertEqual(
+            self.redactor.redact_patient_data({"id": "1234"}),
+            {"id": "[PATIENT_ID]"}
+        )
+        self.assertEqual(
+            self.redactor.redact_patient_data({"id": "123456"}),
+            {"id": "[PATIENT_ID]"}
+        )
+        self.assertEqual(
+            self.redactor.redact_patient_data({"patientId": "9876543210"}),
+            {"patientId": "[PATIENT_ID]"}
+        )
+        self.assertEqual(
+            self.redactor.redact_patient_data({"mrn": "7890123"}),
+            {"mrn": "[PATIENT_ID]"}
+        )
+
+        # Non-numeric ID formats continue to be redacted as before.
+        self.assertEqual(
+            self.redactor.redact_patient_data({"id": "MRN-9876"}),
+            {"id": "[PATIENT_ID]"}
+        )
+
+        # Numeric (int) IDs are untouched — only string values are redacted,
+        # matching existing behavior for internal integer primary keys.
+        self.assertEqual(
+            self.redactor.redact_patient_data({"id": 123456}),
+            {"id": 123456}
+        )
+
     def test_large_note_input(self):
         """Verify performance and memory stability on extremely large notes."""
         import time


### PR DESCRIPTION
## Summary
Fixes #1675. In `redact_patient_data`, the guard `isinstance(v, str) and not v.isdigit()` exempted *any* all-digit string from redaction for the `patientId`/`mrn`/`id` keys — including 6–10 digit MRN-style IDs, the most common identifier format in EHR systems. These values passed through unredacted into logs, audit trails, and any response containing the raw dict.

## Root cause
`str.isdigit()` returns `True` for digit strings of any length. The guard was intended to protect short internal PKs (e.g. `"1"`, `"42"`) from being clobbered, but it had no length bound, so it also exempted genuine MRNs like `"123456"`.

## Fix
Replaced the blanket guard with a length threshold: digit-only strings of 3 characters or fewer are treated as plausible internal PKs and left alone; anything 4+ digits is redacted as `[PATIENT_ID]`, matching the intent already implemented for text-embedded MRNs in `redact_text`/`mrn_indicator_regex`.

```python
elif k in ["patientId", "mrn", "id"] and isinstance(v, str) and not (v.isdigit() and len(v) <= 3):
    redacted_dict[k] = "[PATIENT_ID]"
```

## Testing
Added `test_numeric_patient_id_redaction` to `tests/test_phi_redactor.py`:
- `{"id": "1"}`, `{"id": "42"}`, `{"id": "999"}` → left unredacted (short PK-like values)
- `{"id": "1234"}`, `{"id": "123456"}`, `{"patientId": "9876543210"}`, `{"mrn": "7890123"}` → redacted to `[PATIENT_ID]`
- `{"id": "MRN-9876"}` → still redacted (non-numeric format, unaffected by this change)
- `{"id": 123456}` (int, not str) → unaffected, confirming only string values are in scope

All 13 tests in `tests/test_phi_redactor.py` pass (`python3 -m pytest tests/test_phi_redactor.py -q`).

## Risk / rollout notes
- Any caller currently relying on numeric string IDs passing through `redact_patient_data` unredacted will now see `[PATIENT_ID]` for values 4+ digits long — this is the intended fix, not a regression.
- Integer-typed IDs (not strings) are unaffected, preserving existing behavior for internal PKs stored as `int`.