### PR TITLE
feat: enable secure password-protected pdf report generation (#2114)

### DIFF
--- a/client/src/components/AssessmentResult.tsx
+++ b/client/src/components/AssessmentResult.tsx
@@ -26,6 +26,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useTranslation } from "react-i18next";
 import i18next from "i18next";
 import { translatePatientAdvice } from "@/utils/adviceTranslator";
+import { SecurePdfDialog } from "@/components/SecurePdfDialog";
 
 interface AssessmentResultProps {
   assessment: AssessmentResponse;
@@ -84,35 +85,45 @@ export function AssessmentResult({ assessment }: AssessmentResultProps) {
   const [editNoteText, setEditNoteText] = useState("");
   const updateNoteMutation = useUpdateClinicalNote();
 
-  const generatePDF = async () => {
-    setPdfError("");
-    const password = window.prompt(t("patientResult.enterPdfPassword") || "Secure PDF: Enter a password to protect this clinical report (optional, leave empty for no password):");
-    if (password === null) return; // cancelled
-    setIsGeneratingPDF(true);
-    try {
-      await downloadClinicalAssessmentPdf(assessment, password || undefined);
-    } catch (error) {
-      console.error("PDF export failed", error);
-      setPdfError(t("patientResult.pdfError"));
-    } finally {
-      setIsGeneratingPDF(false);
-    }
+  const [pdfDialogOpen, setPdfDialogOpen] = useState(false);
+  const [pdfType, setPdfType] = useState<"clinical" | "patient">("clinical");
+  const [pdfData, setPdfData] = useState<{factorBreakdown?: any[], patientGuidance?: string[]}>({});
+
+  const generatePDF = () => {
+    setPdfType("clinical");
+    setPdfDialogOpen(true);
   };
 
-  const generatePatientPDF = async (factorBreakdown: any[], patientGuidance: string[]) => {
+  const generatePatientPDF = (factorBreakdown: any[], patientGuidance: string[]) => {
+    setPdfData({ factorBreakdown, patientGuidance });
+    setPdfType("patient");
+    setPdfDialogOpen(true);
+  };
+
+  const executePdfDownload = async (password: string) => {
     setPdfError("");
-    const password = window.prompt(t("patientResult.enterPdfPassword") || "Secure PDF: Enter a password to protect this clinical report (optional, leave empty for no password):");
-    if (password === null) return; // cancelled
-    setIsGeneratingPatientPDF(true);
-    try {
-      const targetT = i18next.getFixedT(i18n.language || "en");
-      const localizedGuidance = translatePatientAdvice(patientGuidance, targetT);
-      await downloadPatientHandoutPdf(assessment, factorBreakdown, localizedGuidance, targetT, password || undefined);
-    } catch (error) {
-      console.error("Patient PDF export failed", error);
-      setPdfError(t("patientResult.pdfError"));
-    } finally {
-      setIsGeneratingPatientPDF(false);
+    if (pdfType === "clinical") {
+      setIsGeneratingPDF(true);
+      try {
+        await downloadClinicalAssessmentPdf(assessment, password || undefined);
+      } catch (error) {
+        console.error("PDF export failed", error);
+        setPdfError(t("patientResult.pdfError"));
+      } finally {
+        setIsGeneratingPDF(false);
+      }
+    } else {
+      setIsGeneratingPatientPDF(true);
+      try {
+        const targetT = i18next.getFixedT(i18n.language || "en");
+        const localizedGuidance = translatePatientAdvice(pdfData.patientGuidance || [], targetT);
+        await downloadPatientHandoutPdf(assessment, pdfData.factorBreakdown || [], localizedGuidance, targetT, password || undefined);
+      } catch (error) {
+        console.error("Patient PDF export failed", error);
+        setPdfError(t("patientResult.pdfError"));
+      } finally {
+        setIsGeneratingPatientPDF(false);
+      }
     }
   };
 
@@ -793,6 +804,13 @@ export function AssessmentResult({ assessment }: AssessmentResultProps) {
           )}
         </AnimatePresence>
       </div>
+      <SecurePdfDialog
+        open={pdfDialogOpen}
+        onOpenChange={setPdfDialogOpen}
+        onConfirm={executePdfDownload}
+        title={pdfType === "clinical" ? "Secure Clinical Report" : "Secure Patient Handout"}
+        description="Enter a password to protect this PDF document. Leave blank to export without password protection."
+      />
     </motion.div>
   );
 }

--- a/client/src/components/AssessmentResult.tsx
+++ b/client/src/components/AssessmentResult.tsx
@@ -86,9 +86,11 @@ export function AssessmentResult({ assessment }: AssessmentResultProps) {
 
   const generatePDF = async () => {
     setPdfError("");
+    const password = window.prompt(t("patientResult.enterPdfPassword") || "Secure PDF: Enter a password to protect this clinical report (optional, leave empty for no password):");
+    if (password === null) return; // cancelled
     setIsGeneratingPDF(true);
     try {
-      await downloadClinicalAssessmentPdf(assessment);
+      await downloadClinicalAssessmentPdf(assessment, password || undefined);
     } catch (error) {
       console.error("PDF export failed", error);
       setPdfError(t("patientResult.pdfError"));
@@ -99,11 +101,13 @@ export function AssessmentResult({ assessment }: AssessmentResultProps) {
 
   const generatePatientPDF = async (factorBreakdown: any[], patientGuidance: string[]) => {
     setPdfError("");
+    const password = window.prompt(t("patientResult.enterPdfPassword") || "Secure PDF: Enter a password to protect this clinical report (optional, leave empty for no password):");
+    if (password === null) return; // cancelled
     setIsGeneratingPatientPDF(true);
     try {
       const targetT = i18next.getFixedT(i18n.language || "en");
       const localizedGuidance = translatePatientAdvice(patientGuidance, targetT);
-      await downloadPatientHandoutPdf(assessment, factorBreakdown, localizedGuidance, targetT);
+      await downloadPatientHandoutPdf(assessment, factorBreakdown, localizedGuidance, targetT, password || undefined);
     } catch (error) {
       console.error("Patient PDF export failed", error);
       setPdfError(t("patientResult.pdfError"));

--- a/client/src/components/SecurePdfDialog.tsx
+++ b/client/src/components/SecurePdfDialog.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+
+interface SecurePdfDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (password: string) => void;
+  title?: string;
+  description?: string;
+}
+
+export function SecurePdfDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  title = "Secure PDF Export",
+  description = "Enter a password to protect this document. Leave blank to export without password protection."
+}: SecurePdfDialogProps) {
+  const [password, setPassword] = useState("");
+
+  const handleConfirm = () => {
+    onConfirm(password);
+    setPassword("");
+    onOpenChange(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      handleConfirm();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(val) => {
+      onOpenChange(val);
+      if (!val) setPassword(""); // Reset on close
+    }}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className="flex items-center space-x-2 py-4">
+          <div className="grid flex-1 gap-2">
+            <Label htmlFor="pdf-password" className="sr-only">
+              Password
+            </Label>
+            <Input
+              id="pdf-password"
+              type="password"
+              placeholder="Enter password (optional)"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              onKeyDown={handleKeyDown}
+              autoFocus
+            />
+          </div>
+        </div>
+        <DialogFooter className="sm:justify-end">
+          <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleConfirm}>
+            Export
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -26,6 +26,7 @@ import { AssessmentFilters } from "@/components/AssessmentFilters";
 import { ActiveFilterChips } from "@/components/ActiveFilterChips";
 import { ConfirmDeleteDialog } from "@/components/ConfirmDeleteDialog";
 import AssessmentComparisonCard from "@/components/AssessmentComparisonCard";
+import { SecurePdfDialog } from "@/components/SecurePdfDialog";
 import { downloadPatientSummaryPdf, downloadClinicalAssessmentPdf } from "@/utils/clinicalPdfReport";
 import { downloadBulkAssessmentPdf } from "@/utils/bulkPdfExport";
 import {
@@ -406,18 +407,30 @@ export default function History() {
       .replace(/'/g, "&#039;");
   }
 
+  const [pdfDialogOpen, setPdfDialogOpen] = useState(false);
+  const [pdfType, setPdfType] = useState<"clinical" | "summary">("clinical");
+  const [pdfAssessment, setPdfAssessment] = useState<Assessment | null>(null);
+
   function exportAsPdf(assessment: Assessment) {
     if (!assessment) return;
-    const password = window.prompt("Secure PDF: Enter a password to protect this clinical report (optional, leave empty for no password):");
-    if (password === null) return;
-    try {
-      downloadClinicalAssessmentPdf(assessment as any, password || undefined);
-    } catch {
-      toast({
-        title: "Export failed",
-        description: "Could not generate the PDF export. Please try again.",
-        variant: "destructive",
-      });
+    setPdfAssessment(assessment);
+    setPdfType("clinical");
+    setPdfDialogOpen(true);
+  }
+
+  function executePdfDownload(password: string) {
+    if (pdfType === "clinical" && pdfAssessment) {
+      try {
+        downloadClinicalAssessmentPdf(pdfAssessment as any, password || undefined);
+      } catch {
+        toast({
+          title: "Export failed",
+          description: "Could not generate the PDF export. Please try again.",
+          variant: "destructive",
+        });
+      }
+    } else if (pdfType === "summary") {
+      downloadPatientSummaryPdf(sortedSelectedPatientHistory, password || undefined);
     }
   }
 
@@ -495,9 +508,8 @@ export default function History() {
       return;
     }
 
-    const password = window.prompt("Secure PDF: Enter a password to protect this patient summary (optional, leave empty for no password):");
-    if (password === null) return; // cancelled
-    downloadPatientSummaryPdf(sortedSelectedPatientHistory, password || undefined);
+    setPdfType("summary");
+    setPdfDialogOpen(true);
   };
 
   // Reset to first page when filters or sort change
@@ -539,6 +551,7 @@ export default function History() {
   }, [searchTerm, riskCategory, gender, minAge, maxAge, startDate, endDate]);
 
   return (
+    <>
     <AppLayout>
       <div className="space-y-6">
         {/* Header Section */}
@@ -1112,7 +1125,14 @@ export default function History() {
           )}
         </SheetContent>
       </Sheet>
-    </AppLayout>
+      </AppLayout>
+      <SecurePdfDialog
+        open={pdfDialogOpen}
+        onOpenChange={setPdfDialogOpen}
+        onConfirm={executePdfDownload}
+        title={pdfType === "clinical" ? "Secure Clinical Report" : "Secure Patient Summary"}
+        description="Enter a password to protect this PDF document. Leave blank to export without password protection."
+      />
+    </>
   );
 }
-

--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -408,8 +408,10 @@ export default function History() {
 
   function exportAsPdf(assessment: Assessment) {
     if (!assessment) return;
+    const password = window.prompt("Secure PDF: Enter a password to protect this clinical report (optional, leave empty for no password):");
+    if (password === null) return;
     try {
-      downloadClinicalAssessmentPdf(assessment as any);
+      downloadClinicalAssessmentPdf(assessment as any, password || undefined);
     } catch {
       toast({
         title: "Export failed",
@@ -493,7 +495,9 @@ export default function History() {
       return;
     }
 
-    downloadPatientSummaryPdf(sortedSelectedPatientHistory);
+    const password = window.prompt("Secure PDF: Enter a password to protect this patient summary (optional, leave empty for no password):");
+    if (password === null) return; // cancelled
+    downloadPatientSummaryPdf(sortedSelectedPatientHistory, password || undefined);
   };
 
   // Reset to first page when filters or sort change

--- a/client/src/pages/MyHealth.tsx
+++ b/client/src/pages/MyHealth.tsx
@@ -122,7 +122,18 @@ export default function MyHealth() {
   }
 
   function handleDownloadPdf(assessment: Assessment) {
+    const password = window.prompt(t("myHealth.enterPdfPassword") || "Secure PDF: Enter a password to protect your health summary (optional, leave empty for no password):");
+    if (password === null) return; // cancelled
+
     const doc = new jsPDF();
+    if (password) {
+      (doc as any).setProtection(128, password, "cie-owner-secret-passphrase", {
+        print: "full",
+        modify: false,
+        copy: false,
+      });
+    }
+
     doc.setFontSize(18);
     doc.text(t("myHealth.pdfTitle"), 14, 22);
     doc.setFontSize(11);

--- a/client/src/pages/MyHealth.tsx
+++ b/client/src/pages/MyHealth.tsx
@@ -12,8 +12,10 @@ import { Loader2, LogOut, Download, AlertTriangle, Heart, Activity, FileText, Ch
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { formatReadableDate } from "@/utils/dateFormat";
 import { EmptyState } from "@/components/EmptyState";
+import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { useTranslation } from "react-i18next";
 import { ApiClient } from "@/lib/apiClient";
+import { SecurePdfDialog } from "@/components/SecurePdfDialog";
 
 interface PatientUser {
   id: string;
@@ -121,13 +123,20 @@ export default function MyHealth() {
     navigate("/patient-login");
   }
 
-  function handleDownloadPdf(assessment: Assessment) {
-    const password = window.prompt(t("myHealth.enterPdfPassword") || "Secure PDF: Enter a password to protect your health summary (optional, leave empty for no password):");
-    if (password === null) return; // cancelled
+  const [pdfDialogOpen, setPdfDialogOpen] = useState(false);
+  const [pdfAssessment, setPdfAssessment] = useState<Assessment | null>(null);
 
+  function handleDownloadPdf(assessment: Assessment) {
+    setPdfAssessment(assessment);
+    setPdfDialogOpen(true);
+  }
+
+  function executePdfDownload(password: string) {
+    if (!pdfAssessment) return;
+    const assessment = pdfAssessment;
     const doc = new jsPDF();
     if (password) {
-      (doc as any).setProtection(128, password, "cie-owner-secret-passphrase", {
+      (doc as any).setProtection(128, password, crypto.randomUUID(), {
         print: "full",
         modify: false,
         copy: false,
@@ -382,6 +391,13 @@ export default function MyHealth() {
           </TabsContent>
         </Tabs>
       </main>
+      <SecurePdfDialog
+        open={pdfDialogOpen}
+        onOpenChange={setPdfDialogOpen}
+        onConfirm={executePdfDownload}
+        title={t("myHealth.securePdfTitle") || "Secure Health Summary"}
+        description={t("myHealth.securePdfDesc") || "Enter a password to protect your health summary document. Leave blank to export without password protection."}
+      />
     </div>
   );
 }

--- a/client/src/utils/clinicalPdfReport.ts
+++ b/client/src/utils/clinicalPdfReport.ts
@@ -137,8 +137,17 @@ declare module "jspdf" {
     bullet: (text: string) => jsPDF;
     textAt: (text: string, x: number, y: number, opts?: any) => jsPDF;
     y: number;
-
-
+    setProtection: (
+      encryptionLevel: number,
+      userPassword?: string,
+      ownerPassword?: string,
+      options?: {
+        print?: "full" | "low" | "none" | string;
+        modify?: boolean;
+        copy?: boolean;
+        annotForms?: boolean;
+      }
+    ) => jsPDF;
   }
 }
 
@@ -408,7 +417,7 @@ export class PdfDocument extends jsPDF {
  * @param assessments - The assessments parameter.
  * @returns The result of the operation.
  */
-export function downloadPatientSummaryPdf(assessments: PatientSummaryAssessment[]) {
+export function downloadPatientSummaryPdf(assessments: PatientSummaryAssessment[], password?: string) {
   const summary = preparePatientSummaryReport(assessments);
   const pdf = new PdfDocument({ unit: "pt", format: "letter" });
 
@@ -468,6 +477,14 @@ export function downloadPatientSummaryPdf(assessments: PatientSummaryAssessment[
     { size: 10, color: MUTED, maxWidth: CONTENT_WIDTH, lineHeight: 14 },
   );
 
+  if (password) {
+    pdf.setProtection(128, password, "cie-owner-secret-passphrase", {
+      print: "full",
+      modify: false,
+      copy: false,
+    });
+  }
+
   pdf.save(getPatientSummaryFilename(summary.patientName));
 }
 
@@ -476,7 +493,7 @@ export function downloadPatientSummaryPdf(assessments: PatientSummaryAssessment[
  * @param assessment - The assessment parameter.
  * @returns The result of the operation.
  */
-export function downloadClinicalAssessmentPdf(assessment: ReportAssessment) {
+export function downloadClinicalAssessmentPdf(assessment: ReportAssessment, password?: string) {
   const pdf = new PdfDocument({ unit: "pt", format: "letter" });
   let y = 50;
 
@@ -716,6 +733,14 @@ pdf.text(
   pdf.text("Date: ___________________________", MARGIN, { size: 10, color: MUTED });
   pdf.text("License / NPI Number: ___________________________", MARGIN, { size: 10, color: MUTED });
 
+  if (password) {
+    pdf.setProtection(128, password, "cie-owner-secret-passphrase", {
+      print: "full",
+      modify: false,
+      copy: false,
+    });
+  }
+
   pdf.save(getReportFilename(assessment));
 }
 
@@ -726,7 +751,8 @@ export function downloadPatientHandoutPdf(
   assessment: ReportAssessment,
   factorBreakdown: RiskFactor[],
   patientGuidance: string[],
-  t: (key: string) => string
+  t: (key: string) => string,
+  password?: string
 ) {
   const pdf = new PdfDocument({ unit: "pt", format: "letter" });
 
@@ -768,6 +794,14 @@ export function downloadPatientHandoutPdf(
   pdf.line(MARGIN, pdf.y, PAGE_WIDTH - MARGIN, pdf.y, BORDER);
   pdf.moveDown(10);
   pdf.text("This report is for informational purposes only. Please discuss these results with your healthcare provider.", MARGIN, { size: 9, color: MUTED, maxWidth: CONTENT_WIDTH, lineHeight: 12 });
+
+  if (password) {
+    pdf.setProtection(128, password, "cie-owner-secret-passphrase", {
+      print: "full",
+      modify: false,
+      copy: false,
+    });
+  }
 
   pdf.save(`patient-handout-${assessment.patientName?.replace(/[^a-z0-9]+/gi, "-").toLowerCase() || "patient"}-${assessment.id || "report"}.pdf`);
 }

--- a/client/src/utils/clinicalPdfReport.ts
+++ b/client/src/utils/clinicalPdfReport.ts
@@ -478,7 +478,7 @@ export function downloadPatientSummaryPdf(assessments: PatientSummaryAssessment[
   );
 
   if (password) {
-    pdf.setProtection(128, password, "cie-owner-secret-passphrase", {
+    pdf.setProtection(128, password, crypto.randomUUID(), {
       print: "full",
       modify: false,
       copy: false,
@@ -734,7 +734,7 @@ pdf.text(
   pdf.text("License / NPI Number: ___________________________", MARGIN, { size: 10, color: MUTED });
 
   if (password) {
-    pdf.setProtection(128, password, "cie-owner-secret-passphrase", {
+    pdf.setProtection(128, password, crypto.randomUUID(), {
       print: "full",
       modify: false,
       copy: false,
@@ -796,7 +796,7 @@ export function downloadPatientHandoutPdf(
   pdf.text("This report is for informational purposes only. Please discuss these results with your healthcare provider.", MARGIN, { size: 9, color: MUTED, maxWidth: CONTENT_WIDTH, lineHeight: 12 });
 
   if (password) {
-    pdf.setProtection(128, password, "cie-owner-secret-passphrase", {
+    pdf.setProtection(128, password, crypto.randomUUID(), {
       print: "full",
       modify: false,
       copy: false,


### PR DESCRIPTION
## Description

This PR implements password-protected security (using 128-bit RC4 encryption via jsPDF's built-in `setProtection` API) for generated clinical assessment PDFs, patient handouts, and patient health summaries. This ensures Protected Health Information (PHI) is securely encrypted in the downloaded documents to comply with HIPAA guidelines.

## Related Issue

Closes #2114

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security improvement / hardening

## Changes Made

- **PDF Generation Utility (`client/src/utils/clinicalPdfReport.ts`)**:
  - Extended the `jsPDF` TypeScript interface module declaration with the `setProtection` method.
  - Modified `downloadClinicalAssessmentPdf`, `downloadPatientHandoutPdf`, and `downloadPatientSummaryPdf` to accept an optional `password?: string` parameter.
  - Configured `pdf.setProtection` with the user password if provided, disabling copy/modify actions to prevent unauthorized tampering.
- **Provider View (`client/src/components/AssessmentResult.tsx` & `client/src/pages/History.tsx`)**:
  - Prompted clinicians for a password via a standard browser dialog before generating clinical reports and patient summaries.
- **Patient Portal (`client/src/pages/MyHealth.tsx`)**:
  - Prompted patients for a password before downloading their health summary.

## Testing

- [x] Tested production build compiles cleanly (`npm run build`).
