### PR TITLE
Test/2132 requestid middleware unit tests

### DIFF
--- a/server/middleware/requestId.integration.test.ts
+++ b/server/middleware/requestId.integration.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import type { Request, Response } from "express";
+import { requestIdMiddleware } from "./requestId";
+import { requestContext } from "../logger";
+
+// Integration test: uses the REAL requestContext (AsyncLocalStorage), unmocked,
+// to verify the request ID is genuinely retrievable from within the async
+// context established by the middleware, not just passed to a mocked run().
+
+function mockRequest(headers: Record<string, string> = {}): Request {
+  return { headers } as unknown as Request;
+}
+
+function mockResponse() {
+  return { setHeader: () => {} } as unknown as Response;
+}
+
+describe("requestIdMiddleware - AsyncLocalStorage integration", () => {
+  it("makes the request id retrievable via requestContext.getStore() inside next()", () => {
+    const req = mockRequest({ "x-request-id": "integration-trace-id" });
+    const res = mockResponse();
+
+    let storeValueInsideNext: string | undefined;
+
+    requestIdMiddleware(req, res, () => {
+      storeValueInsideNext = requestContext.getStore();
+    });
+
+    expect(storeValueInsideNext).toBe("integration-trace-id");
+  });
+
+  it("makes a generated UUID retrievable via requestContext.getStore() when no header is provided", () => {
+    const req = mockRequest();
+    const res = mockResponse();
+
+    let storeValueInsideNext: string | undefined;
+
+    requestIdMiddleware(req, res, () => {
+      storeValueInsideNext = requestContext.getStore();
+    });
+
+    expect(storeValueInsideNext).toBe((req as any).id);
+    expect(storeValueInsideNext).toBeTruthy();
+  });
+
+  it("does not leak context between two sequential requests", () => {
+    const req1 = mockRequest({ "x-request-id": "request-one" });
+    const req2 = mockRequest({ "x-request-id": "request-two" });
+    const res = mockResponse();
+
+    let firstStore: string | undefined;
+    let secondStore: string | undefined;
+
+    requestIdMiddleware(req1, res, () => {
+      firstStore = requestContext.getStore();
+    });
+
+    requestIdMiddleware(req2, res, () => {
+      secondStore = requestContext.getStore();
+    });
+
+    expect(firstStore).toBe("request-one");
+    expect(secondStore).toBe("request-two");
+    expect(requestContext.getStore()).toBeUndefined();
+  });
+});

