### PR TITLE
fix: remove duplicate claimPasswordResetToken call in reset-password handler

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -749,7 +749,6 @@ out
         }
       });
 
-      await authRepository.claimPasswordResetToken(token, passwordHash);
       return res.json({ success: true, message: "Password has been reset successfully." });
     } catch (err: any) {
       if (err.statusCode === 400) {


### PR DESCRIPTION
## Description

Removed a duplicate `authRepository.claimPasswordResetToken()` call in the `POST /api/auth/reset-password` handler that executed the password reset flow a second time after the inline `db.transaction()` had already completed it.

The inline transaction (lines 726-750) correctly:
- Marks the token as `used: true` (using SHA-256 hash)
- Updates the user's `passwordHash`
- Deletes active sessions for that user

The removed repository call (`claimPasswordResetToken`) searched by the **raw token** (not SHA-256 hash), so it never found a matching token — it silently errored on every password reset attempt.

## Related Issue

Closes #2267

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Removed `await authRepository.claimPasswordResetToken(token, passwordHash);` from `server/auth.ts:752`
- The `db.transaction()` block above already handles everything — this was dead code left over from a previous refactor

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable (existing auth tests cover the flow)
- [x] All existing tests pass (44 test files, 584 tests pass; 7 pre-existing failures from missing `resend`/`jsdom` packages)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed (not needed — API behavior unchanged)
- [x] My changes generate no new warnings or errors