### PR TITLE
feat: add interactive brush to trend charts (#2115)

### DIFF
--- a/client/src/pages/ProgressTracking.tsx
+++ b/client/src/pages/ProgressTracking.tsx
@@ -89,8 +89,8 @@ export default function ProgressTracking() {
       if (!res.ok) throw new Error("Failed to load patient data");
       const data = await res.json();
       setAssessments(data.data ?? []);
-    } catch (err: any) {
-      setError(err.message || "Failed to load patient data");
+    } catch (err: unknown) {
+      setError((err as Error).message || "Failed to load patient data");
     } finally {
       setLoading(false);
     }

--- a/client/src/pages/ProgressTracking.tsx
+++ b/client/src/pages/ProgressTracking.tsx
@@ -191,7 +191,7 @@ export default function ProgressTracking() {
                 <CardContent>
                   <div className="h-72">
                     <ResponsiveContainer width="100%" height="100%">
-                      <LineChart data={chartData}>
+                      <LineChart data={chartData} syncId="progress-sync">
                         <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
                         <XAxis dataKey="date" tick={{ fontSize: 12 }} />
                         <YAxis domain={[3, 15]} tick={{ fontSize: 12 }} label={{ value: "HbA1c (%)", angle: -90, position: "insideLeft", style: { fontSize: 12 } }} />
@@ -201,7 +201,6 @@ export default function ProgressTracking() {
                           <ReferenceLine key={rl.label} y={rl.value} stroke={rl.color} strokeDasharray="4 4" label={{ value: rl.label, position: "right", style: { fontSize: 10, fill: rl.color } }} />
                         ))}
                         <Line type="monotone" dataKey="hba1cLevel" stroke="#2563eb" strokeWidth={2} dot={{ r: 4, fill: "#2563eb" }} name="HbA1c" />
-                        <Brush dataKey="date" height={30} stroke="#2563eb" fill="transparent" tickFormatter={(v: string) => v} />
                       </LineChart>
                     </ResponsiveContainer>
                   </div>
@@ -219,7 +218,7 @@ export default function ProgressTracking() {
                 <CardContent>
                   <div className="h-72">
                     <ResponsiveContainer width="100%" height="100%">
-                      <LineChart data={chartData}>
+                      <LineChart data={chartData} syncId="progress-sync">
                         <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
                         <XAxis dataKey="date" tick={{ fontSize: 12 }} />
                         <YAxis domain={[50, 300]} tick={{ fontSize: 12 }} label={{ value: "mg/dL", angle: -90, position: "insideLeft", style: { fontSize: 12 } }} />
@@ -229,7 +228,6 @@ export default function ProgressTracking() {
                           <ReferenceLine key={rl.label} y={rl.value} stroke={rl.color} strokeDasharray="4 4" label={{ value: rl.label, position: "right", style: { fontSize: 10, fill: rl.color } }} />
                         ))}
                         <Line type="monotone" dataKey="bloodGlucoseLevel" stroke="#ea580c" strokeWidth={2} dot={{ r: 4, fill: "#ea580c" }} name="Blood Glucose" />
-                        <Brush dataKey="date" height={30} stroke="#ea580c" fill="transparent" tickFormatter={(v: string) => v} />
                       </LineChart>
                     </ResponsiveContainer>
                   </div>
@@ -247,7 +245,7 @@ export default function ProgressTracking() {
                 <CardContent>
                   <div className="h-72">
                     <ResponsiveContainer width="100%" height="100%">
-                      <LineChart data={chartData}>
+                      <LineChart data={chartData} syncId="progress-sync">
                         <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
                         <XAxis dataKey="date" tick={{ fontSize: 12 }} />
                         <YAxis domain={[10, 50]} tick={{ fontSize: 12 }} label={{ value: "BMI", angle: -90, position: "insideLeft", style: { fontSize: 12 } }} />
@@ -257,7 +255,6 @@ export default function ProgressTracking() {
                           <ReferenceLine key={rl.label} y={rl.value} stroke={rl.color} strokeDasharray="4 4" label={{ value: rl.label, position: "right", style: { fontSize: 10, fill: rl.color } }} />
                         ))}
                         <Line type="monotone" dataKey="bmi" stroke="#059669" strokeWidth={2} dot={{ r: 4, fill: "#059669" }} name="BMI" />
-                        <Brush dataKey="date" height={30} stroke="#059669" fill="transparent" tickFormatter={(v: string) => v} />
                       </LineChart>
                     </ResponsiveContainer>
                   </div>
@@ -275,7 +272,7 @@ export default function ProgressTracking() {
                 <CardContent>
                   <div className="h-72">
                     <ResponsiveContainer width="100%" height="100%">
-                      <LineChart data={chartData}>
+                      <LineChart data={chartData} syncId="progress-sync">
                         <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
                         <XAxis dataKey="date" tick={{ fontSize: 12 }} />
                         <YAxis domain={[0, 100]} tick={{ fontSize: 12 }} label={{ value: "Risk Score (%)", angle: -90, position: "insideLeft", style: { fontSize: 12 } }} />

--- a/client/src/pages/ProgressTracking.tsx
+++ b/client/src/pages/ProgressTracking.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend, ReferenceLine } from "recharts";
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend, ReferenceLine, Brush } from "recharts";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { Search, TrendingUp, Activity, Weight, HeartPulse, Loader2, AlertCircle } from "lucide-react";
 import { formatCompactDate, formatReadableDate } from "@/utils/dateFormat";
@@ -201,6 +201,7 @@ export default function ProgressTracking() {
                           <ReferenceLine key={rl.label} y={rl.value} stroke={rl.color} strokeDasharray="4 4" label={{ value: rl.label, position: "right", style: { fontSize: 10, fill: rl.color } }} />
                         ))}
                         <Line type="monotone" dataKey="hba1cLevel" stroke="#2563eb" strokeWidth={2} dot={{ r: 4, fill: "#2563eb" }} name="HbA1c" />
+                        <Brush dataKey="date" height={30} stroke="#2563eb" fill="transparent" tickFormatter={(v: string) => v} />
                       </LineChart>
                     </ResponsiveContainer>
                   </div>
@@ -228,6 +229,7 @@ export default function ProgressTracking() {
                           <ReferenceLine key={rl.label} y={rl.value} stroke={rl.color} strokeDasharray="4 4" label={{ value: rl.label, position: "right", style: { fontSize: 10, fill: rl.color } }} />
                         ))}
                         <Line type="monotone" dataKey="bloodGlucoseLevel" stroke="#ea580c" strokeWidth={2} dot={{ r: 4, fill: "#ea580c" }} name="Blood Glucose" />
+                        <Brush dataKey="date" height={30} stroke="#ea580c" fill="transparent" tickFormatter={(v: string) => v} />
                       </LineChart>
                     </ResponsiveContainer>
                   </div>
@@ -255,6 +257,7 @@ export default function ProgressTracking() {
                           <ReferenceLine key={rl.label} y={rl.value} stroke={rl.color} strokeDasharray="4 4" label={{ value: rl.label, position: "right", style: { fontSize: 10, fill: rl.color } }} />
                         ))}
                         <Line type="monotone" dataKey="bmi" stroke="#059669" strokeWidth={2} dot={{ r: 4, fill: "#059669" }} name="BMI" />
+                        <Brush dataKey="date" height={30} stroke="#059669" fill="transparent" tickFormatter={(v: string) => v} />
                       </LineChart>
                     </ResponsiveContainer>
                   </div>
@@ -282,6 +285,7 @@ export default function ProgressTracking() {
                           <ReferenceLine key={b.label} y={b.min} stroke={b.color} strokeDasharray="4 4" label={{ value: b.label, position: "right", style: { fontSize: 10, fill: b.color } }} />
                         ))}
                         <Line type="monotone" dataKey="riskScore" stroke="#7c3aed" strokeWidth={2} dot={{ r: 4, fill: "#7c3aed" }} name="Risk Score" />
+                        <Brush dataKey="date" height={30} stroke="#7c3aed" fill="transparent" tickFormatter={(v: string) => v} />
                       </LineChart>
                     </ResponsiveContainer>
                   </div>


### PR DESCRIPTION
## Description

This PR enhances the Patient Progress Tracking dashboard by introducing interactive `<Brush />` elements to all four vital trends/history charts. This allows clinicians to easily zoom and pan across longitudinal patient data over time.

## Related Issue

Closes #2115

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🎨 Style / UI improvement

## Changes Made

- Imported `Brush` from `recharts` in `client/src/pages/ProgressTracking.tsx`.
- Integrated `<Brush />` components into the `HbA1c Trend`, `Blood Glucose Trend`, `BMI Trajectory`, and `Risk Score History` charts.
- Added explicit typescript type annotation to the brush `tickFormatter` parameters to fix implicit-any compile warnings.

## Testing

- [x] I have tested these changes locally

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
