### PR TITLE
feat: add confidence indicator for generated insights

### DIFF
--- a/client/src/components/ClinicalNoteViewer.tsx
+++ b/client/src/components/ClinicalNoteViewer.tsx
@@ -7,6 +7,7 @@ export interface ExplainableInsight {
   insight: string;
   source_snippet: string | null;
   source_index: [number, number] | null;
+  confidence: "high" | "medium" | "low";
 }
 
 interface ClinicalNoteViewerProps {
@@ -125,6 +126,20 @@ export function ClinicalNoteViewer({ noteText, insights }: ClinicalNoteViewerPro
               {insights.map((ins, idx) => {
                 const isSelected = selectedIndex === idx;
                 const hasCitation = ins.source_index !== null;
+                const confidenceBadge = {
+  high: {
+    label: "🟢 High Confidence",
+    className: "bg-green-100 text-green-700",
+  },
+  medium: {
+    label: "🟡 Medium Confidence",
+    className: "bg-yellow-100 text-yellow-700",
+  },
+  low: {
+    label: "🔴 Low Confidence",
+    className: "bg-red-100 text-red-700",
+  },
+}[ins.confidence];
 
                 return (
                   <button
@@ -149,6 +164,14 @@ export function ClinicalNoteViewer({ noteText, insights }: ClinicalNoteViewerPro
                       )}
                       <span className="font-semibold text-sm leading-tight flex-1">{ins.insight}</span>
                     </div>
+                    <span
+  className={cn(
+    "mt-2 inline-flex items-center rounded-full px-2 py-1 text-[11px] font-medium",
+    confidenceBadge.className
+  )}
+>
+  {confidenceBadge.label}
+</span>
                     {ins.source_snippet && (
                       <span className="text-[11px] mt-1.5 opacity-80 italic line-clamp-2 bg-slate-100/60 dark:bg-slate-900/60 px-2 py-1 rounded w-full border border-slate-200/40 dark:border-slate-800/40">
                         "{ins.source_snippet}"

--- a/server/services/fhirParser.ts
+++ b/server/services/fhirParser.ts
@@ -211,6 +211,7 @@ export interface ExplainableInsight {
   insight: string;
   source_snippet: string | null;
   source_index: [number, number] | null;
+  confidence: "high" | "medium" | "low";
 }
 
 export function extractExplainableInsights(noteText: string): ExplainableInsight[] {
@@ -226,7 +227,12 @@ export function extractExplainableInsights(noteText: string): ExplainableInsight
   const lowerText = noteText.toLowerCase();
 
   // 1. Hypertension
-  let htInsight: ExplainableInsight = { insight: "Patient shows signs of hypertension", source_snippet: null, source_index: null };
+  let htInsight: ExplainableInsight = {
+  insight: "Patient shows signs of hypertension",
+  source_snippet: null,
+  source_index: null,
+  confidence: "low",
+};
   const bpRegex = /\b(?:bp|blood pressure|reading|vitals)?\s*(\d{2,3})\s*[/|-]\s*(\d{2,3})\b/i;
   const bpMatch = noteText.match(bpRegex);
   if (bpMatch) {
@@ -235,10 +241,11 @@ export function extractExplainableInsights(noteText: string): ExplainableInsight
     if (systolic > 140 || diastolic > 90) {
       const sentence = getSentenceContaining(noteText, bpMatch.index!, bpMatch[0].length);
       htInsight = {
-        insight: "Patient shows signs of hypertension",
-        source_snippet: sentence.snippet,
-        source_index: [sentence.start, sentence.end],
-      };
+  insight: "Patient shows signs of hypertension",
+  source_snippet: sentence.snippet,
+  source_index: [sentence.start, sentence.end],
+  confidence: "high",
+};
     }
   }
   
@@ -252,6 +259,7 @@ export function extractExplainableInsights(noteText: string): ExplainableInsight
           insight: "Patient shows signs of hypertension",
           source_snippet: sentence.snippet,
           source_index: [sentence.start, sentence.end],
+          confidence: "high",
         };
         break;
       }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -35,10 +35,11 @@ export const assessments = pgTable("assessments", {
   userId: text("user_id"),
   clinicalNote: text("clinical_note"),
   explainableInsights: jsonb("explainable_insights").$type<Array<{
-    insight: string;
-    source_snippet: string | null;
-    source_index: [number, number] | null;
-  }>>(),
+  insight: string;
+  source_snippet: string | null;
+  source_index: [number, number] | null;
+  confidence: "high" | "medium" | "low";
+}>(),
 }, (table) => [
   index("created_by_id_idx").on(table.createdBy, table.id),
   index("owner_id_idx").on(table.ownerId),
@@ -113,11 +114,12 @@ export const insertAssessmentSchema = createInsertSchema(assessments, {
   ),
   createdBy: z.string().email("Created by email must be a valid email address.").optional(),
   clinicalNote: z.string().optional().nullable(),
-  explainableInsights: z.array(z.object({
-    insight: z.string(),
-    source_snippet: z.string().nullable(),
-    source_index: z.tuple([z.number(), z.number()]).nullable()
-  })).optional().nullable(),
+ explainableInsights: z.array(z.object({
+  insight: z.string(),
+  source_snippet: z.string().nullable(),
+  source_index: z.tuple([z.number(), z.number()]).nullable(),
+  confidence: z.enum(["high", "medium", "low"]),
+})).optional().nullable(),
 }).omit({
   id: true,
   userId: true,


### PR DESCRIPTION
## Description

Adds confidence indicators for generated clinical insights to improve transparency and help users assess the reliability of AI-generated findings. Each insight now displays a visual confidence badge based on the availability of supporting evidence.

## Related Issue

Closes #1629

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🎨 Style / UI improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Chore / Tooling / Config

## Changes Made

- Added confidence field to explainable insights schema and types.
- Assigned confidence levels based on supporting clinical evidence during insight generation.
- Displayed color-coded confidence badges (High, Medium, Low) alongside generated insights in the Clinical Note Viewer.

## Screenshots (if applicable)

<!-- Add before/after screenshots for UI changes -->

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors