### PR TITLE
test: extend requestId middleware coverage with edge cases and AsyncLocalStorage integration tests

### DIFF
--- a/server/middleware/requestId.integration.test.ts
+++ b/server/middleware/requestId.integration.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import type { Request, Response } from "express";
+import { requestIdMiddleware } from "./requestId";
+import { requestContext } from "../logger";
+
+// Integration test: uses the REAL requestContext (AsyncLocalStorage), unmocked,
+// to verify the request ID is genuinely retrievable from within the async
+// context established by the middleware, not just passed to a mocked run().
+
+function mockRequest(headers: Record<string, string> = {}): Request {
+  return { headers } as unknown as Request;
+}
+
+function mockResponse() {
+  return { setHeader: () => {} } as unknown as Response;
+}
+
+describe("requestIdMiddleware - AsyncLocalStorage integration", () => {
+  it("makes the request id retrievable via requestContext.getStore() inside next()", () => {
+    const req = mockRequest({ "x-request-id": "integration-trace-id" });
+    const res = mockResponse();
+
+    let storeValueInsideNext: string | undefined;
+
+    requestIdMiddleware(req, res, () => {
+      storeValueInsideNext = requestContext.getStore();
+    });
+
+    expect(storeValueInsideNext).toBe("integration-trace-id");
+  });
+
+  it("makes a generated UUID retrievable via requestContext.getStore() when no header is provided", () => {
+    const req = mockRequest();
+    const res = mockResponse();
+
+    let storeValueInsideNext: string | undefined;
+
+    requestIdMiddleware(req, res, () => {
+      storeValueInsideNext = requestContext.getStore();
+    });
+
+    expect(storeValueInsideNext).toBe((req as any).id);
+    expect(storeValueInsideNext).toBeTruthy();
+  });
+
+  it("does not leak context between two sequential requests", () => {
+    const req1 = mockRequest({ "x-request-id": "request-one" });
+    const req2 = mockRequest({ "x-request-id": "request-two" });
+    const res = mockResponse();
+
+    let firstStore: string | undefined;
+    let secondStore: string | undefined;
+
+    requestIdMiddleware(req1, res, () => {
+      firstStore = requestContext.getStore();
+    });
+
+    requestIdMiddleware(req2, res, () => {
+      secondStore = requestContext.getStore();
+    });
+
+    expect(firstStore).toBe("request-one");
+    expect(secondStore).toBe("request-two");
+    expect(requestContext.getStore()).toBeUndefined();
+  });
+});

--- a/server/middleware/requestId.test.ts
+++ b/server/middleware/requestId.test.ts
@@ -41,21 +41,29 @@ describe("requestIdMiddleware", () => {
 
   it("sets X-Request-ID header on the response", () => {
     requestIdMiddleware(mockReq as Request, mockRes as Response, mockNext);
-    expect(mockRes.setHeader).toHaveBeenCalledWith("X-Request-ID", expect.any(String));
+    expect(mockRes.setHeader).toHaveBeenCalledWith(
+      "X-Request-ID",
+      expect.any(String)
+    );
   });
 
   it("uses existing x-request-id header when present", () => {
     mockReq.headers = { "x-request-id": "existing-id-123" };
     requestIdMiddleware(mockReq as Request, mockRes as Response, mockNext);
-    expect(mockRes.setHeader).toHaveBeenCalledWith("X-Request-ID", "existing-id-123");
+    expect(mockRes.setHeader).toHaveBeenCalledWith(
+      "X-Request-ID",
+      "existing-id-123"
+    );
   });
 
   it("generates a new UUID when x-request-id header is absent", () => {
     requestIdMiddleware(mockReq as Request, mockRes as Response, mockNext);
-    const headerCall = (mockRes.setHeader as ReturnType<typeof vi.fn>).mock.calls.find(
-      (call) => call[0] === "X-Request-ID"
+    const headerCall = (
+      mockRes.setHeader as ReturnType<typeof vi.fn>
+    ).mock.calls.find((call) => call[0] === "X-Request-ID");
+    expect(headerCall[1]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
     );
-    expect(headerCall[1]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
   });
 
   it("attaches the request ID to req.id", () => {
@@ -67,7 +75,10 @@ describe("requestIdMiddleware", () => {
     mockReq.headers = { "x-request-id": "my-custom-id" };
     requestIdMiddleware(mockReq as Request, mockRes as Response, mockNext);
     expect((mockReq as any).id).toBe("my-custom-id");
-    expect(mockRes.setHeader).toHaveBeenCalledWith("X-Request-ID", "my-custom-id");
+    expect(mockRes.setHeader).toHaveBeenCalledWith(
+      "X-Request-ID",
+      "my-custom-id"
+    );
   });
 
   it("runs next within requestContext.run", () => {
@@ -76,5 +87,22 @@ describe("requestIdMiddleware", () => {
       expect.any(String),
       expect.any(Function)
     );
+  });
+  it("falls back to generating a new UUID when x-request-id header is an empty string", () => {
+    mockReq.headers = { "x-request-id": "" };
+    requestIdMiddleware(mockReq as Request, mockRes as Response, mockNext);
+    const headerCall = (mockRes.setHeader as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call) => call[0] === "X-Request-ID"
+    );
+    expect(headerCall[1]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+    expect(headerCall[1]).not.toBe("");
+  });
+
+  it("does not crash when x-request-id header arrives as an array (duplicate headers)", () => {
+    mockReq.headers = { "x-request-id": ["first-id", "second-id"] as any };
+    expect(() =>
+      requestIdMiddleware(mockReq as Request, mockRes as Response, mockNext)
+    ).not.toThrow();
+    expect(mockNext).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Description
While picking up issue #2132 (add unit tests for the `requestId` middleware), I found the base test coverage had already been merged via PR #2217 (commit `45cc9953`), covering UUID assignment, header setting, header preservation, and a mocked `requestContext.run` call.

Since that coverage was fully mocked, none of the existing tests actually verified real `AsyncLocalStorage` propagation, nor did they cover a couple of edge cases in header handling. This PR extends coverage with genuinely new test cases rather than duplicating existing ones.

## Related Issue
Related to #2132

## Type of Change
- [x] 🧪 Test addition or update

## Changes Made
- Added 2 edge-case tests to `server/middleware/requestId.test.ts`: empty-string `x-request-id` header falls back to a generated UUID, and array-valued `x-request-id` header (duplicate headers) does not crash the middleware
- Added a new `server/middleware/requestId.integration.test.ts` file that uses the **real**, unmocked `requestContext` (`AsyncLocalStorage`) to verify the request ID is genuinely retrievable via `requestContext.getStore()` inside `next()`, and that context doesn't leak between sequential requests

## Screenshots (if applicable)
N/A — test-only change, no UI.

## Testing
- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors