### PR TITLE
docs: add missing blank line after example request heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,7 @@ On the **Clinician View** tab of the results page, the clinical note is rendered
   * Press **Escape** to clear the selection and highlight.
 
 #### Example Request
+
 ```bash
 curl -X POST http://localhost:3000/api/ingest/fhir \
   -H "Content-Type: application/json" \


### PR DESCRIPTION
## Description

This PR fixes a Markdown rendering issue in the README. Previously, there was a missing blank line between the `#### Example Request` heading (under the FHIR Ingestion section) and the subsequent bash code block. In standard Markdown, failing to place a blank line after a heading can cause parsers to fail to render it as a header, leaving it formatted as plain text merged with the code block below it. Adding this blank line ensures the section is correctly recognized and formatted as an `h4` element.

## Related Issue

Closes #None (just a documentation quick fix)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- Added a missing blank line immediately after the `#### Example Request` heading in `README.md`.
- Ensured standard Markdown parsers will correctly render the heading as an `h4` element instead of plain text.

## Screenshots (if applicable)

N/A

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors