### PR TITLE
feat: implement counterfactual explanations what-if analysis in clinician view (#2112)

### DIFF
--- a/client/src/components/AssessmentResult.tsx
+++ b/client/src/components/AssessmentResult.tsx
@@ -23,6 +23,7 @@ import { CollaborativeNotes } from "./CollaborativeNotes";
 import { PathToImprovement } from "./assessment/PathToImprovement";
 import { Tooltip as UiTooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Textarea } from "@/components/ui/textarea";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useTranslation } from "react-i18next";
 import i18next from "i18next";
 import { translatePatientAdvice } from "@/utils/adviceTranslator";
@@ -679,17 +680,25 @@ export function AssessmentResult({ assessment }: AssessmentResultProps) {
                 </div>
               )}
 
-              <ExplainabilityPanel
-                factors={factorBreakdown}
-                increasedRiskFactors={increasedRiskFactors}
-                reducedRiskFactors={reducedRiskFactors}
-              />
-
-              <PredictionExplanation explanation={assessment.explanation} view="clinician" />
-              
-              <div className="mt-8">
-                <WhatIfRiskSimulator assessment={assessment} />
-              </div>
+              <Tabs defaultValue="explanation" className="mt-8">
+                <TabsList className="grid w-full grid-cols-2 max-w-[600px] mb-4">
+                  <TabsTrigger value="explanation">{t("patientResult.riskExplanation") || "Risk Explanation"}</TabsTrigger>
+                  <TabsTrigger value="whatif">{t("patientResult.whatIfAnalysis") || "What-If Analysis"}</TabsTrigger>
+                </TabsList>
+                
+                <TabsContent value="explanation" className="space-y-6">
+                  <ExplainabilityPanel
+                    factors={factorBreakdown}
+                    increasedRiskFactors={increasedRiskFactors}
+                    reducedRiskFactors={reducedRiskFactors}
+                  />
+                  <PredictionExplanation explanation={assessment.explanation} view="clinician" />
+                </TabsContent>
+                
+                <TabsContent value="whatif">
+                  <WhatIfRiskSimulator assessment={assessment} />
+                </TabsContent>
+              </Tabs>
               
               <div className="mt-8">
                 <CollaborativeNotes assessmentId={assessment.id} />

--- a/client/src/components/AssessmentResult.tsx
+++ b/client/src/components/AssessmentResult.tsx
@@ -688,6 +688,10 @@ export function AssessmentResult({ assessment }: AssessmentResultProps) {
               <PredictionExplanation explanation={assessment.explanation} view="clinician" />
               
               <div className="mt-8">
+                <WhatIfRiskSimulator assessment={assessment} />
+              </div>
+              
+              <div className="mt-8">
                 <CollaborativeNotes assessmentId={assessment.id} />
               </div>
 


### PR DESCRIPTION
## Description

This PR integrates the pre-existing `WhatIfRiskSimulator` component into the single patient assessment clinician view (`client/src/components/AssessmentResult.tsx`). This allows clinicians to run real-time what-if simulations on patient clinical metrics and immediately see the simulated risk difference.

## Related Issue

Closes #2112

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Rendered the `<WhatIfRiskSimulator assessment={assessment} />` component inside `AssessmentResult.tsx` between the explanation and notes sections to provide immediate clinical utility.

## Testing

- [x] I have tested these changes locally
