### PR TITLE
feat: add clinical finding categorization tags

### DIFF
--- a/client/src/components/ClinicalAttentionNavigator.tsx
+++ b/client/src/components/ClinicalAttentionNavigator.tsx
@@ -22,7 +22,53 @@ const PRIORITY_STYLES: Record<PriorityLevel, string> = {
   moderate: "bg-amber-100 text-amber-900 border-amber-200",
   monitor: "bg-emerald-100 text-emerald-900 border-emerald-200",
 };
+const getCategory = (factor: string) => {
+  const text = factor.toLowerCase();
 
+  if (
+    text.includes("blood pressure") ||
+    text.includes("cholesterol") ||
+    text.includes("ldl") ||
+    text.includes("hdl") ||
+    text.includes("heart") ||
+    text.includes("cardio")
+  ) {
+    return { label: "🫀 Cardiovascular" };
+  }
+
+  if (
+    text.includes("lung") ||
+    text.includes("respiratory") ||
+    text.includes("oxygen")
+  ) {
+    return { label: "🫁 Respiratory" };
+  }
+
+  if (
+    text.includes("hemoglobin") ||
+    text.includes("blood") ||
+    text.includes("platelet")
+  ) {
+    return { label: "🩸 Hematology" };
+  }
+
+  if (
+    text.includes("brain") ||
+    text.includes("neuro")
+  ) {
+    return { label: "🧠 Neurology" };
+  }
+
+  if (
+    text.includes("bone") ||
+    text.includes("joint") ||
+    text.includes("muscle")
+  ) {
+    return { label: "🦴 Musculoskeletal" };
+  }
+
+  return { label: "General" };
+};
 export function ClinicalAttentionNavigator({ navigator }: { navigator?: NavigatorProps }) {
   if (!navigator || !navigator.priorities || navigator.priorities.length === 0) {
     return null;
@@ -35,25 +81,51 @@ export function ClinicalAttentionNavigator({ navigator }: { navigator?: Navigato
         <h3 className="mt-2 text-xl font-bold text-foreground">Priority findings for clinician review</h3>
       </div>
       <div className="grid gap-4">
-        {navigator.priorities.map((item: AttentionNavigatorItem) => (
-          <article
-            key={item.factor}
-            className="rounded-3xl border border-border/70 bg-muted/80 p-4 shadow-sm sm:flex sm:items-start sm:justify-between"
-          >
-            <div className="min-w-0">
-              <div className="flex items-center gap-3">
-                <span className={cn("inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold border", PRIORITY_STYLES[item.priority])}>
-                  {item.priority === "high" ? "High" : item.priority === "moderate" ? "Moderate" : "Monitor"}
-                </span>
-                <h4 className="text-base font-semibold text-foreground truncate">{item.factor}</h4>
-              </div>
-              <p className="mt-3 text-sm leading-6 text-muted-foreground">{item.reason}</p>
-              {typeof item.value === "number" && (
-                <p className="mt-3 text-xs font-medium text-slate-500">Current value: {item.value}</p>
+  {navigator.priorities.map((item: AttentionNavigatorItem) => {
+    const category = getCategory(item.factor);
+
+    return (
+      <article
+        key={item.factor}
+        className="rounded-3xl border border-border/70 bg-muted/80 p-4 shadow-sm sm:flex sm:items-start sm:justify-between"
+      >
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={cn(
+                "inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold border",
+                PRIORITY_STYLES[item.priority]
               )}
-            </div>
-          </article>
-        ))}
+            >
+              {item.priority === "high"
+                ? "High"
+                : item.priority === "moderate"
+                ? "Moderate"
+                : "Monitor"}
+            </span>
+
+            <span className="inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700">
+              {category.label}
+            </span>
+          </div>
+
+          <h4 className="mt-3 text-base font-semibold text-foreground">
+            {item.factor}
+          </h4>
+
+          <p className="mt-3 text-sm leading-6 text-muted-foreground">
+            {item.reason}
+          </p>
+
+          {typeof item.value === "number" && (
+            <p className="mt-3 text-xs font-medium text-slate-500">
+              Current value: {item.value}
+            </p>
+          )}
+        </div>
+      </article>
+    );
+  })}
       </div>
     </section>
   );


### PR DESCRIPTION
## 📌 Overview

Adds automatic category tags to clinical findings in the Clinical Attention Navigator, making findings easier to identify and organize.

## ✨ Changes Made

- Added automatic category mapping based on finding names.
- Displays specialty tags alongside each priority badge.
- Supports categories such as:
  - 🫀 Cardiovascular
  - 🫁 Respiratory
  - 🩸 Hematology
  - 🧠 Neurology
  - 🦴 Musculoskeletal
- Falls back to a generic category when no match is found.

## 🧪 Testing

- [x] ESLint passes successfully
- [x] Application builds successfully
- [x] Category tags display correctly beside findings
- [x] Existing functionality remains unchanged

Fixes #1635