### PR TITLE
fix: add error logging to empty catch blocks

### DIFF
--- a/client/src/pages/CounterfactualAnalysis.tsx
+++ b/client/src/pages/CounterfactualAnalysis.tsx
@@ -36,7 +36,9 @@ export default function CounterfactualAnalysis() {
     try {
       const names = await ApiClient.get<string[]>(`/api/assessments/autocomplete?q=${encodeURIComponent(q)}`);
       setSuggestions(names);
-    } catch {}
+    } catch (error) {
+      console.error("Failed to fetch counterfactual suggestions", error);
+    }
   }, []);
 
   useEffect(() => {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -179,7 +179,9 @@ export default function Dashboard() {
           if (!allowedKeys.includes(k)) return;
           try {
             setValue(k as keyof AssessmentFormData, v as any, { shouldDirty: true });
-          } catch (e) {}
+          } catch (e) {
+            console.error("Failed to apply draft field", k, e);
+          }
         });
       }
     } catch (e) {

--- a/client/src/pages/MyHealth.tsx
+++ b/client/src/pages/MyHealth.tsx
@@ -110,7 +110,9 @@ export default function MyHealth() {
       if (!response.ok) return;
       const data = await response.json();
       setTrends(data ?? []);
-    } catch {}
+    } catch (error) {
+      console.error("Failed to fetch health trends", error);
+    }
   }
 
   async function handleLogout() {

--- a/client/src/pages/RiskTrends.tsx
+++ b/client/src/pages/RiskTrends.tsx
@@ -79,7 +79,9 @@ export default function RiskTrends() {
     try {
       const names = await ApiClient.get<string[]>(`/api/assessments/autocomplete?q=${encodeURIComponent(q)}`);
       setSuggestions(names);
-    } catch {}
+    } catch (error) {
+      console.error("Failed to fetch assessment suggestions", error);
+    }
   }, []);
 
   useEffect(() => {

--- a/server/services/mlService.ts
+++ b/server/services/mlService.ts
@@ -549,7 +549,9 @@ class PythonDaemonManager {
     if (this.process) {
       try {
         this.process.kill();
-      } catch (e) {}
+      } catch (e) {
+        logger.warn("Failed to kill Python subprocess during teardown", { error: e });
+      }
       this.process = null;
     }
   }


### PR DESCRIPTION
## Summary
Adds error logging to empty catch blocks so silent failures become observable.

## Changes
- `client/src/pages/RiskTrends.tsx`: log autocomplete fetch failure
- `client/src/pages/MyHealth.tsx`: log health trends fetch failure
- `client/src/pages/Dashboard.tsx`: log draft field apply failure
- `client/src/pages/CounterfactualAnalysis.tsx`: log suggestions fetch failure
- `server/services/mlService.ts`: log Python subprocess teardown failure

## Checklist
- [x] No new dependencies
- [x] Uses existing logger on server, console on client