--- a/server/middleware/requestId.test.ts
+++ b/server/middleware/requestId.test.ts
@@ -41,21 +41,29 @@ describe("requestIdMiddleware", () => {
 
   it("sets X-Request-ID header on the response", () => {
     requestIdMiddleware(mockReq as Request, mockRes as Response, mockNext);
-    expect(mockRes.setHeader).toHaveBeenCalledWith("X-Request-ID", expect.any(String));
+    expect(mockRes.setHeader).toHaveBeenCalledWith(
+      "X-Request-ID",
+      expect.any(String)
+    );
   });
 
   it("uses existing x-request-id header when present", () => {
     mockReq.headers = { "x-request-id": "existing-id-123" };
     requestIdMiddleware(mockReq as Request, mockRes as Response, mockNext);
-    expect(mockRes.setHeader).toHaveBeenCalledWith("X-Request-ID", "existing-id-123");
+    expect(mockRes.setHeader).toHaveBeenCalledWith(
+      "X-Request-ID",
+      "existing-id-123"
+    );
   });
 
   it("generates a new UUID when x-request-id header is absent", () => {
     requestIdMiddleware(mockReq as Request, mockRes as Response, mockNext);
-    const headerCall = (mockRes.setHeader as ReturnType<typeof vi.fn>).mock.calls.find(
-      (call) => call[0] === "X-Request-ID"
+    const headerCall = (
+      mockRes.setHeader as ReturnType<typeof vi.fn>
+    ).mock.calls.find((call) => call[0] === "X-Request-ID");
+    expect(headerCall[1]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
     );
-    expect(headerCall[1]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
   });
 
   it("attaches the request ID to req.id", () => {
@@ -67,7 +75,10 @@ describe("requestIdMiddleware", () => {
     mockReq.headers = { "x-request-id": "my-custom-id" };
     requestIdMiddleware(mockReq as Request, mockRes as Response, mockNext);
     expect((mockReq as any).id).toBe("my-custom-id");
-    expect(mockRes.setHeader).toHaveBeenCalledWith("X-Request-ID", "my-custom-id");
+    expect(mockRes.setHeader).toHaveBeenCalledWith(
+      "X-Request-ID",
+      "my-custom-id"
+    );
   });
 
   it("runs next within requestContext.run", () => {
@@ -76,5 +87,22 @@ describe("requestIdMiddleware", () => {
       expect.any(String),
       expect.any(Function)
     );
+  });
+  it("falls back to generating a new UUID when x-request-id header is an empty string", () => {
+    mockReq.headers = { "x-request-id": "" };
+    requestIdMiddleware(mockReq as Request, mockRes as Response, mockNext);
+    const headerCall = (mockRes.setHeader as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call) => call[0] === "X-Request-ID"
+    );
+    expect(headerCall[1]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+    expect(headerCall[1]).not.toBe("");
+  });
+
+  it("does not crash when x-request-id header arrives as an array (duplicate headers)", () => {
+    mockReq.headers = { "x-request-id": ["first-id", "second-id"] as any };
+    expect(() =>
+      requestIdMiddleware(mockReq as Request, mockRes as Response, mockNext)
+    ).not.toThrow();
+    expect(mockNext).toHaveBeenCalledTimes(1);
   });
 });

--- a/server/middleware/requestId.test.ts
+++ b/server/middleware/requestId.test.ts
@@ -106,3 +106,55 @@ describe("requestIdMiddleware", () => {
     expect(mockNext).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("requestIdMiddleware - client-supplied X-Request-ID validation (security)", () => {
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let mockNext: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requestContext.run).mockImplementation(
+      (id: string, fn: () => void) => fn()
+    );
+    mockReq = { headers: {} };
+    mockRes = { setHeader: vi.fn(), statusCode: 200 };
+    mockNext = vi.fn();
+  });
+
+  // Documents current behavior: no sanitization is applied to a client-supplied
+  // X-Request-ID. Flagging for maintainer review — control characters could
+  // enable log/header injection downstream.
+  it("passes a header containing control characters straight through unsanitized", () => {
+    const malicious = "id-with-\r\nSet-Cookie:evil=1";
+    mockReq.headers = { "x-request-id": malicious };
+
+    requestIdMiddleware(mockReq as Request, mockRes as Response, mockNext);
+
+    expect((mockReq as any).id).toBe(malicious);
+    expect(mockRes.setHeader).toHaveBeenCalledWith("X-Request-ID", malicious);
+  });
+
+  // Documents current behavior: no length cap is enforced on a client-supplied
+  // X-Request-ID. Flagging for maintainer review — unbounded values get
+  // reflected into every log line for the request.
+  it("passes an excessively long header value straight through with no length cap", () => {
+    const oversized = "a".repeat(10000);
+    mockReq.headers = { "x-request-id": oversized };
+
+    requestIdMiddleware(mockReq as Request, mockRes as Response, mockNext);
+
+    expect((mockReq as any).id).toHaveLength(10000);
+    expect(mockRes.setHeader).toHaveBeenCalledWith("X-Request-ID", oversized);
+  });
+
+  // Documents current behavior: no format/charset validation (e.g. UUID shape)
+  // is enforced on a client-supplied X-Request-ID.
+  it("accepts any non-empty string as a valid request id with no format check", () => {
+    mockReq.headers = { "x-request-id": "!!!not-a-uuid???" };
+
+    requestIdMiddleware(mockReq as Request, mockRes as Response, mockNext);
+
+    expect((mockReq as any).id).toBe("!!!not-a-uuid???");
+  });
+});


### PR DESCRIPTION
## Description
Adds unit tests documenting the current handling of a client-supplied `X-Request-ID` header in `requestId` middleware. This issue's core ask (UUID assignment, header set on response, existing header preserved, `requestContext.run` mocked/verified) is already covered by tests merged under #2217 (`server/middleware/requestId.test.ts` + `requestId.integration.test.ts`, commit `45cc9953`). This PR adds coverage for a gap not previously tested: the middleware trusts a client-supplied ID with no sanitization, length limit, or format check — relevant given this issue's `type:security` label.

## Related Issue
Relates to #2132 

## Type of Change
- [x] 🧪 Test addition or update

## Changes Made
- Added `"requestIdMiddleware - client-supplied X-Request-ID validation (security)"` test block in `server/middleware/requestId.test.ts`
- Test: control characters (e.g. CRLF) in the header pass through unsanitized
- Test: no length cap is enforced (10,000-char value accepted)
- Test: no format/charset validation is performed (arbitrary non-UUID strings accepted)

## Screenshots (if applicable)
N/A — test-only change

## Testing
- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] All existing tests pass (12/12, including 9 pre-existing)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings or errors

## Note for maintainers
These tests characterize existing behavior rather than fixing it — flagging for discussion on whether client-supplied `X-Request-ID` values should be validated/sanitized before being trusted. Leaving #2132 open rather than closing it, since the underlying security question isn't resolved yet, just documented.